### PR TITLE
fix n2kd_monitor forking bug

### DIFF
--- a/n2kd/n2kd_monitor
+++ b/n2kd/n2kd_monitor
@@ -72,11 +72,16 @@ my $monitor;
 my $child;
 my $stop = 0;
 my $last_monitor = 0;
+my $do_monitor;
 
 if ($MONITOR ne "true" && $MONITOR ne "yes")
 {
   # Disable the monitoring part. This is not open source yet, so disable it by default.
-  $last_monitor = LONG_MAX;
+  $do_monitor = 0;
+}
+else
+{
+  $do_monitor = 1;
 }
 
 use POSIX();
@@ -225,7 +230,7 @@ for (;;)
       }
       sleep(15);
     }
-    if (!$monitor && (time > $last_monitor + 30))
+    if ($do_monitor && !$monitor && (time > $last_monitor + 30))
     {
       $last_monitor = time;
       if (($monitor = fork()) == 0)


### PR DESCRIPTION
Looks like your test `(time > $last_monitor + 30)` isn't doing what you expect
it to:

```
svzeno@navigation:~$ perl -e 'printf("%d > %d\n", time, LONG_MAX+30);'
1549263734 > 30
```

So rather than doing some clever thing like setting the timestamp to the max
value, I just added a different variable to store the boolean for do or don't
do. In the event that you did successfully set the `last_monitor` variable to
maxint, what would maxint+30 evaluate to in perl?

fixes canboat/canboat#93