### PR TITLE
Fix PGN 127493 Transmission Parameters, Dynamic.

### DIFF
--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -1149,13 +1149,14 @@ Pgn pgnList[] =
 }
 
 ,
-{ "Transmission Parameters, Dynamic", 127493, true, 7, 0,
-  { { "Engine Instance", 2, RES_LOOKUP, false, LOOKUP_ENGINE_INSTANCE, "" }
+{ "Transmission Parameters, Dynamic", 127493, true, 8, 0,
+  { { "Engine Instance", 8, RES_LOOKUP, false, LOOKUP_ENGINE_INSTANCE, "" }
   , { "Transmission Gear", 2, RES_LOOKUP, false, LOOKUP_GEAR_STATUS, "" }
-  , { "Reserved", 4, 1, false, 0, "" }
+  , { "Reserved", 6, RES_NOTUSED, false, 0, "" }
   , { "Oil pressure", BYTES(2), RES_PRESSURE, false, "hPa", "" }
   , { "Oil temperature", BYTES(2), RES_TEMPERATURE, false, "K", "" }
   , { "Discrete Status 1", BYTES(1), RES_INTEGER, false, 0, "" }
+  , { "Reserved", BYTES(1), RES_NOTUSED, false, 0, "" }
   , { 0 }
   }
 }


### PR DESCRIPTION
Based on own research and the official PGN and field list at
http://www.nmea.org/Assets/july%202010%20nmea2000_v1-301_app_b_pgn_field_list.pdf

This PGN is transmitted with DLC=8 bytes and contains another Reserved
Bits field at the end. The Engine Instance is actually 8 bits wide.
The Transmission Gear field is padded with 6 bits to the next byte
boundary for the following 16-bit values.
