### PR TITLE
Added X-Flags support to Makefiles and socketcan support to n2kd_monitor

### DIFF
--- a/actisense-serial/Makefile
+++ b/actisense-serial/Makefile
@@ -25,7 +25,7 @@ TARGETS=$(ACTISENSE)
 all: $(TARGETS)
 
 $(ACTISENSE): actisense-serial.c actisense.h ../common/common.c ../common/common.h
-	$(CC) -o $(ACTISENSE) -I../common actisense-serial.c ../common/common.c $(LDLIBS$(LDLIBS-$(@)))
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(ACTISENSE) -I../common actisense-serial.c ../common/common.c $(LDLIBS$(LDLIBS-$(@)))
 
 clean:
 	-rm -f $(TARGETS) *.elf *.gdb

--- a/analyzer/Makefile
+++ b/analyzer/Makefile
@@ -21,14 +21,13 @@ PLATFORM=$(shell uname | tr '[A-Z]' '[a-z]')-$(shell uname -m)
 TARGETDIR=../rel/$(PLATFORM)
 ANALYZER=$(TARGETDIR)/analyzer
 TARGETS=$(ANALYZER)
-CFLAGS=-O3
 XMLFILE=pgns.xml
 JSONFILE=pgns.json
 
 all: $(TARGETS)
 
 $(ANALYZER): analyzer.c pgn.c analyzer.h pgn.h ../common/common.c ../common/common.h Makefile
-	$(CC) $(CFLAGS) -o $(ANALYZER) -I../common pgn.c analyzer.c ../common/common.c $(LDLIBS$(LDLIBS-$(@)))
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(ANALYZER) -I../common pgn.c analyzer.c ../common/common.c $(LDLIBS$(LDLIBS-$(@)))
 
 json: $(ANALYZER) pgns2json.xslt
 	$(ANALYZER) -explain-xml >$(XMLFILE) && xsltproc pgns2json.xslt $(XMLFILE) >$(JSONFILE)

--- a/candump2analyzer/Makefile
+++ b/candump2analyzer/Makefile
@@ -21,12 +21,11 @@ PLATFORM=$(shell uname | tr '[A-Z]' '[a-z]')-$(shell uname -m)
 TARGETDIR=../rel/$(PLATFORM)
 CANDUMP2ANALYZER=$(TARGETDIR)/candump2analyzer
 TARGETS=$(CANDUMP2ANALYZER)
-CFLAGS=-O3
 
 all: $(TARGETS)
 
 $(CANDUMP2ANALYZER): candump2analyzer.c ../common/common.c ../common/common.h Makefile
-	$(CC) $(CFLAGS) -o $(CANDUMP2ANALYZER) -I../common candump2analyzer.c ../common/common.c $(LDLIBS$(LDLIBS-$(@)))
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(CANDUMP2ANALYZER) -I../common candump2analyzer.c ../common/common.c $(LDLIBS$(LDLIBS-$(@)))
 
 clean:
 	-rm -f $(TARGETS) *.elf *.gdb

--- a/config/n2kd
+++ b/config/n2kd
@@ -1,3 +1,5 @@
+# CAN_INTERFACE=<network_interface>
+# OR
 # ACTISENSE_PRIMARY_DEVICE=<devicename>
 
 # OPTIONAL OPTIONS:

--- a/group-function/Makefile
+++ b/group-function/Makefile
@@ -26,10 +26,10 @@ TARGETS=$(COMMAND) $(REQUEST)
 all: $(TARGETS)
 
 $(COMMAND): command.c ../common/common.c ../common/common.h
-	$(CC) -o $(COMMAND) -I../common command.c ../common/common.c $(LDLIBS$(LDLIBS-$(@)))
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(COMMAND) -I../common command.c ../common/common.c $(LDLIBS$(LDLIBS-$(@)))
 
 $(REQUEST): request.c ../common/common.c ../common/common.h
-	$(CC) -o $(REQUEST) -I../common request.c ../common/common.c $(LDLIBS$(LDLIBS-$(@)))
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(REQUEST) -I../common request.c ../common/common.c $(LDLIBS$(LDLIBS-$(@)))
 
 clean:
 	-rm -f $(TARGETS) *.elf *.gdb

--- a/ip/Makefile
+++ b/ip/Makefile
@@ -23,7 +23,6 @@ PLATFORM=$(shell uname | tr '[A-Z]' '[a-z]')-$(shell uname -m)
 TARGETDIR=../rel/$(PLATFORM)
 TARGET1=../rel/$(PLATFORM)/iptee
 TARGETLIST=$(TARGET1)
-CFLAGS=-O3
 
 all:	$(TARGETDIR) $(TARGETLIST)
 
@@ -34,4 +33,4 @@ clean:
 	-rm -f $(TARGETLIST) *.elf *.gdb
 
 $(TARGET1):	iptee.c ../common/common.c ../common/common.h
-	$(CC) -o $(TARGET1) $(CFLAGS) -I../common iptee.c ../common/common.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TARGET1) $(CFLAGS) -I../common iptee.c ../common/common.c

--- a/n2kd/Makefile
+++ b/n2kd/Makefile
@@ -22,13 +22,12 @@ TARGETDIR=../rel/$(PLATFORM)
 N2KD=$(TARGETDIR)/n2kd
 N2KD_MONITOR=$(TARGETDIR)/n2kd_monitor
 TARGETS=$(N2KD) $(N2KD_MONITOR)
-CFLAGS=-O3
-LDLIBS=-lm
+LDLIBS+=-lm
 
 all: $(TARGETS)
 
 $(N2KD): main.c nmea0183.c gps_ais.h nmea0183.h ../common/common.c ../common/common.h Makefile
-	$(CC) $(CFLAGS) -o $(N2KD) -I../common main.c gps_ais.c nmea0183.c ../common/common.c $(LDLIBS$(LDLIBS-$(@)))
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(N2KD) -I../common main.c gps_ais.c nmea0183.c ../common/common.c $(LDLIBS$(LDLIBS-$(@)))
 
 $(N2KD_MONITOR): n2kd_monitor
 	cp n2kd_monitor $(N2KD_MONITOR)

--- a/n2kd/n2kd_monitor
+++ b/n2kd/n2kd_monitor
@@ -8,6 +8,7 @@
 # This assumes there is a configuration file /etc/default/n2kd
 # containing one or more of the following configuration settings:
 #
+#       CAN_INTERFACE=can0
 #       ACTISENSE_PRIMARY=/dev/actisense-1
 #       ACTISENSE_SECONDARY=/dev/actisense-2
 #       MONITOR=false
@@ -41,6 +42,7 @@ my $configFile = '/etc/default/n2kd';
 my $configObject = Config::General->new(-ConfigFile => $configFile,
                 -MergeDuplicateOptions => 1,
 #               -DefaultConfig => {
+#                       CAN_INTERFACE => "can0",
 #                       ACTISENSE_PRIMARY => "/dev/ttyUSB0",
 #                       MONITOR => "false",
 #                       N2KD_OPTIONS => "",
@@ -51,17 +53,19 @@ die "Could not read config from $configFile!\n" unless ref $configObject;
 
 my %config = $configObject->getall();
 
+my $CAN_INTERFACE = $config{'CAN_INTERFACE'};
 my $ACTISENSE_PRIMARY = $config{'ACTISENSE_PRIMARY'};
 my $ACTISENSE_SECONDARY = $config{'ACTISENSE_SECONDARY'};
 my $MONITOR = $config{'MONITOR'};
 my $N2KD_OPTIONS = $config{'N2KD_OPTIONS'};
 my $ANALYZER_OPTIONS = $config{'ANALYZER_OPTIONS'};
-die "Configuration file $configFile incomplete: No ACTISENSE_PRIMARY" unless $ACTISENSE_PRIMARY;
+die "Configuration file $configFile incomplete: No ACTISENSE_PRIMARY" unless ($ACTISENSE_PRIMARY or $CAN_INTERFACE);
 
 my $LOGFILE = '/var/log/n2kd_monitor.log';
 my $N2KD_LOGFILE = '/var/log/n2kd.log';
 my $MONITOR_LOGFILE = '/var/log/n2k-status.log';
 
+my $CAN = 0;
 my $stat;
 my $n2kd;
 my $monitor;
@@ -101,6 +105,44 @@ sub sigHandler()
   $stop = 1;
 }
 
+# checks if CAN_INTERFACE network interface is configured and up
+# if not true, it configures and brings it up
+# return undef, if it could not bring the interfac up and 1 on success
+sub manageCanInterface($)
+{
+  # disable experimental warnings (smartmatch), because
+  # the messages lead to failing n2kd_monitor service
+  no if ($] >= 5.018), 'warnings' => 'experimental';
+
+  my $CAN_INTERFACE = shift;
+
+  my @result = `ip a show $CAN_INTERFACE up`;
+  if(scalar(@result) < 1 or !(/$CAN_INTERFACE/ ~~ @result))
+  {
+    @result = `ip a show $CAN_INTERFACE`;
+    if(scalar(@result) < 1 or !(/$CAN_INTERFACE/ ~~ @result))
+    {
+      if(system("ip link add $CAN_INTERFACE type can bitrate 250000") == 0)
+      {
+        logText("Added $CAN_INTERFACE network interface\n");
+      }
+      else
+      {
+        logText("Failed to add $CAN_INTERFACE\n");
+        return undef;
+      }
+    }
+    @result = `ip link set $CAN_INTERFACE up type can bitrate 250000`;
+    if(scalar(@result) != 0)
+    {
+      logText("Failed to bring $CAN_INTERFACE up\n");
+      return undef;
+    }
+  }
+  logText("$CAN_INTERFACE up");
+  return 1;
+}
+
 daemonize();
 
 logText("Delayed start of N2KD monitor.");
@@ -110,7 +152,17 @@ logText("Starting N2KD monitor.");
 $SIG{'INT'} = 'sigHandler';
 $SIG{'HUP'} = 'sigHandler';
 
-if (!stat($ACTISENSE_PRIMARY))
+if($CAN_INTERFACE)
+{
+  logText("Using socket can interface $CAN_INTERFACE, disabling ACTISENSE_PRIMARY");
+  $CAN = 1;
+  if(!manageCanInterface($CAN_INTERFACE))
+  {
+    die "Could not add or bring $CAN_INTERFACE up\n";
+  }
+}
+
+if (!$CAN_INTERFACE and !stat($ACTISENSE_PRIMARY))
 {
   logText("Waiting for $ACTISENSE_PRIMARY to appear.");
 }
@@ -135,9 +187,9 @@ for (;;)
     }
   }
 
-  if ($stop == 0 and stat($ACTISENSE_PRIMARY))
+  if ($stop == 0 and ($CAN or stat($ACTISENSE_PRIMARY)))
   {
-    if (!$stat)
+    if (!$CAN and !$stat)
     {
       logText("Hardware device $ACTISENSE_PRIMARY found.");
       $stat = 1;
@@ -150,7 +202,11 @@ for (;;)
         open STDOUT, '>&PIPEWRITE' or die "Can't reassign PIPEWRITE: $!";
         open STDERR, '>>', $N2KD_LOGFILE or die "Can't write to $N2KD_LOGFILE $!";
         $ENV{'PATH'} = '/usr/local/bin:/bin:/usr/bin';
-        if ($ACTISENSE_SECONDARY)
+        if($CAN)
+        {
+            exec '/bin/bash', '-c', "candump $CAN_INTERFACE | candump2analyzer | analyzer $ANALYZER_OPTIONS -json | n2kd $N2KD_OPTIONS";
+        }
+        elsif ($ACTISENSE_SECONDARY)
         {
           exec '/bin/bash', '-c', "actisense-serial -t 10 $ACTISENSE_PRIMARY | actisense-serial $ACTISENSE_SECONDARY -t 10 | analyzer $ANALYZER_OPTIONS -json | n2kd $N2KD_OPTIONS";
         }
@@ -187,7 +243,7 @@ for (;;)
   }
   else
   {
-    if ($stop == 0 and $stat)
+    if ($stop == 0 and !$CAN and $stat)
     {
       logText("Hardware device $ACTISENSE_PRIMARY disappeared.");
       $stat = undef;
@@ -196,7 +252,14 @@ for (;;)
     {
       logText("Requesting stop for N2K port daemon $n2kd.");
       kill 2, $n2kd;
-      system 'killall -9 actisense-serial';
+      if($CAN)
+      {
+        system 'killall -9 candump';
+      }
+      else
+      {
+        system 'killall -9 actisense-serial';
+      }
     }
     if ($stop)
     {

--- a/n2kd/n2kd_monitor.service
+++ b/n2kd/n2kd_monitor.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=n2kd Monitor service
+After=network.target
+
+[Service]
+Type=forking
+User=root
+Group=root
+PrivateDevices=no
+SyslogLevel=err
+ExecStart=/usr/bin/n2kd_monitor
+StandardOutput=syslog
+StandardError=syslog
+WorkingDirectory=/tmp
+
+[Install]
+WantedBy=multi-user.target

--- a/nmea0183/Makefile
+++ b/nmea0183/Makefile
@@ -23,7 +23,6 @@ PLATFORM=$(shell uname | tr '[A-Z]' '[a-z]')-$(shell uname -m)
 TARGETDIR=../rel/$(PLATFORM)
 TARGET1=../rel/$(PLATFORM)/nmea0183-serial
 TARGETLIST=$(TARGET1)
-CFLAGS=-O3
 
 all:	$(TARGETDIR) $(TARGETLIST)
 
@@ -34,4 +33,4 @@ clean:
 	-rm -f $(TARGETLIST) *.elf *.gdb
 
 $(TARGET1):	nmeareader.c ../common/common.c ../common/common.h
-	$(CC) -o $(TARGET1) $(CFLAGS) -I../common nmeareader.c ../common/common.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(TARGET1) $(CFLAGS) -I../common nmeareader.c ../common/common.c

--- a/socketcan-writer/Makefile
+++ b/socketcan-writer/Makefile
@@ -31,7 +31,7 @@ endif
 all: $(TARGETS)
 
 $(SOCKETCAN_WRITER): socketcan-writer.c ../analyzer/*.h ../analyzer/*.c ../common/*.h ../common/*.c
-	$(CC) -o $(SOCKETCAN_WRITER) -I../analyzer -I../common socketcan-writer.c ../analyzer/pgn.c ../common/common.c $(LDLIBS$(LDLIBS-$(@)))
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(SOCKETCAN_WRITER) -I../analyzer -I../common socketcan-writer.c ../analyzer/pgn.c ../common/common.c $(LDLIBS$(LDLIBS-$(@)))
 
 clean:
 	-rm -f $(TARGETS) *.elf *.gdb


### PR DESCRIPTION
Makefiles use X-flag (compiler and linker flags) variables now. This is very useful to compile the sources with standard flags for the distribution and also allows users to compile with individually optimized ones.

Also added support for socketcan to n2kd_monitor. It's now able to start the socketcan "pipe" with candump and also brings the configured can network interface up, if needed. Therefore a new variable to /etc/default/n2kd named CAN_INTERFACE was added. If set, n2kd_monitor prefers socketcan over actisense.

P.s.: I made a mistake. The debian folder should go in a seperate debian/jessie branch. This allows to maintain different version of canboat with different package settings for each distribution (like debian jessie, stretch, ubuntu ... and so on.) May you move the debian folder into an own branch debian/jessie? Afterwards I will create a pull request for this branch with several packaging updates.