### PR TITLE
actisense-serial: Escape length when sending sentences to Actisense device

### DIFF
--- a/actisense-serial/actisense-serial.c
+++ b/actisense-serial/actisense-serial.c
@@ -393,7 +393,6 @@ static void writeMessage(int handle, unsigned char command, const unsigned char 
   unsigned char  bst[255];
   unsigned char *b = bst;
   unsigned char *r = bst;
-  unsigned char *lenPtr;
   unsigned char  crc;
 
   int i;
@@ -402,7 +401,11 @@ static void writeMessage(int handle, unsigned char command, const unsigned char 
   *b++   = STX;
   *b++   = command;
   crc    = command;
-  lenPtr = b++;
+  *b++   = len;
+  if (len == DLE)
+  {
+    *b++ = DLE;
+  }
 
   for (i = 0; i < len; i++)
   {
@@ -414,7 +417,6 @@ static void writeMessage(int handle, unsigned char command, const unsigned char 
     crc += (unsigned char) cmd[i];
   }
 
-  *lenPtr = i;
   crc += i;
 
   crc = 256 - (int)crc;


### PR DESCRIPTION
If the length of a sentence is 10 bytes, then the Actisense was not sending the sentence over the CAN bus. This is caused by the length parameter not being escaped, causing the Actisense device to fail to
parse the command to send this sentence.
