### PR TITLE
Correct Fields for PGN 130312

### DIFF
--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -2447,8 +2447,8 @@ Pgn pgnList[] =
 ,
 { "Temperature", 130312, false, 8, 0,
   { { "SID", BYTES(1), 1, false, 0, "" }
-  , { "Temperature Instance", 4, 1, false, 0, "" }
-  , { "Temperature Source", 4, 1, false, 0, "" }
+  , { "Temperature Instance", BYTES(1), 1, false, 0, "" }
+  , { "Temperature Source", BYTES(1), 1, false, 0, "" }
   , { "Actual Temperature", BYTES(2), RES_TEMPERATURE, false, "K", "" }
   , { "Set Temperature", BYTES(2), RES_TEMPERATURE, false, "K", "" }
   , { 0 }


### PR DESCRIPTION
...r PGN 130312 to reflect correct usage of one byte per field

I am waiting on the arrival of a Maretron TMP100 to verify the mapping of temperature source IDs to names. I believe it should look like this, but I'm not 100% on the correct order:

``` C
#define LOOKUP_TEMPERATURE_SOURCE ( \
    ",0=Sea Temperature" \
    ",1=Outside Temperature" \
    ",2=Inside Temperature" \
    ",3=Engine Room Temperature" \
    ",4=Main Cabin Temperature" \
    ",5=Live Well Temperature" \
    ",6=Bait Well Temperature" \
    ",7=Refridgeration Temperature" \
    ",8=Heating System Temperature" \
    ",9=Freezer Temperature" )
```
