### PR TITLE
fix: PGNInfos from object to array

### DIFF
--- a/analyzer/pgns.json
+++ b/analyzer/pgns.json
@@ -2,9 +2,9 @@
     "Comment":"See https://github.com/canboat/canboat for the full source code",
     "CreatorCode":"Canboat NMEA2000 Analyzer",
     "License":"GPL v3",
-    "PGNs":{
+    "PGNs": [
     
-      "59392":{
+      {
         "PGN":59392,
         "Id":"isoAcknowledgement",
         "Description":"ISO Acknowledgement",
@@ -55,7 +55,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "59904":{
+      {
         "PGN":59904,
         "Id":"isoRequest",
         "Description":"ISO Request",
@@ -73,7 +73,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}}},
-      "60160":{
+      {
         "PGN":60160,
         "Id":"isoTransportProtocolDataTransfer",
         "Description":"ISO Transport Protocol, Data Transfer",
@@ -97,7 +97,7 @@
             "BitOffset":8,
             "BitStart":0,
             "Signed":false}]},
-      "60416":{
+      {
         "PGN":60416,
         "Id":"isoTransportProtocolConnectionManagementRequestToSend",
         "Description":"ISO Transport Protocol, Connection Management - Request To Send",
@@ -153,7 +153,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "60416":{
+      {
         "PGN":60416,
         "Id":"isoTransportProtocolConnectionManagementClearToSend",
         "Description":"ISO Transport Protocol, Connection Management - Clear To Send",
@@ -209,7 +209,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "60416":{
+      {
         "PGN":60416,
         "Id":"isoTransportProtocolConnectionManagementEndOfMessage",
         "Description":"ISO Transport Protocol, Connection Management - End Of Message",
@@ -265,7 +265,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "60416":{
+      {
         "PGN":60416,
         "Id":"isoTransportProtocolConnectionManagementBroadcastAnnounce",
         "Description":"ISO Transport Protocol, Connection Management - Broadcast Announce",
@@ -321,7 +321,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "60416":{
+      {
         "PGN":60416,
         "Id":"isoTransportProtocolConnectionManagementAbort",
         "Description":"ISO Transport Protocol, Connection Management - Abort",
@@ -368,7 +368,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "60928":{
+      {
         "PGN":60928,
         "Id":"isoAddressClaim",
         "Description":"ISO Address Claim",
@@ -493,7 +493,7 @@
             "BitStart":7,
             "Type":"Binary data",
             "Signed":false}]},
-      "61184":{
+      {
         "PGN":61184,
         "Id":"seatalkWirelessKeypadLightControl",
         "Description":"Seatalk: Wireless Keypad Light Control",
@@ -568,7 +568,7 @@
             "BitOffset":40,
             "BitStart":0,
             "Signed":false}]},
-      "61184":{
+      {
         "PGN":61184,
         "Id":"seatalkWirelessKeypadLightControl",
         "Description":"Seatalk: Wireless Keypad Light Control",
@@ -631,7 +631,7 @@
             "BitOffset":32,
             "BitStart":0,
             "Signed":false}]},
-      "61184":{
+      {
         "PGN":61184,
         "Id":"victronBatteryRegister",
         "Description":"Victron Battery Register",
@@ -686,7 +686,7 @@
             "BitOffset":32,
             "BitStart":0,
             "Signed":false}]},
-      "61184":{
+      {
         "PGN":61184,
         "Id":"manufacturerProprietarySingleFrameAddressed",
         "Description":"Manufacturer Proprietary single-frame addressed",
@@ -737,7 +737,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "61440":{
+      {
         "PGN":61440,
         "Id":"unknownSingleFrameNonAddressed",
         "Description":"Unknown single-frame non-addressed",
@@ -788,7 +788,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "65001":{
+      {
         "PGN":65001,
         "Id":"bus1PhaseCBasicAcQuantities",
         "Description":"Bus #1 Phase C Basic AC Quantities",
@@ -824,7 +824,7 @@
             "Units":"Hz",
             "Resolution":"0.0078125",
             "Signed":false}]},
-      "65002":{
+      {
         "PGN":65002,
         "Id":"bus1PhaseBBasicAcQuantities",
         "Description":"Bus #1 Phase B Basic AC Quantities",
@@ -860,7 +860,7 @@
             "Units":"Hz",
             "Resolution":"0.0078125",
             "Signed":false}]},
-      "65003":{
+      {
         "PGN":65003,
         "Id":"bus1PhaseABasicAcQuantities",
         "Description":"Bus #1 Phase A Basic AC Quantities",
@@ -896,7 +896,7 @@
             "Units":"Hz",
             "Resolution":"0.0078125",
             "Signed":false}]},
-      "65004":{
+      {
         "PGN":65004,
         "Id":"bus1AverageBasicAcQuantities",
         "Description":"Bus #1 Average Basic AC Quantities",
@@ -932,7 +932,7 @@
             "Units":"Hz",
             "Resolution":"0.0078125",
             "Signed":false}]},
-      "65005":{
+      {
         "PGN":65005,
         "Id":"utilityTotalAcEnergy",
         "Description":"Utility Total AC Energy",
@@ -958,7 +958,7 @@
             "BitStart":0,
             "Units":"kWh",
             "Signed":false}]},
-      "65006":{
+      {
         "PGN":65006,
         "Id":"utilityPhaseCAcReactivePower",
         "Description":"Utility Phase C AC Reactive Power",
@@ -997,7 +997,7 @@
               {"name":"Leading","value":"0"},
               {"name":"Lagging","value":"1"},
               {"name":"Error","value":"2"}]}]},
-      "65007":{
+      {
         "PGN":65007,
         "Id":"utilityPhaseCAcPower",
         "Description":"Utility Phase C AC Power",
@@ -1025,7 +1025,7 @@
             "Units":"VA",
             "Signed":true,
             "Offset":-2000000000}]},
-      "65008":{
+      {
         "PGN":65008,
         "Id":"utilityPhaseCBasicAcQuantities",
         "Description":"Utility Phase C Basic AC Quantities",
@@ -1070,7 +1070,7 @@
             "BitStart":0,
             "Units":"A",
             "Signed":false}]},
-      "65009":{
+      {
         "PGN":65009,
         "Id":"utilityPhaseBAcReactivePower",
         "Description":"Utility Phase B AC Reactive Power",
@@ -1109,7 +1109,7 @@
               {"name":"Leading","value":"0"},
               {"name":"Lagging","value":"1"},
               {"name":"Error","value":"2"}]}]},
-      "65010":{
+      {
         "PGN":65010,
         "Id":"utilityPhaseBAcPower",
         "Description":"Utility Phase B AC Power",
@@ -1137,7 +1137,7 @@
             "Units":"VA",
             "Signed":true,
             "Offset":-2000000000}]},
-      "65011":{
+      {
         "PGN":65011,
         "Id":"utilityPhaseBBasicAcQuantities",
         "Description":"Utility Phase B Basic AC Quantities",
@@ -1182,7 +1182,7 @@
             "BitStart":0,
             "Units":"A",
             "Signed":false}]},
-      "65012":{
+      {
         "PGN":65012,
         "Id":"utilityPhaseAAcReactivePower",
         "Description":"Utility Phase A AC Reactive Power",
@@ -1222,7 +1222,7 @@
               {"name":"Leading","value":"0"},
               {"name":"Lagging","value":"1"},
               {"name":"Error","value":"2"}]}]},
-      "65013":{
+      {
         "PGN":65013,
         "Id":"utilityPhaseAAcPower",
         "Description":"Utility Phase A AC Power",
@@ -1250,7 +1250,7 @@
             "Units":"VA",
             "Signed":true,
             "Offset":-2000000000}]},
-      "65014":{
+      {
         "PGN":65014,
         "Id":"utilityPhaseABasicAcQuantities",
         "Description":"Utility Phase A Basic AC Quantities",
@@ -1295,7 +1295,7 @@
             "BitStart":0,
             "Units":"A",
             "Signed":false}]},
-      "65015":{
+      {
         "PGN":65015,
         "Id":"utilityTotalAcReactivePower",
         "Description":"Utility Total AC Reactive Power",
@@ -1335,7 +1335,7 @@
               {"name":"Leading","value":"0"},
               {"name":"Lagging","value":"1"},
               {"name":"Error","value":"2"}]}]},
-      "65016":{
+      {
         "PGN":65016,
         "Id":"utilityTotalAcPower",
         "Description":"Utility Total AC Power",
@@ -1363,7 +1363,7 @@
             "Units":"VA",
             "Signed":true,
             "Offset":-2000000000}]},
-      "65017":{
+      {
         "PGN":65017,
         "Id":"utilityAverageBasicAcQuantities",
         "Description":"Utility Average Basic AC Quantities",
@@ -1408,7 +1408,7 @@
             "BitStart":0,
             "Units":"A",
             "Signed":false}]},
-      "65018":{
+      {
         "PGN":65018,
         "Id":"generatorTotalAcEnergy",
         "Description":"Generator Total AC Energy",
@@ -1434,7 +1434,7 @@
             "BitStart":0,
             "Units":"kWh",
             "Signed":false}]},
-      "65019":{
+      {
         "PGN":65019,
         "Id":"generatorPhaseCAcReactivePower",
         "Description":"Generator Phase C AC Reactive Power",
@@ -1474,7 +1474,7 @@
               {"name":"Leading","value":"0"},
               {"name":"Lagging","value":"1"},
               {"name":"Error","value":"2"}]}]},
-      "65020":{
+      {
         "PGN":65020,
         "Id":"generatorPhaseCAcPower",
         "Description":"Generator Phase C AC Power",
@@ -1502,7 +1502,7 @@
             "Units":"VA",
             "Signed":false,
             "Offset":-2000000000}]},
-      "65021":{
+      {
         "PGN":65021,
         "Id":"generatorPhaseCBasicAcQuantities",
         "Description":"Generator Phase C Basic AC Quantities",
@@ -1547,7 +1547,7 @@
             "BitStart":0,
             "Units":"A",
             "Signed":false}]},
-      "65022":{
+      {
         "PGN":65022,
         "Id":"generatorPhaseBAcReactivePower",
         "Description":"Generator Phase B AC Reactive Power",
@@ -1587,7 +1587,7 @@
               {"name":"Leading","value":"0"},
               {"name":"Lagging","value":"1"},
               {"name":"Error","value":"2"}]}]},
-      "65023":{
+      {
         "PGN":65023,
         "Id":"generatorPhaseBAcPower",
         "Description":"Generator Phase B AC Power",
@@ -1615,7 +1615,7 @@
             "Units":"VA",
             "Signed":false,
             "Offset":-2000000000}]},
-      "65024":{
+      {
         "PGN":65024,
         "Id":"generatorPhaseBBasicAcQuantities",
         "Description":"Generator Phase B Basic AC Quantities",
@@ -1660,7 +1660,7 @@
             "BitStart":0,
             "Units":"A",
             "Signed":false}]},
-      "65025":{
+      {
         "PGN":65025,
         "Id":"generatorPhaseAAcReactivePower",
         "Description":"Generator Phase A AC Reactive Power",
@@ -1700,7 +1700,7 @@
               {"name":"Leading","value":"0"},
               {"name":"Lagging","value":"1"},
               {"name":"Error","value":"2"}]}]},
-      "65026":{
+      {
         "PGN":65026,
         "Id":"generatorPhaseAAcPower",
         "Description":"Generator Phase A AC Power",
@@ -1728,7 +1728,7 @@
             "Units":"VA",
             "Signed":false,
             "Offset":-2000000000}]},
-      "65027":{
+      {
         "PGN":65027,
         "Id":"generatorPhaseABasicAcQuantities",
         "Description":"Generator Phase A Basic AC Quantities",
@@ -1773,7 +1773,7 @@
             "BitStart":0,
             "Units":"A",
             "Signed":false}]},
-      "65028":{
+      {
         "PGN":65028,
         "Id":"generatorTotalAcReactivePower",
         "Description":"Generator Total AC Reactive Power",
@@ -1813,7 +1813,7 @@
               {"name":"Leading","value":"0"},
               {"name":"Lagging","value":"1"},
               {"name":"Error","value":"2"}]}]},
-      "65029":{
+      {
         "PGN":65029,
         "Id":"generatorTotalAcPower",
         "Description":"Generator Total AC Power",
@@ -1841,7 +1841,7 @@
             "Units":"VA",
             "Signed":false,
             "Offset":-2000000000}]},
-      "65030":{
+      {
         "PGN":65030,
         "Id":"generatorAverageBasicAcQuantities",
         "Description":"Generator Average Basic AC Quantities",
@@ -1886,7 +1886,7 @@
             "BitStart":0,
             "Units":"A",
             "Signed":false}]},
-      "65240":{
+      {
         "PGN":65240,
         "Id":"isoCommandedAddress",
         "Description":"ISO Commanded Address",
@@ -2018,7 +2018,7 @@
             "BitOffset":64,
             "BitStart":0,
             "Signed":false}]},
-      "65280":{
+      {
         "PGN":65280,
         "Id":"manufacturerProprietarySingleFrameNonAddressed",
         "Description":"Manufacturer Proprietary single-frame non-addressed",
@@ -2069,7 +2069,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "65285":{
+      {
         "PGN":65285,
         "Id":"airmarBootStateAcknowledgment",
         "Description":"Airmar: Boot State Acknowledgment",
@@ -2121,7 +2121,7 @@
               {"name":"in Startup Monitor","value":"0"},
               {"name":"running Bootloader","value":"1"},
               {"name":"running Application","value":"2"}]}]},
-      "65285":{
+      {
         "PGN":65285,
         "Id":"lowranceTemperature",
         "Description":"Lowrance: Temperature",
@@ -2196,7 +2196,7 @@
             "Type":"Temperature",
             "Resolution":"0.01",
             "Signed":false}]},
-      "65286":{
+      {
         "PGN":65286,
         "Id":"airmarBootStateRequest",
         "Description":"Airmar: Boot State Request",
@@ -2235,7 +2235,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "65287":{
+      {
         "PGN":65287,
         "Id":"airmarAccessLevel",
         "Description":"Airmar: Access Level",
@@ -2318,7 +2318,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "65287":{
+      {
         "PGN":65287,
         "Id":"simnetConfigureTemperatureSensor",
         "Description":"Simnet: Configure Temperature Sensor",
@@ -2357,7 +2357,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "65288":{
+      {
         "PGN":65288,
         "Id":"seatalkAlarm",
         "Description":"Seatalk: Alarm",
@@ -2561,7 +2561,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "65289":{
+      {
         "PGN":65289,
         "Id":"simnetTrimTabSensorCalibration",
         "Description":"Simnet: Trim Tab Sensor Calibration",
@@ -2600,7 +2600,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "65290":{
+      {
         "PGN":65290,
         "Id":"simnetPaddleWheelSpeedConfiguration",
         "Description":"Simnet: Paddle Wheel Speed Configuration",
@@ -2639,7 +2639,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "65292":{
+      {
         "PGN":65292,
         "Id":"simnetClearFluidLevelWarnings",
         "Description":"Simnet: Clear Fluid Level Warnings",
@@ -2678,7 +2678,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "65293":{
+      {
         "PGN":65293,
         "Id":"simnetLgc2000Configuration",
         "Description":"Simnet: LGC-2000 Configuration",
@@ -2717,7 +2717,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "65309":{
+      {
         "PGN":65309,
         "Id":"navicoWirelessBatteryStatus",
         "Description":"Navico: Wireless Battery Status",
@@ -2790,7 +2790,7 @@
             "BitOffset":40,
             "BitStart":0,
             "Signed":false}]},
-      "65312":{
+      {
         "PGN":65312,
         "Id":"navicoWirelessSignalStatus",
         "Description":"Navico: Wireless Signal Status",
@@ -2854,7 +2854,7 @@
             "BitOffset":32,
             "BitStart":0,
             "Signed":false}]},
-      "65325":{
+      {
         "PGN":65325,
         "Id":"simnetReprogramStatus",
         "Description":"Simnet: Reprogram Status",
@@ -2893,7 +2893,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "65341":{
+      {
         "PGN":65341,
         "Id":"simnetAutopilotMode",
         "Description":"Simnet: Autopilot Mode",
@@ -2932,7 +2932,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "65345":{
+      {
         "PGN":65345,
         "Id":"seatalkPilotWindDatum",
         "Description":"Seatalk: Pilot Wind Datum",
@@ -2999,7 +2999,7 @@
             "BitOffset":48,
             "BitStart":0,
             "Signed":false}]},
-      "65359":{
+      {
         "PGN":65359,
         "Id":"seatalkPilotHeading",
         "Description":"Seatalk: Pilot Heading",
@@ -3075,7 +3075,7 @@
             "BitOffset":56,
             "BitStart":0,
             "Signed":false}]},
-      "65360":{
+      {
         "PGN":65360,
         "Id":"seatalkPilotLockedHeading",
         "Description":"Seatalk: Pilot Locked Heading",
@@ -3152,7 +3152,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "65361":{
+      {
         "PGN":65361,
         "Id":"seatalkSilenceAlarm",
         "Description":"Seatalk: Silence Alarm",
@@ -3334,7 +3334,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "65371":{
+      {
         "PGN":65371,
         "Id":"seatalkKeypadMessage",
         "Description":"Seatalk: Keypad Message",
@@ -3430,7 +3430,7 @@
             "BitOffset":48,
             "BitStart":0,
             "Signed":false}]},
-      "65374":{
+      {
         "PGN":65374,
         "Id":"seatalkKeypadHeartbeat",
         "Description":"SeaTalk: Keypad Heartbeat",
@@ -3493,7 +3493,7 @@
             "BitOffset":32,
             "BitStart":0,
             "Signed":false}]},
-      "65379":{
+      {
         "PGN":65379,
         "Id":"seatalkPilotMode",
         "Description":"Seatalk: Pilot Mode",
@@ -3568,7 +3568,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "65408":{
+      {
         "PGN":65408,
         "Id":"airmarDepthQualityFactor",
         "Description":"Airmar: Depth Quality Factor",
@@ -3626,7 +3626,7 @@
             "Signed":false,
             "EnumValues":[
               {"name":"No Depth Lock","value":"0"}]}]},
-      "65410":{
+      {
         "PGN":65410,
         "Id":"airmarDeviceInformation",
         "Description":"Airmar: Device Information",
@@ -3703,7 +3703,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "65480":{
+      {
         "PGN":65480,
         "Id":"simnetAutopilotMode",
         "Description":"Simnet: Autopilot Mode",
@@ -3742,7 +3742,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "65536":{
+      {
         "PGN":65536,
         "Id":"unknownFastPacketAddressed",
         "Description":"Unknown fast-packet addressed",
@@ -3759,7 +3759,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}}},
-      "126208":{
+      {
         "PGN":126208,
         "Id":"nmeaRequestGroupFunction",
         "Description":"NMEA - Request group function",
@@ -3841,7 +3841,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "126208":{
+      {
         "PGN":126208,
         "Id":"nmeaCommandGroupFunction",
         "Description":"NMEA - Command group function",
@@ -3920,7 +3920,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "126208":{
+      {
         "PGN":126208,
         "Id":"nmeaAcknowledgeGroupFunction",
         "Description":"NMEA - Acknowledge group function",
@@ -4008,7 +4008,7 @@
               {"name":"Access denied","value":"4"},
               {"name":"Not supported","value":"5"},
               {"name":"Read or Write not supported","value":"6"}]}]},
-      "126208":{
+      {
         "PGN":126208,
         "Id":"nmeaReadFieldsGroupFunction",
         "Description":"NMEA - Read Fields group function",
@@ -4130,7 +4130,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "126208":{
+      {
         "PGN":126208,
         "Id":"nmeaReadFieldsReplyGroupFunction",
         "Description":"NMEA - Read Fields reply group function",
@@ -4265,7 +4265,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "126208":{
+      {
         "PGN":126208,
         "Id":"nmeaWriteFieldsGroupFunction",
         "Description":"NMEA - Write Fields group function",
@@ -4400,7 +4400,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "126208":{
+      {
         "PGN":126208,
         "Id":"nmeaWriteFieldsReplyGroupFunction",
         "Description":"NMEA - Write Fields reply group function",
@@ -4535,7 +4535,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "126270":{
+      {
         "PGN":126270,
         "Id":"maretronSlaveResponse",
         "Description":"Maretron: Slave Response",
@@ -4608,7 +4608,7 @@
             "BitOffset":56,
             "BitStart":0,
             "Signed":false}]},
-      "126464":{
+      {
         "PGN":126464,
         "Id":"pgnListTransmitAndReceive",
         "Description":"PGN List (Transmit and Receive)",
@@ -4639,7 +4639,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "126720":{
+      {
         "PGN":126720,
         "Id":"seatalk1Keystroke",
         "Description":"Seatalk1: Keystroke",
@@ -4739,7 +4739,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "126720":{
+      {
         "PGN":126720,
         "Id":"seatalk1DeviceIndentification",
         "Description":"Seatalk1: Device Indentification",
@@ -4822,7 +4822,7 @@
             "EnumValues":[
               {"name":"S100","value":"3"},
               {"name":"Course Computer","value":"5"}]}]},
-      "126720":{
+      {
         "PGN":126720,
         "Id":"airmarAttitudeOffset",
         "Description":"Airmar: Attitude Offset",
@@ -4906,7 +4906,7 @@
             "Units":"rad",
             "Resolution":"0.0001",
             "Signed":true}]},
-      "126720":{
+      {
         "PGN":126720,
         "Id":"airmarCalibrateCompass",
         "Description":"Airmar: Calibrate Compass",
@@ -5096,7 +5096,7 @@
             "Units":"s",
             "Resolution":"0.05",
             "Signed":true}]},
-      "126720":{
+      {
         "PGN":126720,
         "Id":"airmarTrueWindOptions",
         "Description":"Airmar: True Wind Options",
@@ -5283,7 +5283,7 @@
             "Units":"s",
             "Resolution":"0.05",
             "Signed":true}]},
-      "126720":{
+      {
         "PGN":126720,
         "Id":"airmarSimulateMode",
         "Description":"Airmar: Simulate Mode",
@@ -5356,7 +5356,7 @@
             "BitStart":2,
             "Type":"Binary data",
             "Signed":false}]},
-      "126720":{
+      {
         "PGN":126720,
         "Id":"airmarCalibrateDepth",
         "Description":"Airmar: Calibrate Depth",
@@ -5428,7 +5428,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "126720":{
+      {
         "PGN":126720,
         "Id":"airmarCalibrateSpeed",
         "Description":"Airmar: Calibrate Speed",
@@ -5510,7 +5510,7 @@
             "Units":"m/s",
             "Resolution":"0.01",
             "Signed":false}]},
-      "126720":{
+      {
         "PGN":126720,
         "Id":"airmarCalibrateTemperature",
         "Description":"Airmar: Calibrate Temperature",
@@ -5605,7 +5605,7 @@
             "Units":"K",
             "Resolution":"0.001",
             "Signed":true}]},
-      "126720":{
+      {
         "PGN":126720,
         "Id":"airmarSpeedFilter",
         "Description":"Airmar: Speed Filter",
@@ -5698,7 +5698,7 @@
             "Units":"s",
             "Resolution":"0.01",
             "Signed":false}]},
-      "126720":{
+      {
         "PGN":126720,
         "Id":"airmarTemperatureFilter",
         "Description":"Airmar: Temperature Filter",
@@ -5792,7 +5792,7 @@
             "Units":"s",
             "Resolution":"0.01",
             "Signed":false}]},
-      "126720":{
+      {
         "PGN":126720,
         "Id":"airmarNmea2000Options",
         "Description":"Airmar: NMEA 2000 options",
@@ -5867,7 +5867,7 @@
             "BitStart":2,
             "Type":"Binary data",
             "Signed":false}]},
-      "126720":{
+      {
         "PGN":126720,
         "Id":"airmarAddressableMultiFrame",
         "Description":"Airmar: Addressable Multi-Frame",
@@ -5916,7 +5916,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "126720":{
+      {
         "PGN":126720,
         "Id":"manufacturerProprietaryFastPacketAddressed",
         "Description":"Manufacturer Proprietary fast-packet addressed",
@@ -5967,7 +5967,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "126976":{
+      {
         "PGN":126976,
         "Id":"unknownFastPacketNonAddressed",
         "Description":"Unknown fast-packet non-addressed",
@@ -5984,49 +5984,49 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}}},
-      "126983":{
+      {
         "PGN":126983,
         "Id":"alert",
         "Description":"Alert",
         "Complete":false,
         "Length":8,
         "RepeatingFields":0},
-      "126984":{
+      {
         "PGN":126984,
         "Id":"alertResponse",
         "Description":"Alert Response",
         "Complete":false,
         "Length":8,
         "RepeatingFields":0},
-      "126985":{
+      {
         "PGN":126985,
         "Id":"alertText",
         "Description":"Alert Text",
         "Complete":false,
         "Length":8,
         "RepeatingFields":0},
-      "126986":{
+      {
         "PGN":126986,
         "Id":"alertConfiguration",
         "Description":"Alert Configuration",
         "Complete":false,
         "Length":8,
         "RepeatingFields":0},
-      "126987":{
+      {
         "PGN":126987,
         "Id":"alertThreshold",
         "Description":"Alert Threshold",
         "Complete":false,
         "Length":8,
         "RepeatingFields":0},
-      "126988":{
+      {
         "PGN":126988,
         "Id":"alertValue",
         "Description":"Alert Value",
         "Complete":false,
         "Length":8,
         "RepeatingFields":0},
-      "126992":{
+      {
         "PGN":126992,
         "Id":"systemTime",
         "Description":"System Time",
@@ -6092,7 +6092,7 @@
             "Type":"Time",
             "Resolution":"0.0001",
             "Signed":false}]},
-      "126993":{
+      {
         "PGN":126993,
         "Id":"heartbeat",
         "Description":"Heartbeat",
@@ -6131,7 +6131,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "126996":{
+      {
         "PGN":126996,
         "Id":"productInformation",
         "Description":"Product Information",
@@ -6207,7 +6207,7 @@
             "BitOffset":1064,
             "BitStart":0,
             "Signed":false}]},
-      "126998":{
+      {
         "PGN":126998,
         "Id":"configurationInformation",
         "Description":"Configuration Information",
@@ -6264,7 +6264,7 @@
             "BitOffset":352,
             "BitStart":0,
             "Signed":false}]},
-      "127233":{
+      {
         "PGN":127233,
         "Id":"manOverboardNotification",
         "Description":"Man Overboard Notification",
@@ -6466,7 +6466,7 @@
             "BitStart":3,
             "Type":"Binary data",
             "Signed":false}]},
-      "127237":{
+      {
         "PGN":127237,
         "Id":"headingTrackControl",
         "Description":"Heading/Track control",
@@ -6636,7 +6636,7 @@
             "Units":"rad",
             "Resolution":"0.0001",
             "Signed":false}]},
-      "127245":{
+      {
         "PGN":127245,
         "Id":"rudder",
         "Description":"Rudder",
@@ -6690,7 +6690,7 @@
             "Units":"rad",
             "Resolution":"0.0001",
             "Signed":true}]},
-      "127250":{
+      {
         "PGN":127250,
         "Id":"vesselHeading",
         "Description":"Vessel Heading",
@@ -6748,7 +6748,7 @@
             "EnumValues":[
               {"name":"True","value":"0"},
               {"name":"Magnetic","value":"1"}]}]},
-      "127251":{
+      {
         "PGN":127251,
         "Id":"rateOfTurn",
         "Description":"Rate of Turn",
@@ -6774,7 +6774,7 @@
             "Units":"rad/s",
             "Resolution":3.125e-08,
             "Signed":true}]},
-      "127257":{
+      {
         "PGN":127257,
         "Id":"attitude",
         "Description":"Attitude",
@@ -6820,7 +6820,7 @@
             "Units":"rad",
             "Resolution":"0.0001",
             "Signed":true}]},
-      "127258":{
+      {
         "PGN":127258,
         "Id":"magneticVariation",
         "Description":"Magnetic Variation",
@@ -6887,7 +6887,7 @@
             "Units":"rad",
             "Resolution":"0.0001",
             "Signed":true}]},
-      "127488":{
+      {
         "PGN":127488,
         "Id":"engineParametersRapidUpdate",
         "Description":"Engine Parameters, Rapid Update",
@@ -6936,7 +6936,7 @@
             "BitStart":0,
             "Units":null,
             "Signed":true}]},
-      "127489":{
+      {
         "PGN":127489,
         "Id":"engineParametersDynamic",
         "Description":"Engine Parameters, Dynamic",
@@ -7111,7 +7111,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":true}]},
-      "127493":{
+      {
         "PGN":127493,
         "Id":"transmissionParametersDynamic",
         "Description":"Transmission Parameters, Dynamic",
@@ -7193,7 +7193,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "127496":{
+      {
         "PGN":127496,
         "Id":"tripParametersVessel",
         "Description":"Trip Parameters, Vessel",
@@ -7240,7 +7240,7 @@
             "Units":"s",
             "Resolution":"0.001",
             "Signed":false}]},
-      "127497":{
+      {
         "PGN":127497,
         "Id":"tripParametersEngine",
         "Description":"Trip Parameters, Engine",
@@ -7299,7 +7299,7 @@
             "Units":"L/h",
             "Resolution":"0.1",
             "Signed":true}]},
-      "127498":{
+      {
         "PGN":127498,
         "Id":"engineParametersStatic",
         "Description":"Engine Parameters, Static",
@@ -7343,7 +7343,7 @@
             "BitOffset":32,
             "BitStart":0,
             "Signed":false}]},
-      "127501":{
+      {
         "PGN":127501,
         "Id":"binarySwitchBankStatus",
         "Description":"Binary Switch Bank Status",
@@ -7723,7 +7723,7 @@
               {"name":"Off","value":"0"},
               {"name":"On","value":"1"},
               {"name":"Failed","value":"2"}]}]},
-      "127502":{
+      {
         "PGN":127502,
         "Id":"switchBankControl",
         "Description":"Switch Bank Control",
@@ -7751,7 +7751,7 @@
             "EnumValues":[
               {"name":"Off","value":"0"},
               {"name":"On","value":"1"}]}]},
-      "127503":{
+      {
         "PGN":127503,
         "Id":"acInputStatus",
         "Description":"AC Input Status",
@@ -7884,7 +7884,7 @@
             "Units":"Cos Phi",
             "Resolution":"0.01",
             "Signed":false}]},
-      "127504":{
+      {
         "PGN":127504,
         "Id":"acOutputStatus",
         "Description":"AC Output Status",
@@ -8016,7 +8016,7 @@
             "Units":"Cos Phi",
             "Resolution":"0.01",
             "Signed":false}]},
-      "127505":{
+      {
         "PGN":127505,
         "Id":"fluidLevel",
         "Description":"Fluid Level",
@@ -8068,7 +8068,7 @@
             "Units":"L",
             "Resolution":"0.1",
             "Signed":false}]},
-      "127506":{
+      {
         "PGN":127506,
         "Id":"dcDetailedStatus",
         "Description":"DC Detailed Status",
@@ -8134,7 +8134,7 @@
             "Units":"V",
             "Resolution":"0.01",
             "Signed":false}]},
-      "127507":{
+      {
         "PGN":127507,
         "Id":"chargerStatus",
         "Description":"Charger Status",
@@ -8233,7 +8233,7 @@
             "BitOffset":32,
             "BitStart":0,
             "Signed":false}]},
-      "127508":{
+      {
         "PGN":127508,
         "Id":"batteryStatus",
         "Description":"Battery Status",
@@ -8288,7 +8288,7 @@
             "BitOffset":56,
             "BitStart":0,
             "Signed":false}]},
-      "127509":{
+      {
         "PGN":127509,
         "Id":"inverterStatus",
         "Description":"Inverter Status",
@@ -8344,7 +8344,7 @@
             "EnumValues":[
               {"name":"Standby","value":"0"},
               {"name":"On","value":"1"}]}]},
-      "127510":{
+      {
         "PGN":127510,
         "Id":"chargerConfigurationStatus",
         "Description":"Charger Configuration Status",
@@ -8446,7 +8446,7 @@
             "BitOffset":80,
             "BitStart":0,
             "Signed":false}]},
-      "127511":{
+      {
         "PGN":127511,
         "Id":"inverterConfigurationStatus",
         "Description":"Inverter Configuration Status",
@@ -8518,7 +8518,7 @@
             "BitOffset":50,
             "BitStart":2,
             "Signed":false}]},
-      "127512":{
+      {
         "PGN":127512,
         "Id":"agsConfigurationStatus",
         "Description":"AGS Configuration Status",
@@ -8550,7 +8550,7 @@
             "BitOffset":16,
             "BitStart":0,
             "Signed":false}]},
-      "127513":{
+      {
         "PGN":127513,
         "Id":"batteryConfigurationStatus",
         "Description":"Battery Configuration Status",
@@ -8641,7 +8641,7 @@
             "BitOffset":96,
             "BitStart":0,
             "Signed":false}]},
-      "127514":{
+      {
         "PGN":127514,
         "Id":"agsStatus",
         "Description":"AGS Status",
@@ -8697,7 +8697,7 @@
             "BitOffset":40,
             "BitStart":0,
             "Signed":false}]},
-      "128000":{
+      {
         "PGN":128000,
         "Id":"leewayAngle",
         "Description":"Leeway Angle",
@@ -8732,7 +8732,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "128259":{
+      {
         "PGN":128259,
         "Id":"speed",
         "Description":"Speed",
@@ -8791,7 +8791,7 @@
             "BitOffset":48,
             "BitStart":0,
             "Signed":false}]},
-      "128267":{
+      {
         "PGN":128267,
         "Id":"waterDepth",
         "Description":"Water Depth",
@@ -8840,7 +8840,7 @@
             "Units":"m",
             "Resolution":10,
             "Signed":false}]},
-      "128275":{
+      {
         "PGN":128275,
         "Id":"distanceLog",
         "Description":"Distance Log",
@@ -8892,7 +8892,7 @@
             "BitStart":0,
             "Units":"m",
             "Signed":false}]},
-      "128520":{
+      {
         "PGN":128520,
         "Id":"trackedTargetData",
         "Description":"Tracked Target Data",
@@ -9058,7 +9058,7 @@
             "BitStart":0,
             "Type":"ASCII text",
             "Signed":false}]},
-      "129025":{
+      {
         "PGN":129025,
         "Id":"positionRapidUpdate",
         "Description":"Position, Rapid Update",
@@ -9088,7 +9088,7 @@
             "Type":"Longitude",
             "Resolution":"0.0000001",
             "Signed":true}]},
-      "129026":{
+      {
         "PGN":129026,
         "Id":"cogSogRapidUpdate",
         "Description":"COG & SOG, Rapid Update",
@@ -9156,7 +9156,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "129027":{
+      {
         "PGN":129027,
         "Id":"positionDeltaRapidUpdate",
         "Description":"Position Delta, Rapid Update",
@@ -9196,7 +9196,7 @@
             "BitOffset":40,
             "BitStart":0,
             "Signed":true}]},
-      "129028":{
+      {
         "PGN":129028,
         "Id":"altitudeDeltaRapidUpdate",
         "Description":"Altitude Delta, Rapid Update",
@@ -9264,7 +9264,7 @@
             "BitOffset":64,
             "BitStart":0,
             "Signed":true}]},
-      "129029":{
+      {
         "PGN":129029,
         "Id":"gnssPositionData",
         "Description":"GNSS Position Data",
@@ -9485,7 +9485,7 @@
             "Units":"s",
             "Resolution":"0.01",
             "Signed":false}]},
-      "129033":{
+      {
         "PGN":129033,
         "Id":"timeDate",
         "Description":"Time & Date",
@@ -9529,7 +9529,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":true}]},
-      "129038":{
+      {
         "PGN":129038,
         "Id":"aisClassAPositionReport",
         "Description":"AIS Class A Position Report",
@@ -9748,7 +9748,7 @@
             "BitStart":1,
             "Type":"Binary data",
             "Signed":false}]},
-      "129039":{
+      {
         "PGN":129039,
         "Id":"aisClassBPositionReport",
         "Description":"AIS Class B Position Report",
@@ -10009,7 +10009,7 @@
             "EnumValues":[
               {"name":"SOTDMA","value":"0"},
               {"name":"ITDMA","value":"1"}]}]},
-      "129040":{
+      {
         "PGN":129040,
         "Id":"aisClassBExtendedPositionReport",
         "Description":"AIS Class B Extended Position Report",
@@ -10346,7 +10346,7 @@
               {"name":"Channel B VDL transmission","value":"3"},
               {"name":"Own information not broadcast","value":"4"},
               {"name":"Reserved","value":"5"}]}]},
-      "129041":{
+      {
         "PGN":129041,
         "Id":"aisAidsToNavigationAtonReport",
         "Description":"AIS Aids to Navigation (AtoN) Report",
@@ -10647,7 +10647,7 @@
             "BitStart":0,
             "Type":"ASCII or UNICODE string starting with length and control byte",
             "Signed":false}]},
-      "129044":{
+      {
         "PGN":129044,
         "Id":"datum",
         "Description":"Datum",
@@ -10707,7 +10707,7 @@
             "BitStart":0,
             "Type":"ASCII text",
             "Signed":false}]},
-      "129045":{
+      {
         "PGN":129045,
         "Id":"userDatum",
         "Description":"User Datum",
@@ -10820,7 +10820,7 @@
             "BitStart":0,
             "Type":"ASCII text",
             "Signed":false}]},
-      "129283":{
+      {
         "PGN":129283,
         "Id":"crossTrackError",
         "Description":"Cross Track Error",
@@ -10883,7 +10883,7 @@
             "Units":"m",
             "Resolution":"0.01",
             "Signed":true}]},
-      "129284":{
+      {
         "PGN":129284,
         "Id":"navigationData",
         "Description":"Navigation Data",
@@ -11049,7 +11049,7 @@
             "Units":"m/s",
             "Resolution":"0.01",
             "Signed":true}]},
-      "129285":{
+      {
         "PGN":129285,
         "Id":"navigationRouteWpInformation",
         "Description":"Navigation - Route/WP Information",
@@ -11173,7 +11173,7 @@
             "Type":"Longitude",
             "Resolution":"0.0000001",
             "Signed":true}]},
-      "129291":{
+      {
         "PGN":129291,
         "Id":"setDriftRapidUpdate",
         "Description":"Set & Drift, Rapid Update",
@@ -11231,7 +11231,7 @@
             "Units":"m/s",
             "Resolution":"0.01",
             "Signed":false}]},
-      "129301":{
+      {
         "PGN":129301,
         "Id":"navigationRouteTimeToFromMark",
         "Description":"Navigation - Route / Time to+from Mark",
@@ -11291,7 +11291,7 @@
             "BitOffset":48,
             "BitStart":0,
             "Signed":false}]},
-      "129302":{
+      {
         "PGN":129302,
         "Id":"bearingAndDistanceBetweenTwoMarks",
         "Description":"Bearing and Distance between two Marks",
@@ -11389,7 +11389,7 @@
             "BitOffset":104,
             "BitStart":0,
             "Signed":false}]},
-      "129538":{
+      {
         "PGN":129538,
         "Id":"gnssControlStatus",
         "Description":"GNSS Control Status",
@@ -11504,7 +11504,7 @@
             "EnumValues":[
               {"name":"use last 3D height","value":"0"},
               {"name":"Use antenna altitude","value":"1"}]}]},
-      "129539":{
+      {
         "PGN":129539,
         "Id":"gnssDops",
         "Description":"GNSS DOPs",
@@ -11594,7 +11594,7 @@
             "BitStart":0,
             "Resolution":"0.01",
             "Signed":false}]},
-      "129540":{
+      {
         "PGN":129540,
         "Id":"gnssSatsInView",
         "Description":"GNSS Sats in View",
@@ -11711,7 +11711,7 @@
             "BitStart":4,
             "Type":"Binary data",
             "Signed":false}]},
-      "129541":{
+      {
         "PGN":129541,
         "Id":"gpsAlmanacData",
         "Description":"GPS Almanac Data",
@@ -11823,7 +11823,7 @@
             "BitOffset":96,
             "BitStart":0,
             "Signed":false}]},
-      "129542":{
+      {
         "PGN":129542,
         "Id":"gnssPseudorangeNoiseStatistics",
         "Description":"GNSS Pseudorange Noise Statistics",
@@ -11895,7 +11895,7 @@
             "BitOffset":64,
             "BitStart":0,
             "Signed":false}]},
-      "129545":{
+      {
         "PGN":129545,
         "Id":"gnssRaimOutput",
         "Description":"GNSS RAIM Output",
@@ -11985,7 +11985,7 @@
             "BitOffset":64,
             "BitStart":0,
             "Signed":false}]},
-      "129546":{
+      {
         "PGN":129546,
         "Id":"gnssRaimSettings",
         "Description":"GNSS RAIM Settings",
@@ -12025,7 +12025,7 @@
             "BitOffset":24,
             "BitStart":0,
             "Signed":false}]},
-      "129547":{
+      {
         "PGN":129547,
         "Id":"gnssPseudorangeErrorStatistics",
         "Description":"GNSS Pseudorange Error Statistics",
@@ -12097,7 +12097,7 @@
             "BitOffset":64,
             "BitStart":0,
             "Signed":false}]},
-      "129549":{
+      {
         "PGN":129549,
         "Id":"dgnssCorrections",
         "Description":"DGNSS Corrections",
@@ -12194,7 +12194,7 @@
             "BitOffset":96,
             "BitStart":0,
             "Signed":false}]},
-      "129550":{
+      {
         "PGN":129550,
         "Id":"gnssDifferentialCorrectionReceiverInterface",
         "Description":"GNSS Differential Correction Receiver Interface",
@@ -12250,7 +12250,7 @@
             "BitOffset":40,
             "BitStart":0,
             "Signed":false}]},
-      "129551":{
+      {
         "PGN":129551,
         "Id":"gnssDifferentialCorrectionReceiverSignal",
         "Description":"GNSS Differential Correction Receiver Signal",
@@ -12372,7 +12372,7 @@
             "BitOffset":104,
             "BitStart":0,
             "Signed":false}]},
-      "129556":{
+      {
         "PGN":129556,
         "Id":"glonassAlmanacData",
         "Description":"GLONASS Almanac Data",
@@ -12484,7 +12484,7 @@
             "BitOffset":96,
             "BitStart":0,
             "Signed":false}]},
-      "129792":{
+      {
         "PGN":129792,
         "Id":"aisDgnssBroadcastBinaryMessage",
         "Description":"AIS DGNSS Broadcast Binary Message",
@@ -12591,7 +12591,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "129793":{
+      {
         "PGN":129793,
         "Id":"aisUtcAndDateReport",
         "Description":"AIS UTC and Date Report",
@@ -12776,7 +12776,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "129794":{
+      {
         "PGN":129794,
         "Id":"aisClassAStaticAndVoyageRelatedData",
         "Description":"AIS Class A Static and Voyage Related Data",
@@ -13054,7 +13054,7 @@
               {"name":"Channel B VDL transmission","value":"3"},
               {"name":"Own information not broadcast","value":"4"},
               {"name":"Reserved","value":"5"}]}]},
-      "129795":{
+      {
         "PGN":129795,
         "Id":"aisAddressedBinaryMessage",
         "Description":"AIS Addressed Binary Message",
@@ -13187,7 +13187,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "129796":{
+      {
         "PGN":129796,
         "Id":"aisAcknowledge",
         "Description":"AIS Acknowledge",
@@ -13300,7 +13300,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "129797":{
+      {
         "PGN":129797,
         "Id":"aisBinaryBroadcastMessage",
         "Description":"AIS Binary Broadcast Message",
@@ -13391,7 +13391,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "129798":{
+      {
         "PGN":129798,
         "Id":"aisSarAircraftPositionReport",
         "Description":"AIS SAR Aircraft Position Report",
@@ -13580,7 +13580,7 @@
             "BitStart":1,
             "Type":"Binary data",
             "Signed":false}]},
-      "129799":{
+      {
         "PGN":129799,
         "Id":"radioFrequencyModePower",
         "Description":"Radio Frequency/Mode/Power",
@@ -13640,7 +13640,7 @@
             "BitOffset":88,
             "BitStart":0,
             "Signed":false}]},
-      "129800":{
+      {
         "PGN":129800,
         "Id":"aisUtcDateInquiry",
         "Description":"AIS UTC/Date Inquiry",
@@ -13732,7 +13732,7 @@
             "BitStart":6,
             "Type":"Binary data",
             "Signed":false}]},
-      "129801":{
+      {
         "PGN":129801,
         "Id":"aisAddressedSafetyRelatedMessage",
         "Description":"AIS Addressed Safety Related Message",
@@ -13851,7 +13851,7 @@
             "BitStart":0,
             "Type":"ASCII text",
             "Signed":false}]},
-      "129802":{
+      {
         "PGN":129802,
         "Id":"aisSafetyRelatedBroadcastMessage",
         "Description":"AIS Safety Related Broadcast Message",
@@ -13936,7 +13936,7 @@
             "BitStart":0,
             "Type":"ASCII text",
             "Signed":false}]},
-      "129803":{
+      {
         "PGN":129803,
         "Id":"aisInterrogation",
         "Description":"AIS Interrogation",
@@ -14092,7 +14092,7 @@
             "BitStart":6,
             "Type":"Binary data",
             "Signed":false}]},
-      "129804":{
+      {
         "PGN":129804,
         "Id":"aisAssignmentModeCommand",
         "Description":"AIS Assignment Mode Command",
@@ -14200,7 +14200,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "129805":{
+      {
         "PGN":129805,
         "Id":"aisDataLinkManagementMessage",
         "Description":"AIS Data Link Management Message",
@@ -14316,7 +14316,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "129806":{
+      {
         "PGN":129806,
         "Id":"aisChannelManagement",
         "Description":"AIS Channel Management",
@@ -14537,7 +14537,7 @@
             "BitOffset":232,
             "BitStart":0,
             "Signed":false}]},
-      "129807":{
+      {
         "PGN":129807,
         "Id":"aisClassBGroupAssignment",
         "Description":"AIS Class B Group Assignment",
@@ -14703,7 +14703,7 @@
             "BitOffset":210,
             "BitStart":2,
             "Signed":false}]},
-      "129808":{
+      {
         "PGN":129808,
         "Id":"dscDistressCallInformation",
         "Description":"DSC Distress Call Information",
@@ -14960,7 +14960,7 @@
             "BitStart":0,
             "Type":"ASCII or UNICODE string starting with length and control byte",
             "Signed":false}]},
-      "129808":{
+      {
         "PGN":129808,
         "Id":"dscCallInformation",
         "Description":"DSC Call Information",
@@ -15222,7 +15222,7 @@
             "BitStart":0,
             "Type":"ASCII or UNICODE string starting with length and control byte",
             "Signed":false}]},
-      "129809":{
+      {
         "PGN":129809,
         "Id":"aisClassBStaticDataMsg24PartA",
         "Description":"AIS Class B static data (msg 24 Part A)",
@@ -15272,7 +15272,7 @@
             "BitStart":0,
             "Type":"ASCII text",
             "Signed":false}]},
-      "129810":{
+      {
         "PGN":129810,
         "Id":"aisClassBStaticDataMsg24PartB",
         "Description":"AIS Class B static data (msg 24 Part B)",
@@ -15460,21 +15460,21 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "130060":{
+      {
         "PGN":130060,
         "Id":"label",
         "Description":"Label",
         "Complete":false,
         "Length":0,
         "RepeatingFields":0},
-      "130061":{
+      {
         "PGN":130061,
         "Id":"channelSourceConfiguration",
         "Description":"Channel Source Configuration",
         "Complete":false,
         "Length":0,
         "RepeatingFields":0},
-      "130064":{
+      {
         "PGN":130064,
         "Id":"routeAndWpServiceDatabaseList",
         "Description":"Route and WP Service - Database List",
@@ -15589,7 +15589,7 @@
             "BitOffset":184,
             "BitStart":0,
             "Signed":false}]},
-      "130065":{
+      {
         "PGN":130065,
         "Id":"routeAndWpServiceRouteList",
         "Description":"Route and WP Service - Route List",
@@ -15672,7 +15672,7 @@
             "BitOffset":110,
             "BitStart":6,
             "Signed":false}]},
-      "130066":{
+      {
         "PGN":130066,
         "Id":"routeAndWpServiceRouteWpListAttributes",
         "Description":"Route and WP Service - Route/WP-List Attributes",
@@ -15785,7 +15785,7 @@
             "BitOffset":166,
             "BitStart":6,
             "Signed":false}]},
-      "130067":{
+      {
         "PGN":130067,
         "Id":"routeAndWpServiceRouteWpNamePosition",
         "Description":"Route and WP Service - Route - WP Name & Position",
@@ -15872,7 +15872,7 @@
             "Type":"Longitude",
             "Resolution":"0.0000001",
             "Signed":true}]},
-      "130068":{
+      {
         "PGN":130068,
         "Id":"routeAndWpServiceRouteWpName",
         "Description":"Route and WP Service - Route - WP Name",
@@ -15937,7 +15937,7 @@
             "BitStart":0,
             "Type":"ASCII text",
             "Signed":false}]},
-      "130069":{
+      {
         "PGN":130069,
         "Id":"routeAndWpServiceXteLimitNavigationMethod",
         "Description":"Route and WP Service - XTE Limit & Navigation Method",
@@ -16018,7 +16018,7 @@
             "BitStart":4,
             "Type":"Binary data",
             "Signed":false}]},
-      "130070":{
+      {
         "PGN":130070,
         "Id":"routeAndWpServiceWpComment",
         "Description":"Route and WP Service - WP Comment",
@@ -16083,7 +16083,7 @@
             "BitStart":0,
             "Type":"ASCII text",
             "Signed":false}]},
-      "130071":{
+      {
         "PGN":130071,
         "Id":"routeAndWpServiceRouteComment",
         "Description":"Route and WP Service - Route Comment",
@@ -16140,7 +16140,7 @@
             "BitStart":0,
             "Type":"ASCII text",
             "Signed":false}]},
-      "130072":{
+      {
         "PGN":130072,
         "Id":"routeAndWpServiceDatabaseComment",
         "Description":"Route and WP Service - Database Comment",
@@ -16189,7 +16189,7 @@
             "BitStart":0,
             "Type":"ASCII text",
             "Signed":false}]},
-      "130073":{
+      {
         "PGN":130073,
         "Id":"routeAndWpServiceRadiusOfTurn",
         "Description":"Route and WP Service - Radius of Turn",
@@ -16253,7 +16253,7 @@
             "BitOffset":56,
             "BitStart":0,
             "Signed":false}]},
-      "130074":{
+      {
         "PGN":130074,
         "Id":"routeAndWpServiceWpListWpNamePosition",
         "Description":"Route and WP Service - WP List - WP Name & Position",
@@ -16342,7 +16342,7 @@
             "Type":"Longitude",
             "Resolution":"0.0000001",
             "Signed":true}]},
-      "130306":{
+      {
         "PGN":130306,
         "Id":"windData",
         "Description":"Wind Data",
@@ -16393,7 +16393,7 @@
               {"name":"Apparent","value":"2"},
               {"name":"True (boat referenced)","value":"3"},
               {"name":"True (water referenced)","value":"4"}]}]},
-      "130310":{
+      {
         "PGN":130310,
         "Id":"environmentalParameters",
         "Description":"Environmental Parameters",
@@ -16441,7 +16441,7 @@
             "Units":"hPa",
             "Type":"Pressure",
             "Signed":false}]},
-      "130311":{
+      {
         "PGN":130311,
         "Id":"environmentalParameters",
         "Description":"Environmental Parameters",
@@ -16525,7 +16525,7 @@
             "Units":"hPa",
             "Type":"Pressure",
             "Signed":false}]},
-      "130312":{
+      {
         "PGN":130312,
         "Id":"temperature",
         "Description":"Temperature",
@@ -16596,7 +16596,7 @@
             "Type":"Temperature",
             "Resolution":"0.01",
             "Signed":false}]},
-      "130313":{
+      {
         "PGN":130313,
         "Id":"humidity",
         "Description":"Humidity",
@@ -16652,7 +16652,7 @@
             "Units":"%",
             "Resolution":"0.004",
             "Signed":true}]},
-      "130314":{
+      {
         "PGN":130314,
         "Id":"actualPressure",
         "Description":"Actual Pressure",
@@ -16702,7 +16702,7 @@
             "Type":"Pressure (hires)",
             "Resolution":"0.1",
             "Signed":false}]},
-      "130315":{
+      {
         "PGN":130315,
         "Id":"setPressure",
         "Description":"Set Pressure",
@@ -16752,7 +16752,7 @@
             "Type":"Pressure (hires)",
             "Resolution":"0.1",
             "Signed":false}]},
-      "130316":{
+      {
         "PGN":130316,
         "Id":"temperatureExtendedRange",
         "Description":"Temperature Extended Range",
@@ -16823,7 +16823,7 @@
             "Type":"Temperature",
             "Resolution":"0.1",
             "Signed":false}]},
-      "130320":{
+      {
         "PGN":130320,
         "Id":"tideStationData",
         "Description":"Tide Station Data",
@@ -16952,7 +16952,7 @@
             "BitStart":0,
             "Type":"String with start/stop byte",
             "Signed":false}]},
-      "130321":{
+      {
         "PGN":130321,
         "Id":"salinityStationData",
         "Description":"Salinity Station Data",
@@ -17070,7 +17070,7 @@
             "BitStart":0,
             "Type":"String with start/stop byte",
             "Signed":false}]},
-      "130322":{
+      {
         "PGN":130322,
         "Id":"currentStationData",
         "Description":"Current Station Data",
@@ -17201,7 +17201,7 @@
             "BitStart":0,
             "Type":"String with start/stop byte",
             "Signed":false}]},
-      "130323":{
+      {
         "PGN":130323,
         "Id":"meteorologicalStationData",
         "Description":"Meteorological Station Data",
@@ -17367,7 +17367,7 @@
             "BitStart":0,
             "Type":"String with start/stop byte",
             "Signed":false}]},
-      "130324":{
+      {
         "PGN":130324,
         "Id":"mooredBuoyStationData",
         "Description":"Moored Buoy Station Data",
@@ -17560,14 +17560,14 @@
             "BitStart":0,
             "Type":"ASCII text",
             "Signed":false}]},
-      "130560":{
+      {
         "PGN":130560,
         "Id":"payloadMass",
         "Description":"Payload Mass",
         "Complete":false,
         "Length":0,
         "RepeatingFields":0},
-      "130567":{
+      {
         "PGN":130567,
         "Id":"watermakerInputSettingAndStatus",
         "Description":"Watermaker Input Setting and Status",
@@ -17842,7 +17842,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "130570":{
+      {
         "PGN":130570,
         "Id":"libraryDataFile",
         "Description":"Library Data File",
@@ -18052,7 +18052,7 @@
             "BitStart":0,
             "Type":"ASCII or UNICODE string starting with length and control byte",
             "Signed":false}]},
-      "130571":{
+      {
         "PGN":130571,
         "Id":"libraryDataGroup",
         "Description":"Library Data Group",
@@ -18198,7 +18198,7 @@
             "BitStart":0,
             "Type":"ASCII or UNICODE string starting with length and control byte",
             "Signed":false}]},
-      "130572":{
+      {
         "PGN":130572,
         "Id":"libraryDataSearch",
         "Description":"Library Data Search",
@@ -18349,7 +18349,7 @@
             "BitStart":0,
             "Type":"ASCII or UNICODE string starting with length and control byte",
             "Signed":false}]},
-      "130573":{
+      {
         "PGN":130573,
         "Id":"supportedSourceData",
         "Description":"Supported Source Data",
@@ -18555,7 +18555,7 @@
             "EnumBitValues":[
               {"1": "Play Queue"},
               {"2": "All"}]}]},
-      "130574":{
+      {
         "PGN":130574,
         "Id":"supportedZoneData",
         "Description":"Supported Zone Data",
@@ -18620,7 +18620,7 @@
             "BitStart":0,
             "Type":"ASCII or UNICODE string starting with length and control byte",
             "Signed":false}]},
-      "130576":{
+      {
         "PGN":130576,
         "Id":"smallCraftStatus",
         "Description":"Small Craft Status",
@@ -18644,7 +18644,7 @@
             "BitOffset":8,
             "BitStart":0,
             "Signed":true}]},
-      "130577":{
+      {
         "PGN":130577,
         "Id":"directionData",
         "Description":"Direction Data",
@@ -18757,7 +18757,7 @@
             "Units":"m/s",
             "Resolution":"0.01",
             "Signed":false}]},
-      "130578":{
+      {
         "PGN":130578,
         "Id":"vesselSpeedComponents",
         "Description":"Vessel Speed Components",
@@ -18825,7 +18825,7 @@
             "Units":"m/s",
             "Resolution":"0.001",
             "Signed":true}]},
-      "130579":{
+      {
         "PGN":130579,
         "Id":"systemConfiguration",
         "Description":"System Configuration",
@@ -18908,7 +18908,7 @@
             "BitStart":4,
             "Type":"Binary data",
             "Signed":false}]},
-      "130580":{
+      {
         "PGN":130580,
         "Id":"systemConfigurationDeprecated",
         "Description":"System Configuration (deprecated)",
@@ -18969,7 +18969,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "130581":{
+      {
         "PGN":130581,
         "Id":"zoneConfigurationDeprecated",
         "Description":"Zone Configuration (deprecated)",
@@ -19034,7 +19034,7 @@
             "BitStart":0,
             "Type":"ASCII or UNICODE string starting with length and control byte",
             "Signed":false}]},
-      "130582":{
+      {
         "PGN":130582,
         "Id":"zoneVolume",
         "Description":"Zone Volume",
@@ -19126,7 +19126,7 @@
               {"name":"Back right","value":"10"},
               {"name":"Surround left","value":"11"},
               {"name":"Surround right","value":"12"}]}]},
-      "130583":{
+      {
         "PGN":130583,
         "Id":"availableAudioEqPresets",
         "Description":"Available Audio EQ presets",
@@ -19195,7 +19195,7 @@
             "BitStart":0,
             "Type":"ASCII or UNICODE string starting with length and control byte",
             "Signed":false}]},
-      "130584":{
+      {
         "PGN":130584,
         "Id":"availableBluetoothAddresses",
         "Description":"Available Bluetooth addresses",
@@ -19276,7 +19276,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "130585":{
+      {
         "PGN":130585,
         "Id":"bluetoothSourceStatus",
         "Description":"Bluetooth source status",
@@ -19342,7 +19342,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "130586":{
+      {
         "PGN":130586,
         "Id":"zoneConfiguration",
         "Description":"Zone Configuration",
@@ -19523,7 +19523,7 @@
               {"name":"Back right","value":"10"},
               {"name":"Surround left","value":"11"},
               {"name":"Surround right","value":"12"}]}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubInit2",
         "Description":"SonicHub: Init #2",
@@ -19614,7 +19614,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubAmRadio",
         "Description":"SonicHub: AM Radio",
@@ -19742,7 +19742,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubZoneInfo",
         "Description":"SonicHub: Zone info",
@@ -19823,7 +19823,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubSource",
         "Description":"SonicHub: Source",
@@ -19911,7 +19911,7 @@
               {"name":"AUX","value":"4"},
               {"name":"AUX 2","value":"5"},
               {"name":"Mic","value":"6"}]}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubSourceList",
         "Description":"SonicHub: Source List",
@@ -20011,7 +20011,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubControl",
         "Description":"SonicHub: Control",
@@ -20094,7 +20094,7 @@
             "EnumValues":[
               {"name":"Mute on","value":"1"},
               {"name":"Mute off","value":"2"}]}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubUnknown",
         "Description":"SonicHub: Unknown",
@@ -20185,7 +20185,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubFmRadio",
         "Description":"SonicHub: FM Radio",
@@ -20313,7 +20313,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubPlaylist",
         "Description":"SonicHub: Playlist",
@@ -20447,7 +20447,7 @@
             "Units":"s",
             "Resolution":"0.001",
             "Signed":false}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubTrack",
         "Description":"SonicHub: Track",
@@ -20537,7 +20537,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubArtist",
         "Description":"SonicHub: Artist",
@@ -20627,7 +20627,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubAlbum",
         "Description":"SonicHub: Album",
@@ -20717,7 +20717,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubMenuItem",
         "Description":"SonicHub: Menu Item",
@@ -20831,7 +20831,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubZones",
         "Description":"SonicHub: Zones",
@@ -20912,7 +20912,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubMaxVolume",
         "Description":"SonicHub: Max Volume",
@@ -21006,7 +21006,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubVolume",
         "Description":"SonicHub: Volume",
@@ -21100,7 +21100,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubInit1",
         "Description":"SonicHub: Init #1",
@@ -21171,7 +21171,7 @@
             "EnumValues":[
               {"name":"Set","value":"0"},
               {"name":"Ack","value":"128"}]}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubPosition",
         "Description":"SonicHub: Position",
@@ -21252,7 +21252,7 @@
             "Units":"s",
             "Resolution":"0.001",
             "Signed":false}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"sonichubInit3",
         "Description":"SonicHub: Init #3",
@@ -21343,7 +21343,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"simradTextMessage",
         "Description":"Simrad: Text Message",
@@ -21451,7 +21451,7 @@
             "BitStart":0,
             "Type":"ASCII text",
             "Signed":false}]},
-      "130816":{
+      {
         "PGN":130816,
         "Id":"manufacturerProprietaryFastPacketNonAddressed",
         "Description":"Manufacturer Proprietary fast-packet non-addressed",
@@ -21502,7 +21502,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "130817":{
+      {
         "PGN":130817,
         "Id":"navicoProductInformation",
         "Description":"Navico: Product Information",
@@ -21611,7 +21611,7 @@
             "BitStart":0,
             "Type":"ASCII text",
             "Signed":false}]},
-      "130818":{
+      {
         "PGN":130818,
         "Id":"simnetReprogramData",
         "Description":"Simnet: Reprogram Data",
@@ -21679,7 +21679,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "130819":{
+      {
         "PGN":130819,
         "Id":"simnetRequestReprogram",
         "Description":"Simnet: Request Reprogram",
@@ -21718,7 +21718,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"simnetReprogramStatus",
         "Description":"Simnet: Reprogram Status",
@@ -21783,7 +21783,7 @@
             "BitStart":0,
             "Type":"Binary data",
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"furunoUnknown",
         "Description":"Furuno: Unknown",
@@ -21862,7 +21862,7 @@
             "BitOffset":48,
             "BitStart":0,
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionSourceName",
         "Description":"Fusion: Source Name",
@@ -21960,7 +21960,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionTrackInfo",
         "Description":"Fusion: Track Info",
@@ -22103,7 +22103,7 @@
             "BitOffset":168,
             "BitStart":0,
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionTrack",
         "Description":"Fusion: Track",
@@ -22177,7 +22177,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionArtist",
         "Description":"Fusion: Artist",
@@ -22251,7 +22251,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionAlbum",
         "Description":"Fusion: Album",
@@ -22325,7 +22325,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionUnitName",
         "Description":"Fusion: Unit Name",
@@ -22391,7 +22391,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionZoneName",
         "Description":"Fusion: Zone Name",
@@ -22465,7 +22465,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionPlayProgress",
         "Description":"Fusion: Play Progress",
@@ -22540,7 +22540,7 @@
             "Units":"s",
             "Resolution":"0.001",
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionAmFmStation",
         "Description":"Fusion: AM/FM Station",
@@ -22644,7 +22644,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionVhf",
         "Description":"Fusion: VHF",
@@ -22725,7 +22725,7 @@
             "BitOffset":48,
             "BitStart":0,
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionSquelch",
         "Description":"Fusion: Squelch",
@@ -22798,7 +22798,7 @@
             "BitOffset":40,
             "BitStart":0,
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionScan",
         "Description":"Fusion: Scan",
@@ -22875,7 +22875,7 @@
             "EnumValues":[
               {"name":"Off","value":"0"},
               {"name":"Scan","value":"1"}]}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionMenuItem",
         "Description":"Fusion: Menu Item",
@@ -22997,7 +22997,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionReplay",
         "Description":"Fusion: Replay",
@@ -23129,7 +23129,7 @@
             "BitOffset":104,
             "BitStart":0,
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionMute",
         "Description":"Fusion: Mute",
@@ -23198,7 +23198,7 @@
             "EnumValues":[
               {"name":"Muted","value":"1"},
               {"name":"Not Muted","value":"2"}]}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionSubVolume",
         "Description":"Fusion: Sub Volume",
@@ -23291,7 +23291,7 @@
             "BitStart":0,
             "Units":"vol",
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionTone",
         "Description":"Fusion: Tone",
@@ -23383,7 +23383,7 @@
             "BitStart":0,
             "Units":"vol",
             "Signed":true}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionVolume",
         "Description":"Fusion: Volume",
@@ -23476,7 +23476,7 @@
             "BitStart":0,
             "Units":"vol",
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionTransport",
         "Description":"Fusion: Transport",
@@ -23545,7 +23545,7 @@
             "EnumValues":[
               {"name":"Paused","value":"1"},
               {"name":"Play","value":"2"}]}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionSiriusxmChannel",
         "Description":"Fusion: SiriusXM Channel",
@@ -23611,7 +23611,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionSiriusxmTitle",
         "Description":"Fusion: SiriusXM Title",
@@ -23677,7 +23677,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionSiriusxmArtist",
         "Description":"Fusion: SiriusXM Artist",
@@ -23743,7 +23743,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130820":{
+      {
         "PGN":130820,
         "Id":"fusionSiriusxmGenre",
         "Description":"Fusion: SiriusXM Genre",
@@ -23809,7 +23809,7 @@
             "BitStart":0,
             "Type":"ASCII string starting with length byte",
             "Signed":false}]},
-      "130821":{
+      {
         "PGN":130821,
         "Id":"furunoUnknown",
         "Description":"Furuno: Unknown",
@@ -23928,7 +23928,7 @@
             "BitOffset":88,
             "BitStart":0,
             "Signed":false}]},
-      "130824":{
+      {
         "PGN":130824,
         "Id":"bGWindData",
         "Description":"B&G: Wind data",
@@ -23992,7 +23992,7 @@
             "BitOffset":32,
             "BitStart":0,
             "Signed":false}]},
-      "130824":{
+      {
         "PGN":130824,
         "Id":"maretronAnnunciator",
         "Description":"Maretron: Annunciator",
@@ -24071,7 +24071,7 @@
             "BitOffset":56,
             "BitStart":0,
             "Signed":false}]},
-      "130827":{
+      {
         "PGN":130827,
         "Id":"lowranceUnknown",
         "Description":"Lowrance: unknown",
@@ -24158,7 +24158,7 @@
             "BitOffset":64,
             "BitStart":0,
             "Signed":false}]},
-      "130828":{
+      {
         "PGN":130828,
         "Id":"simnetSetSerialNumber",
         "Description":"Simnet: Set Serial Number",
@@ -24197,7 +24197,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "130831":{
+      {
         "PGN":130831,
         "Id":"suzukiEngineAndStorageDeviceConfig",
         "Description":"Suzuki: Engine and Storage Device Config",
@@ -24234,7 +24234,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "130832":{
+      {
         "PGN":130832,
         "Id":"simnetFuelUsedHighResolution",
         "Description":"Simnet: Fuel Used - High Resolution",
@@ -24273,7 +24273,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "130834":{
+      {
         "PGN":130834,
         "Id":"simnetEngineAndTankConfiguration",
         "Description":"Simnet: Engine and Tank Configuration",
@@ -24312,7 +24312,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "130835":{
+      {
         "PGN":130835,
         "Id":"simnetSetEngineAndTankConfiguration",
         "Description":"Simnet: Set Engine and Tank Configuration",
@@ -24351,7 +24351,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "130836":{
+      {
         "PGN":130836,
         "Id":"simnetFluidLevelSensorConfiguration",
         "Description":"Simnet: Fluid Level Sensor Configuration",
@@ -24473,7 +24473,7 @@
             "BitOffset":104,
             "BitStart":0,
             "Signed":true}]},
-      "130837":{
+      {
         "PGN":130837,
         "Id":"simnetFuelFlowTurbineConfiguration",
         "Description":"Simnet: Fuel Flow Turbine Configuration",
@@ -24512,7 +24512,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "130838":{
+      {
         "PGN":130838,
         "Id":"simnetFluidLevelWarning",
         "Description":"Simnet: Fluid Level Warning",
@@ -24551,7 +24551,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "130839":{
+      {
         "PGN":130839,
         "Id":"simnetPressureSensorConfiguration",
         "Description":"Simnet: Pressure Sensor Configuration",
@@ -24590,7 +24590,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "130840":{
+      {
         "PGN":130840,
         "Id":"simnetDataUserGroupConfiguration",
         "Description":"Simnet: Data User Group Configuration",
@@ -24629,7 +24629,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "130842":{
+      {
         "PGN":130842,
         "Id":"simnetAisClassBStaticDataMsg24PartA",
         "Description":"Simnet: AIS Class B static data (msg 24 Part A)",
@@ -24728,7 +24728,7 @@
             "BitStart":0,
             "Type":"ASCII text",
             "Signed":false}]},
-      "130842":{
+      {
         "PGN":130842,
         "Id":"simnetAisClassBStaticDataMsg24PartB",
         "Description":"Simnet: AIS Class B static data (msg 24 Part B)",
@@ -24963,7 +24963,7 @@
             "Type":"Integer",
             "Resolution":1,
             "Signed":false}]},
-      "130843":{
+      {
         "PGN":130843,
         "Id":"simnetSonarStatusFrequencyAndDspVoltage",
         "Description":"Simnet: Sonar Status, Frequency and DSP Voltage",
@@ -25002,7 +25002,7 @@
             "Match":4,
             "Type":"Lookup table",
             "Signed":false}]},
-      "130845":{
+      {
         "PGN":130845,
         "Id":"simnetCompassHeadingOffset",
         "Description":"Simnet: Compass Heading Offset",
@@ -25109,7 +25109,7 @@
             "BitStart":0,
             "Resolution":0,
             "Signed":false}]},
-      "130845":{
+      {
         "PGN":130845,
         "Id":"simnetCompassLocalField",
         "Description":"Simnet: Compass Local Field",
@@ -25216,7 +25216,7 @@
             "BitStart":0,
             "Resolution":0,
             "Signed":false}]},
-      "130845":{
+      {
         "PGN":130845,
         "Id":"simnetCompassFieldAngle",
         "Description":"Simnet: Compass Field Angle",
@@ -25322,7 +25322,7 @@
             "BitStart":0,
             "Resolution":0,
             "Signed":false}]},
-      "130845":{
+      {
         "PGN":130845,
         "Id":"simnetParameterHandle",
         "Description":"Simnet: Parameter Handle",
@@ -25468,7 +25468,7 @@
             "BitOffset":88,
             "BitStart":0,
             "Signed":false}]},
-      "130847":{
+      {
         "PGN":130847,
         "Id":"seatalkNodeStatistics",
         "Description":"SeaTalk: Node Statistics",
@@ -25545,7 +25545,7 @@
             "Units":"V",
             "Resolution":"0.01",
             "Signed":false}]},
-      "130850":{
+      {
         "PGN":130850,
         "Id":"simnetEventCommandApCommand",
         "Description":"Simnet: Event Command: AP command",
@@ -25659,7 +25659,7 @@
             "BitOffset":88,
             "BitStart":0,
             "Signed":false}]},
-      "130850":{
+      {
         "PGN":130850,
         "Id":"simnetEventCommandAlarm",
         "Description":"Simnet: Event Command: Alarm?",
@@ -25763,7 +25763,7 @@
             "BitOffset":88,
             "BitStart":0,
             "Signed":false}]},
-      "130850":{
+      {
         "PGN":130850,
         "Id":"simnetEventCommandUnknown",
         "Description":"Simnet: Event Command: Unknown",
@@ -25853,7 +25853,7 @@
             "BitOffset":80,
             "BitStart":0,
             "Signed":false}]},
-      "130851":{
+      {
         "PGN":130851,
         "Id":"simnetEventReplyApCommand",
         "Description":"Simnet: Event Reply: AP command",
@@ -25967,7 +25967,7 @@
             "BitOffset":88,
             "BitStart":0,
             "Signed":false}]},
-      "130856":{
+      {
         "PGN":130856,
         "Id":"simnetAlarmMessage",
         "Description":"Simnet: Alarm Message",
@@ -26039,7 +26039,7 @@
             "BitStart":0,
             "Type":"ASCII text",
             "Signed":false}]},
-      "130880":{
+      {
         "PGN":130880,
         "Id":"airmarAdditionalWeatherData",
         "Description":"Airmar: Additional Weather Data",
@@ -26119,7 +26119,7 @@
             "Type":"Temperature",
             "Resolution":"0.01",
             "Signed":false}]},
-      "130881":{
+      {
         "PGN":130881,
         "Id":"airmarHeaterControl",
         "Description":"Airmar: Heater Control",
@@ -26199,7 +26199,7 @@
             "Type":"Temperature",
             "Resolution":"0.01",
             "Signed":false}]},
-      "130944":{
+      {
         "PGN":130944,
         "Id":"airmarPost",
         "Description":"Airmar: POST",
@@ -26300,6 +26300,6 @@
             "Signed":false,
             "EnumValues":[
               {"name":"Pass","value":"0"}]}]}
-    }
+    ]
     }
     

--- a/analyzer/pgns2json.xslt
+++ b/analyzer/pgns2json.xslt
@@ -359,13 +359,13 @@
   </xsl:template>
 
     <xsl:template match="PGNInfo">
-    <xsl:call-template name="indent"/>"<xsl:value-of select="./PGN"/>":<xsl:apply-templates/><xsl:if test="not(position() = last())">,</xsl:if>
+    <xsl:call-template name="indent"/><xsl:apply-templates/><xsl:if test="not(position() = last())">,</xsl:if>
     </xsl:template>
 
     <xsl:template match="PGNs">
-    "PGNs":{
+    "PGNs": [
     <xsl:apply-templates/>
-    }
+    ]
     }
     </xsl:template>
     


### PR DESCRIPTION
There are several PGNs that are in pgns.xml several
times as PGNInfos. The old pgns.json had the PGNInfos
converted to properties of a holder object, keyed by
the pgn number. This was valid JSON, but later properties
overwrote earlier ones and they were not available.

This commit changes the PGNInfo holder to be an array,
that allows access to the duplicates. **Code that uses
pgns.json must be adjusted to account for this change**.