### PR TITLE
Update line 1448 in Analyzer.c

### DIFF
--- a/analyzer/analyzer.c
+++ b/analyzer/analyzer.c
@@ -1445,7 +1445,8 @@ void print_json_escaped(uint8_t *data, int len)
 {
 
   int c;
-  for (int k = 0; k < len; k++)
+  int k;
+  for (k = 0; k < len; k++)
     {
       c = data[k];
       switch(c)


### PR DESCRIPTION
Using Windows 7 and Cygwin. When trying to run 'make install' I received an error at line 1448. Because 'int k' was declared in the 'for' loop.  Added line 'int k;' above the 'for' loop and removed the int declaration from the loop.
