### PR TITLE
socketcan-writer improvements

### DIFF
--- a/analyzer/pgn.c
+++ b/analyzer/pgn.c
@@ -280,18 +280,26 @@ void extractNumber(const Field * field, uint8_t * data, size_t startBit, size_t 
   }
 }
 
+static char * findFirstOccurrence(char * msg, char c)
+{
+  if (*msg == 0 || *msg == '\n')
+  {
+    return 0;
+  }
+  return strchr(msg, c);
+}
+
 int parseRawFormatPlain(char * msg, RawMessage * m, bool showJson)
 {
   unsigned int prio, pgn, dst, src, len, junk, r, i;
   char * p;
   unsigned int data[8];
 
-  if (*msg == 0 || *msg == '\n')
+  p = findFirstOccurrence(msg, ',');
+  if(!p)
   {
     return 1;
   }
-
-  p = strchr(msg, ',');
 
   memcpy(m->timestamp, msg, p - msg);
   m->timestamp[p - msg] = 0;
@@ -350,12 +358,11 @@ int parseRawFormatFast(char * msg, RawMessage * m, bool showJson)
   unsigned int prio, pgn, dst, src, len, r, i;
   char * p;
 
-  if (*msg == 0 || *msg == '\n')
+  p = findFirstOccurrence(msg, ',');
+  if(!p)
   {
     return 1;
   }
-
-  p = strchr(msg, ',');
 
   memcpy(m->timestamp, msg, p - msg);
   m->timestamp[p - msg] = 0;
@@ -424,12 +431,11 @@ int parseRawFormatAirmar(char * msg, RawMessage * m, bool showJson)
   char * p;
   unsigned int id;
 
-  if (*msg == 0 || *msg == '\n')
+  p = findFirstOccurrence(msg, ' ');
+  if(!p)
   {
     return 1;
   }
-
-  p = strchr(msg, ' ');
 
   memcpy(m->timestamp, msg, p - msg - 1);
   m->timestamp[p - msg - 1] = 0;

--- a/analyzer/pgn.c
+++ b/analyzer/pgn.c
@@ -289,6 +289,17 @@ static char * findFirstOccurrence(char * msg, char c)
   return strchr(msg, c);
 }
 
+static int setParsedValues(RawMessage * m, unsigned int prio, unsigned int pgn, unsigned int dst, unsigned int src, unsigned int len)
+{
+  m->prio = prio;
+  m->pgn  = pgn;
+  m->dst  = dst;
+  m->src  = src;
+  m->len  = len;
+
+  return 0;
+}
+
 int parseRawFormatPlain(char * msg, RawMessage * m, bool showJson)
 {
   unsigned int prio, pgn, dst, src, len, junk, r, i;
@@ -344,13 +355,7 @@ int parseRawFormatPlain(char * msg, RawMessage * m, bool showJson)
     return 2;
   }
 
-  m->prio = prio;
-  m->pgn  = pgn;
-  m->dst  = dst;
-  m->src  = src;
-  m->len  = len;
-
-  return 0;
+  return setParsedValues(m, prio, pgn, dst, src, len);
 }
 
 int parseRawFormatFast(char * msg, RawMessage * m, bool showJson)
@@ -416,13 +421,7 @@ int parseRawFormatFast(char * msg, RawMessage * m, bool showJson)
     }
   }
 
-  m->prio = prio;
-  m->pgn  = pgn;
-  m->dst  = dst;
-  m->src  = src;
-  m->len  = len;
-
-  return 0;
+  return setParsedValues(m, prio, pgn, dst, src, len);
 }
 
 int parseRawFormatAirmar(char * msg, RawMessage * m, bool showJson)
@@ -478,13 +477,7 @@ int parseRawFormatAirmar(char * msg, RawMessage * m, bool showJson)
     }
   }
 
-  m->prio = prio;
-  m->pgn  = pgn;
-  m->dst  = dst;
-  m->src  = src;
-  m->len  = len;
-
-  return 0;
+  return setParsedValues(m, prio, pgn, dst, src, len);
 }
 
 int parseRawFormatChetco(char * msg, RawMessage * m, bool showJson)
@@ -524,11 +517,5 @@ int parseRawFormatChetco(char * msg, RawMessage * m, bool showJson)
     }
   }
 
-  m->prio = 0;
-  m->pgn  = pgn;
-  m->dst  = 255;
-  m->src  = src;
-  m->len  = i + 1;
-
-  return 0;
+  return setParsedValues(m, 0, pgn, 255, src, i + 1);
 }

--- a/socketcan-writer/Makefile
+++ b/socketcan-writer/Makefile
@@ -18,6 +18,7 @@
 #
 
 PLATFORM=$(shell uname | tr '[A-Z]' '[a-z]')-$(shell uname -m)
+OS=$(shell uname)
 TARGETDIR=../rel/$(PLATFORM)
 SOCKETCAN_WRITER=$(TARGETDIR)/socketcan-writer
 TARGETS=$(SOCKETCAN_WRITER)
@@ -25,7 +26,11 @@ TARGETS=$(SOCKETCAN_WRITER)
 all: $(TARGETS)
 
 $(SOCKETCAN_WRITER): socketcan-writer.c ../analyzer/*.h ../analyzer/*.c ../common/*.h ../common/*.c
+ifeq ($(OS),Linux)
 	$(CC) -o $(SOCKETCAN_WRITER) -I../analyzer -I../common socketcan-writer.c ../analyzer/pgn.c ../common/common.c $(LDLIBS$(LDLIBS-$(@)))
+else
+	@echo socketcan-writer can be compiled only on Linux platform! Ignoring..
+endif
 
 clean:
 	-rm -f $(TARGETS) *.elf *.gdb


### PR DESCRIPTION
Just a couple of improvements to my previous commits about socketcan-writer.

- Add back better input validation for parsing functions (malformed input leads to segfaults without this)
- Skip compilation of socketcan-writer on non-Linux platforms as SocketCAN is available only on Linux
