### PR TITLE
fix: 130314 actual pressure is a signed value

### DIFF
--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -4748,7 +4748,7 @@ Pgn pgnList[] = {
      {{"SID", BYTES(1), 1, false, 0, ""},
       {"Instance", BYTES(1), 1, false, 0, ""},
       {"Source", BYTES(1), RES_LOOKUP, false, LOOKUP_PRESSURE_SOURCE, ""},
-      {"Pressure", BYTES(4), RES_PRESSURE_HIRES, false, "dPa", ""},
+      {"Pressure", BYTES(4), RES_PRESSURE_HIRES, true, "dPa", ""},
       {0}}}
 
     ,


### PR DESCRIPTION
130314 actual pressure allows for the measurement of vacuum. This change
allows for the negative values to be correctly decoded.

I will post some raw data from a Maretron FPM100.