### PR TITLE
Avoid multiple definitions of StringBuffer sbNew

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -107,7 +107,7 @@ enum Base64Encoding
   BASE64_AIS
 };
 
-StringBuffer sbNew;
+extern StringBuffer sbNew;
 
 void  sbAppendEncodeHex(StringBuffer *sb, const void *data, size_t len, char separator);                     // binary to hex
 void  sbAppendEncodeBase64(StringBuffer *sb, const uint8_t *data, size_t len, enum Base64Encoding encoding); // binary to Base64

--- a/n2kd/main.c
+++ b/n2kd/main.c
@@ -49,6 +49,7 @@ bool     rateLimit;
 
 uint32_t protocol = 1;
 int      debug    = 0;
+StringBuffer sbNew;
 
 #define SENSOR_TIMEOUT (120)       /* Timeout when PGN messages expire (no longer retransmitted) */
 #define AIS_TIMEOUT (3600)         /* AIS messages expiration is much longer */


### PR DESCRIPTION
This helps build with gcc10+

multiple definition of `sbNew'; /tmp/cc7KbBAf.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:28: ../rel/linux-x86_64/actisense-serial] Error 1

Signed-off-by: Khem Raj <raj.khem@gmail.com>