### PR TITLE
30th fast packet is actually 31 hence the math is off by 7  

### DIFF
--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -50,7 +50,7 @@ along with CANboat.  If not, see <http://www.gnu.org/licenses/>.
  * that increases.
  * This means that for 'fast packets' the first bucket (sub-packet) contains 6 payload
  * bytes and 7 for remaining. Since the max index is 31, the maximal payload is
- * 6 + 30 * 7 = 216 bytes
+ * 6 + 31 * 7 = 223 bytes
  */
 
 /*


### PR DESCRIPTION
Don't belive me? 

http://en.wikipedia.org/wiki/NMEA_2000#Message_format_and_parameter_group_numbers_.28PGNs.29 
