### PR TITLE
Fix message lengths for Airmar proprietary PGNs.

### DIFF
--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -845,9 +845,9 @@ Pgn pgnList[] =
 
   /* http://www.airmartechnology.com/uploads/installguide/PB200UserManual.pdf */
 ,
-{ "Airmar: Attitude Offset", 126720, true, 8, 0,
+{ "Airmar: Attitude Offset", 126720, true, 9, 0,
   { { "Manufacturer Code", 11, RES_MANUFACTURER, false, "=135", "Airmar" }
-  , { "Reserved", 2, 1, false, 0, "" }
+  , { "Reserved", 2, RES_NOTUSED, false, 0, "" }
   , { "Industry Code", 3, RES_LOOKUP, false, "=4", "Marine Industry" }
   , { "Proprietary ID", BYTES(1), RES_INTEGER, false, "=32", "Attitude Offsets" }
   , { "Azimuth offset", BYTES(2), RES_DEGREES, true, "deg", "Positive: sensor rotated to port, negative: sensor rotated to starboard" }
@@ -859,9 +859,9 @@ Pgn pgnList[] =
 
   /* http://www.airmartechnology.com/uploads/installguide/PB200UserManual.pdf */
 ,
-{ "Airmar: Calibrate Compass", 126720, true, 8, 0,
+{ "Airmar: Calibrate Compass", 126720, true, 24, 0,
   { { "Manufacturer Code", 11, RES_MANUFACTURER, false, "=135", "Airmar" }
-  , { "Reserved", 2, 1, false, 0, "" }
+  , { "Reserved", 2, RES_NOTUSED, false, 0, "" }
   , { "Industry Code", 3, RES_LOOKUP, false, "=4", "Marine Industry" }
   , { "Proprietary ID", BYTES(1), RES_INTEGER, false, "=33", "Calibrate Compass" }
   , { "Calibrate Function", BYTES(1), RES_LOOKUP, false, ",0=Normal/cancel calibration,1=Enter calibration mode,2=Reset calibration to 0,3=Verify,4=Reset compass to defaults,5=Reset damping to defaults", "" }
@@ -882,9 +882,9 @@ Pgn pgnList[] =
 
   /* http://www.airmartechnology.com/uploads/installguide/PB200UserManual.pdf */
 ,
-{ "Airmar: True Wind Options", 126720, true, 8, 0,
+{ "Airmar: True Wind Options", 126720, true, 6, 0,//FIXME Single Frame: No
   { { "Manufacturer Code", 11, RES_MANUFACTURER, false, "=135", "Airmar" }
-  , { "Reserved", 2, 1, false, 0, "" }
+  , { "Reserved", 2, RES_NOTUSED, false, 0, "" }
   , { "Industry Code", 3, RES_LOOKUP, false, "=4", "Marine Industry" }
   , { "Proprietary ID", BYTES(1), RES_INTEGER, false, "=34", "True Wind Options" }
   , { "COG substition for HDG", 2, RES_LOOKUP, false, ",0=Use HDG only,1=Allow COG to replace HDG", "Allow use of COG when HDG not available?" }
@@ -905,9 +905,9 @@ Pgn pgnList[] =
 
   /* http://www.airmartechnology.com/uploads/installguide/DST200UserlManual.pdf */
 ,
-{ "Airmar: Simulate Mode", 126720, true, 8, 0,
+{ "Airmar: Simulate Mode", 126720, true, 6, 0,//FIXME Single Frame: No
   { { "Manufacturer Code", 11, RES_MANUFACTURER, false, "=135", "Airmar" }
-  , { "Reserved", 2, 1, false, 0, "" }
+  , { "Reserved", 2, RES_NOTUSED, false, 0, "" }
   , { "Industry Code", 3, RES_LOOKUP, false, "=4", "Marine Industry" }
   , { "Proprietary ID", BYTES(1), RES_INTEGER, false, "=35", "Simulate Mode" }
   , { "Simulate Mode", 2, RES_LOOKUP, false, ",0=Off,1=On", "" }
@@ -918,9 +918,9 @@ Pgn pgnList[] =
 
   /* http://www.airmartechnology.com/uploads/installguide/DST200UserlManual.pdf */
 ,
-{ "Airmar: Calibrate Depth", 126720, true, 8, 0,
+{ "Airmar: Calibrate Depth", 126720, true, 6, 0,//FIXME Single Frame: No
   { { "Manufacturer Code", 11, RES_MANUFACTURER, false, "=135", "Airmar" }
-  , { "Reserved", 2, 1, false, 0, "" }
+  , { "Reserved", 2, RES_NOTUSED, false, 0, "" }
   , { "Industry Code", 3, RES_LOOKUP, false, "=4", "Marine Industry" }
   , { "Proprietary ID", BYTES(1), RES_INTEGER, false, "=40", "Calibrate Depth" }
   , { "Speed of Sound Mode", BYTES(2), 0.1, false, "m/s", "actual allowed range is 1350.0 to 1650.0 m/s" }
@@ -931,9 +931,9 @@ Pgn pgnList[] =
 
   /* http://www.airmartechnology.com/uploads/installguide/DST200UserlManual.pdf */
 ,
-{ "Airmar: Calibrate Speed", 126720, true, 8, 2,
+{ "Airmar: Calibrate Speed", 126720, true, 12, 2,
   { { "Manufacturer Code", 11, RES_MANUFACTURER, false, "=135", "Airmar" }
-  , { "Reserved", 2, 1, false, 0, "" }
+  , { "Reserved", 2, RES_NOTUSED, false, 0, "" }
   , { "Industry Code", 3, RES_LOOKUP, false, "=4", "Marine Industry" }
   , { "Proprietary ID", BYTES(1), RES_INTEGER, false, "=41", "Calibrate Speed" }
   , { "Number of pairs of data points", BYTES(1), RES_INTEGER, false, 0, "actual range is 0 to 25. 254=restore default speed curve"
@@ -946,9 +946,9 @@ Pgn pgnList[] =
 
   /* http://www.airmartechnology.com/uploads/installguide/DST200UserlManual.pdf */
 ,
-{ "Airmar: Calibrate Temperature", 126720, true, 8, 2,
+{ "Airmar: Calibrate Temperature", 126720, true, 6, 2,//FIXME Single Frame: No
   { { "Manufacturer Code", 11, RES_MANUFACTURER, false, "=135", "Airmar" }
-  , { "Reserved", 2, 1, false, 0, "" }
+  , { "Reserved", 2, RES_NOTUSED, false, 0, "" }
   , { "Industry Code", 3, RES_LOOKUP, false, "=4", "Marine Industry" }
   , { "Proprietary ID", BYTES(1), RES_INTEGER, false, "=42", "Calibrate Temperature" }
   , { "Temperature instance", 2, RES_LOOKUP, false, ",0=Device Sensor,1=Onboard Water Sensor,2=Optional Water Sensor", "" }
@@ -961,9 +961,9 @@ Pgn pgnList[] =
 
   /* http://www.airmartechnology.com/uploads/installguide/DST200UserlManual.pdf */
 ,
-{ "Airmar: Speed Filter", 126720, true, 8, 2,
+{ "Airmar: Speed Filter", 126720, true, 8, 2,//FIXME Single Frame: No (type 0: NDB=6; type 1:NDB=8)
   { { "Manufacturer Code", 11, RES_MANUFACTURER, false, "=135", "Airmar" }
-  , { "Reserved", 2, 1, false, 0, "" }
+  , { "Reserved", 2, RES_NOTUSED, false, 0, "" }
   , { "Industry Code", 3, RES_LOOKUP, false, "=4", "Marine Industry" }
   , { "Proprietary ID", BYTES(1), RES_INTEGER, false, "=43", "Speed Filter" }
   , { "Filter type", 4, RES_LOOKUP, false, ",0=no filter,1=basic IIR filter", "" }
@@ -976,12 +976,27 @@ Pgn pgnList[] =
 
   /* http://www.airmartechnology.com/uploads/installguide/DST200UserlManual.pdf */
 ,
-{ "Airmar: NMEA 2000 options", 126720, true, 8, 2,
+{ "Airmar: Temperature Filter", 126720, true, 8, 2,//FIXME Single Frame: No (type 0: NDB=6; type 1:NDB=8)
   { { "Manufacturer Code", 11, RES_MANUFACTURER, false, "=135", "Airmar" }
-  , { "Reserved", 2, 1, false, 0, "" }
+  , { "Reserved", 2, RES_NOTUSED, false, 0, "" }
+  , { "Industry Code", 3, RES_LOOKUP, false, "=4", "Marine Industry" }
+  , { "Proprietary ID", BYTES(1), RES_INTEGER, false, "=44", "Temperature Filter" }
+  , { "Filter type", 4, RES_LOOKUP, false, ",0=no filter,1=basic IIR filter,15=data not available", "" }
+  , { "Reserved", 4, RES_BINARY, false, 0, "Reserved" }
+  , { "Sample interval", BYTES(2), 0.01, false, "s", "" }
+  , { "Filter duration", BYTES(2), 0.01, false, "s", "" }
+  , { 0 }
+  }
+}
+
+  /* http://www.airmartechnology.com/uploads/installguide/DST200UserlManual.pdf */
+,
+{ "Airmar: NMEA 2000 options", 126720, true, 6, 2,//FIXME Single Frame: No
+  { { "Manufacturer Code", 11, RES_MANUFACTURER, false, "=135", "Airmar" }
+  , { "Reserved", 2, RES_NOTUSED, false, 0, "" }
   , { "Industry Code", 3, RES_LOOKUP, false, "=4", "Marine Industry" }
   , { "Proprietary ID", BYTES(1), RES_INTEGER, false, "=46", "NMEA 2000 options" }
-  , { "Transmission Interval", 2, RES_LOOKUP, false, ",0=Measure Interval,1=Requested by user", "" }
+  , { "Transmission Interval", 2, RES_LOOKUP, false, ",0=Measure Interval,1=Requested by user,2=reserved,3=data not available", "" }
   , { "Reserved", 22, RES_BINARY, false, 0, "Reserved" }
   , { 0 }
   }


### PR DESCRIPTION
According to the quoted manuals, the PGN 126720 variants for Airmar
are all marked as "Single Frame: No".  Where the message lengths are
not greater than 8 bytes, add a comment to warn that the parser might
fail because it expects a single-frame format.

Use RES_NOTUSED for Reserved fields to suppress useless output.

Add a 126720-44 variant, as found in the DST200 User Manual document.
Extend the lookup for the PGN 126720-46 Transmission Interval field (3
means data not available).
