### PR TITLE
fix make file for ubuntu/debian packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@
 
 # s. https://www.gnu.org/prep/standards/html_node/Directory-Variables.html#Directory-Variables
 DESTDIR ?= ""
-PREFIX ?= /usr/local
+PREFIX ?= /usr
 EXEC_PREFIX ?= $(PREFIX)
 BINDIR=$(EXEC_PREFIX)/bin
-SYSCONFDIR=$(PREFIX)/etc
+SYSCONFDIR= /etc
 
 PLATFORM=$(shell uname | tr '[A-Z]' '[a-z]')-$(shell uname -m)
 OS=$(shell uname -o 2>&1)


### PR DESCRIPTION
I want to create and maintain a debian/ubuntu repository for some packages used in OpenPlotter:

https://launchpad.net/~sailoog/+archive/ubuntu/openplotter

Canboat is there but I have found some problems that make impossible creating a debia/ubuntu package to distribute it. This PR fix the problem.

- canboat install programs in usr/local/bin and this is forbidden in debian packaging. You can force it and create a deb but you can not force this to create a source for distribution. This fix uses /usr/bin
- canboat creates files in /usr/local/etc/default and that folder does not exist there. This fix uses /etc/default

Feel free to add this repo to your installation manual as an extra option if you want. Tested in Ubuntu 16.04 and Raspbian.

