### PR TITLE
Json field names in CamelCase

### DIFF
--- a/analyzer/analyzer.c
+++ b/analyzer/analyzer.c
@@ -2251,7 +2251,7 @@ char * camelize(const char *str)
 }
 
 void camelCaseForJson(void) {
-  for (int i = 1; i < ARRAY_SIZE(pgnList); i++)
+  for (int i = 0; i < ARRAY_SIZE(pgnList); i++)
   {
     pgnList[i].description = camelize(pgnList[i].description);
     for (int j = 0; j < ARRAY_SIZE(pgnList[i].fieldList) && pgnList[i].fieldList[j].name; j++)


### PR DESCRIPTION
With my rusty C skills I managed to add a camelCaseForJson method that will convert all pgn.description and field.name values to CamelCase, stripping all non-alpha and non-digit characters. If interested you can uncomment the printf line to see how things change.

The goal is to be able to use

```
foo.WindAngle
```

instead of the less readable

```
foo['Wind Angle']
```

I think there is a free missing there someplace, but the conversion is done only once I figured things could work ok like this.
