### PR TITLE
PGN129793: Updated min frame size to 0x1a

### DIFF
--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -2880,7 +2880,7 @@ Pgn pgnList[] =
 }
 
 ,
-{ "AIS UTC and Date Report", 129793, false, 8, 0,
+{ "AIS UTC and Date Report", 129793, false, 0x1a, 0,
   { { "Message ID", 6, 1, false, 0, "" }
   , { "Repeat Indicator", 2, RES_LOOKUP, false, LOOKUP_REPEAT_INDICATOR, "" }
   , { "User ID", BYTES(4), RES_INTEGER, false, "MMSI", "" }

--- a/analyzer/pgns.json
+++ b/analyzer/pgns.json
@@ -12426,7 +12426,7 @@
         "Id":"aisUtcAndDateReport",
         "Description":"AIS UTC and Date Report",
         "Complete":false,
-        "Length":8,
+        "Length":26,
         "RepeatingFields":0,
         "Fields":[
           {

--- a/analyzer/pgns.xml
+++ b/analyzer/pgns.xml
@@ -13996,7 +13996,7 @@ along with CANboat.  If not, see <http://www.gnu.org/licenses/>.
        <Id>aisUtcAndDateReport</Id>
        <Description>AIS UTC and Date Report</Description>
        <Complete>false</Complete>
-       <Length>8</Length>
+       <Length>26</Length>
        <RepeatingFields>0</RepeatingFields>
        <Fields>
          <Field>


### PR DESCRIPTION
PGN129793: Updated min frame size to 0x1a
Samples frames from a em-track B300 captured on NMEA2000 bus set the size at 0x1b but in sample file "susteranna-actisense-serial.raw" the frame size is set at 0x1a.
In the 2 cases, the lasts bytes seem not used...
All new samples are welcome.

./samples/susteranna-actisense-serial.raw:2016-04-09T16:41:11.608Z,7,129793,0,255,26,04,28,43,25,00,a5,f1,09,03,c3,dc,60,1f,fd,ff,ff,ff,ff,67,c1,0b,ff,ff,7f,ff,ff
My sample:
2017-08-17-15:35:50.000,7,129793,43,255,8,80,1b,04,55,ea,22,00,52
2017-08-17-15:35:50.000,7,129793,43,255,8,81,bc,28,ff,df,36,72,1b
2017-08-17-15:35:50.000,7,129793,43,255,8,82,01,70,f6,77,21,3a,40
2017-08-17-15:35:50.000,7,129793,43,255,8,83,09,f3,43,70,00,00,ff
