### PR TITLE
Correct field sizes for PGN 126996: Product Information

### DIFF
--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -1005,8 +1005,8 @@ Pgn pgnList[] =
   { { "NMEA 2000 Version", BYTES(2), 1, false, 0, "" }
   , { "Product Code", BYTES(2), 1, false, 0, "" }
   , { "Model ID", BYTES(32), RES_ASCII, false, 0, "" }
-  , { "Software Version Code", BYTES(40), RES_ASCII, false, 0, "" }
-  , { "Model Version", BYTES(24), RES_ASCII, false, 0, "" }
+  , { "Software Version Code", BYTES(32), RES_ASCII, false, 0, "" }
+  , { "Model Version", BYTES(32), RES_ASCII, false, 0, "" }
   , { "Model Serial Code", BYTES(32), RES_ASCII, false, 0, "" }
   , { "Certification Level", BYTES(1), 1, false, 0, "" }
   , { "Load Equivalency", BYTES(1), 1, false, 0, "" }


### PR DESCRIPTION
Software Version Code and Model Version should both be 32 bytes.

Example before and after from four devices on my workbench:
#### Before

```
2014-08-14-22:06:14.091 6   0 255 126996 Product Information:  NMEA 2000 Version = 1300; Product Code = 28199; Model ID = NMEA 2000 PC Interface (NGT-1); Software Version Code = 1.100, 2.210NGT-1-US; Model Version = B  hv1.03; Model Serial Code = 110737; Certification Level = 0; Load Equivalency = 1
2014-08-14-22:06:14.113 6  10 255 126996 Product Information:  NMEA 2000 Version = 1301; Product Code = 29971; Model ID = MS700; Software Version Code = 1.01.18                         FUSION-L; Model Version = INK-1.0; Model Serial Code = 1692; Certification Level = 1; Load Equivalency = 1
2014-08-14-22:06:14.126 6  88 255 126996 Product Information:  NMEA 2000 Version = 1301; Product Code = 21703; Model ID = FPM100; Software Version Code = 1.0.11.0; Model Version = ; Model Serial Code = 1640296; Certification Level = 0; Load Equivalency = 8
2014-08-14-22:06:14.138 6 128 255 126996 Product Information:  NMEA 2000 Version = 1210; Product Code = 5973; Model ID = WSO100; Software Version Code = 2.0.132.0; Model Version = ; Model Serial Code = 1201861; Certification Level = 0; Load Equivalency = 3
```
#### After

```
2014-08-14-22:07:20.481 6   0 255 126996 Product Information:  NMEA 2000 Version = 1300; Product Code = 28199; Model ID = NMEA 2000 PC Interface (NGT-1); Software Version Code = 1.100, 2.210; Model Version = NGT-1-USB  hv1.03; Model Serial Code = 110737; Certification Level = 0; Load Equivalency = 1
2014-08-14-22:07:20.504 6  10 255 126996 Product Information:  NMEA 2000 Version = 1301; Product Code = 29971; Model ID = MS700; Software Version Code = 1.01.18; Model Version = FUSION-LINK-1.0; Model Serial Code = 1692; Certification Level = 1; Load Equivalency = 1
2014-08-14-22:07:20.517 6  88 255 126996 Product Information:  NMEA 2000 Version = 1301; Product Code = 21703; Model ID = FPM100; Software Version Code = 1.0.1; Model Version = 1.0; Model Serial Code = 1640296; Certification Level = 0; Load Equivalency = 8
2014-08-14-22:07:20.528 6 128 255 126996 Product Information:  NMEA 2000 Version = 1210; Product Code = 5973; Model ID = WSO100; Software Version Code = 2.0.13; Model Version = 2.0; Model Serial Code = 1201861; Certification Level = 0; Load Equivalency = 3
```
