### PR TITLE
Refactor definitions fixes

### DIFF
--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -2710,7 +2710,7 @@ Pgn pgnList[] = {
        false,
        "s",
        "If timeout elapses the thruster stops operating and reverts to static mode"},
-      LOOKUP_FIELD("Windlass Control Events", 4, WINDLASS_CONTROL),
+      LOOKUP_BITFIELD("Windlass Control Events", 4, WINDLASS_CONTROL),
       RESERVED_FIELD(4),
       {0}}}
 

--- a/analyzer/pgns-ik.json
+++ b/analyzer/pgns-ik.json
@@ -76,5 +76,5 @@
             "Resolution":1,
             "Signed":false}]}
     ]
-    }
+}
     

--- a/analyzer/pgns-ngt.json
+++ b/analyzer/pgns-ngt.json
@@ -405,5 +405,5 @@
             "Resolution":1,
             "Signed":false}]}
     ]
-    }
+}
     

--- a/analyzer/pgns.json
+++ b/analyzer/pgns.json
@@ -12599,9 +12599,10 @@
             "BitLength":4,
             "BitOffset":48,
             "BitStart":0,
-            "Type":"Lookup table",
+            "Type":"Bitfield",
             "Signed":false,
-            "Enumeration":"WINDLASS_CONTROL"},
+            "Enumeration":"WINDLASS_CONTROL"
+    },
           {
             "Order":14,
             "Id":"reserved",

--- a/analyzer/pgns.json
+++ b/analyzer/pgns.json
@@ -1494,7 +1494,7 @@
         {"1": "Controller over current cut-out"},
         {"2": "Controller over temperature cut-out"},
         {"3": "Manufacturer defined"}
-      ]}}]
+      ]}],
     "PGNs": [
     
       {
@@ -30309,5 +30309,5 @@
             "Resolution":1,
             "Signed":false}]}
     ]
-    }
+}
     

--- a/analyzer/pgns.xml
+++ b/analyzer/pgns.xml
@@ -15051,18 +15051,11 @@ limitations under the License.
           <BitLength>4</BitLength>
           <BitOffset>48</BitOffset>
           <BitStart>0</BitStart>
-          <Type>Lookup table</Type>
+          <Type>Bitfield</Type>
           <Signed>false</Signed>
-          <EnumValues Name='WINDLASS_CONTROL'>
-            <EnumPair Value='0' Name='Another device controlling windlass' />
-            <EnumPair Value='4' Name='Off' />
-            <EnumPair Value='5' Name='Down' />
-            <EnumPair Value='6' Name='Up' />
-            <EnumPair Value='8' Name='Controller under voltage cut-out' />
-            <EnumPair Value='9' Name='Controller over current cut-out' />
-            <EnumPair Value='10' Name='Controller over temperature cut-out' />
-            <EnumPair Value='11' Name='Manufacturer defined' />
-          </EnumValues>
+          <EnumBitValues Name='WINDLASS_CONTROL'>
+            <EnumPair Bit='0' Name='Another device controlling windlass' />
+          </EnumBitValues>
         </Field>
         <Field>
           <Order>14</Order>

--- a/analyzer/pgns2json.xslt
+++ b/analyzer/pgns2json.xslt
@@ -342,20 +342,20 @@
   </xsl:template>
 
   <xsl:template match="Enumerations">
-    <xsl:call-template name="indent"/>"Enumerations":[<xsl:apply-templates/>]<xsl:if
+    <xsl:call-template name="indent"/>"Enumerations":[<xsl:apply-templates/>],<xsl:if
     test="not(following-sibling::*)">}</xsl:if>
   </xsl:template>
 
   <xsl:template match="Enumeration">
     <xsl:call-template name="indent"/>{"type":"lookup","name":"<xsl:value-of select="@Name"/>","maxValue":"<xsl:value-of select="@MaxValue"/>","values":[<xsl:apply-templates/>
       ]}<xsl:if test="not(position() = last())">,</xsl:if>
-    <xsl:if test="not(following-sibling::*)">}</xsl:if>
+    <xsl:if test="not(following-sibling::*)"></xsl:if>
   </xsl:template>
 
   <xsl:template match="BitEnumeration">
     <xsl:call-template name="indent"/>{"type":"bitfield","name":"<xsl:value-of select="@Name"/>","maxValue":"<xsl:value-of select="@MaxValue"/>","values":[<xsl:apply-templates/>
       ]}<xsl:if test="not(position() = last())">,</xsl:if>
-    <xsl:if test="not(following-sibling::*)">}</xsl:if>
+    <xsl:if test="not(following-sibling::*)"></xsl:if>
   </xsl:template>
 
   <xsl:template match="Enumeration/EnumPair">
@@ -395,7 +395,7 @@
     "PGNs": [
     <xsl:apply-templates/>
     ]
-    }
+}
     </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
# Introducing myself
Hi, I'm Lukas, a Student at the University of Oldenburg, Germany.
I'm working on a project where we need to read and write NMEA 2000 messages. For that we want to use CANboat's definitions to generate Java code. Reading #265 and #266 I decided to go with the version from the refactor-definitions branch, as it seems great for code generation.

# What this PR does
- The generated json files contained a syntax error. That error is fixed. It's my first time seeing xslt, so the solution my not be ideal.
-  PGN 128776 Field 13 was incorrectly declared as a Lookup Table. In master it is a Bitfield. I reverted it to how it is in master.

My Team and I consider making more contributions to CANboat.