### PR TITLE
Fix wrong field sizes in PGN 60928 ISO Address Claim.

### DIFF
--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -286,7 +286,7 @@ Pgn pgnList[] =
   /* http://www.nmea.org/Assets/pgn059392.pdf */
   /* http://www8.garmin.com/manuals/GPSMAP4008_NMEA2000NetworkFundamentals.pdf */
   /* http://www.furunousa.com/Furuno/Doc/0/8JT2BMDDIB249FCNUK64DKLV67/GP330B%20NMEA%20PGNs.pdf */
-
+  /* http://www.nmea.org/Assets/20140710%20nmea-2000-060928%20iso%20address%20claim%20pgn%20corrigendum.pdf */
 ,
 { "ISO Acknowledgement", 59392, true, 8, 0,
   { { "Control", BYTES(1), RES_LOOKUP, false, ",0=ACK,1=NAK,2=Access Denied,3=Address Busy", "" }


### PR DESCRIPTION
Some field sizes as well as names does not match the information publicly available at http://www.nmea.org/Assets/20140710%20nmea-2000-060928%20iso%20address%20claim%20pgn%20corrigendum.pdf

Most differences have been fixed for the PGN 60928, resulting in a correct total length of eight bytes.

The same fields are found in PGN 65240 _ISO Commanded Address_ and as far as I understand, the `NAME` information consisting of all fields in the _ISO Address Claim_ must match exactly, so the field format should also be the same. However, I have not modified this part yet, since I do not have a definite source. Especially the total message length for PGN 65240 cannot be correct counting in the additional _New Source Address_ field.

I would be happy to adjust this if anyone could provide a real sample of an _ISO Commanded Address_ PGN, which I have never seen so far.
