### PR TITLE
Extend functionality for candump2analyzer tool

### DIFF
--- a/candump2analyzer/candump2analyzer.c
+++ b/candump2analyzer/candump2analyzer.c
@@ -36,7 +36,7 @@ along with CANboat.  If not, see <http://www.gnu.org/licenses/>.
 #define CANDUMP_LINE_START 	'<'
 #define CANDUMP_DATA_START 	17
 #define CANDUMP_DATA_INC	3
-#define MAX_DATA_BYTES		8
+#define MAX_DATA_BYTES		223
 
 int main(int argc, char ** argv)
 {
@@ -100,7 +100,7 @@ int main(int argc, char ** argv)
 		int i;
 		char *p;
 		unsigned int data[MAX_DATA_BYTES];
-		for (p = msg; *p && *p != ']'; ++p);
+		for (p = msg; p < msg + sizeof(msg) && *p != 0 && *p != ']'; ++p);
 		if (*p == ']') {
 			while (*(++p) == ' ');
 			for (i = 0; i < size; i++, p += CANDUMP_DATA_INC)


### PR DESCRIPTION
First of all, allow the input to be read from a file specified on the command line.

Fix the logic for extracting the packet length to accept more than one digit and still find the start of the data bytes.  Increase the buffer size to allow translating a whole Fast Packet payload that will be accepted by `analyzer` in its `RAWFORMAT_FAST` mode.
