### PR TITLE
 fix: errors when writing too much to fast to the NGT-1

### DIFF
--- a/actisense-serial/actisense-serial.c
+++ b/actisense-serial/actisense-serial.c
@@ -428,11 +428,16 @@ static void writeMessage(int handle, unsigned char command, const unsigned char 
 	  r += written;
 	  needs_written -= written;
 	}
-      else
+      else if ( errno == EAGAIN )
 	{
 	  retryCount--;
 	  usleep(25000);
 	}
+      else
+        {
+          break;
+        }
+        
     } while ( needs_written > 0 && retryCount >= 0 );
 
   if ( written == -1 )

--- a/actisense-serial/actisense-serial.c
+++ b/actisense-serial/actisense-serial.c
@@ -375,7 +375,7 @@ static void writeRaw(int handle, const unsigned char * cmd, const size_t len)
 {
   if (write(handle, cmd, len) != len)
   {
-    logError("XXUnable to write command '%.*s' to NGT-1-A device\n", (int) len, cmd);
+    logError("Unable to write command '%.*s' to NGT-1-A device\n", (int) len, cmd);
     exit(1);
   }
   logDebug("Written %d bytes\n", (int) len);

--- a/actisense-serial/actisense-serial.c
+++ b/actisense-serial/actisense-serial.c
@@ -435,10 +435,6 @@ static void writeMessage(int handle, unsigned char command, const unsigned char 
 	}
     } while ( needs_written > 0 && retryCount >= 0 );
 
-  if ( retryCount != 5 ) {
-    logError("Had to retry: %d\n", (int) retryCount);
-  }
-
   if ( written == -1 )
   {
     logError("Unable to write command '%.*s' to NGT-1-A device\n", (int) len, cmd);


### PR DESCRIPTION
I really hate calling sleep to fix a problem, but don't know else to fix this