### PR TITLE
Fix for actisense-serial not starting because open() blocks

### DIFF
--- a/actisense-serial/actisense-serial.c
+++ b/actisense-serial/actisense-serial.c
@@ -149,7 +149,7 @@ int main(int argc, char ** argv)
 
 retry:
   if (debug) fprintf(stderr, "Opening %s\n", device);
-  handle = open(device, O_RDWR | O_NOCTTY);
+  handle = open(device, O_RDWR | O_NOCTTY | O_NONBLOCK);
   if (debug) fprintf(stderr, "fd = %d\n", handle);
   if (handle < 0)
   {


### PR DESCRIPTION
First time with canboat & Actisense NGT-1 and actisense-serial would not start.

I traced it down to open(device, O_RDWR | O_NOCTTY) never returning. After a bit of Googling I tried adding O_NONBLOCK and it did start working, got data out all the way to n2kd.

I am using the Actisense FTDI drivers on OS X 10.8.4.

Is this solution universal? Don't really understandwhat causes it, I have very meager C skills and no experience with ftdi or ttys, so if there is a better way to fix the issue please let me know and I'll educate myself.
