### PR TITLE
make install should not fail in pristine system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ clean:
 	for dir in $(SUBDIRS); do $(MAKE) -C $$dir clean; done
 	
 install:
-	for i in rel/$(PLATFORM)/* util/* */*_monitor; do f=`basename $$i`; rm /usr/local/bin/$$f; cp $$i /usr/local/bin; done
-	killall -9 actisense-serial n2kd socketcan-writer
+	for i in rel/$(PLATFORM)/* util/* */*_monitor; do f=`basename $$i`; rm -f /usr/local/bin/$$f; cp $$i /usr/local/bin; done
+	-killall -9 actisense-serial n2kd socketcan-writer
 
 zip:
 	(cd rel; zip -r ../packetlogger_`date +%Y%m%d`.zip *)


### PR DESCRIPTION
In a system with no previous canboat installed make install should
not report failure to remove previous components or killing previously
running components as failure.