### PR TITLE
Fix build error

### DIFF
--- a/analyzer/fixup-version.sh
+++ b/analyzer/fixup-version.sh
@@ -7,6 +7,6 @@ FILE="${2}"
 
 NEW_VERSION="$("${ANALYZER}" -version)"
 
-sed -i .bak 's/"version": "[0-9\.]*"/"version": "'"${NEW_VERSION}"'"/' "${FILE}" && rm "${FILE}.bak"
+sed -i.bak 's/"version": "[0-9\.]*"/"version": "'"${NEW_VERSION}"'"/' "${FILE}" && rm "${FILE}.bak"
 
 


### PR DESCRIPTION
Currently, building the master branch fails with this error:
```
make[1]: Entering directory '/root/canboat/analyzer'
./fixup-version.sh ../rel/linux-aarch64/analyzer package.json
sed: -e expression #1, char 1: unknown command: `.'
make[1]: *** [Makefile:76: package.json] Error 1
make[1]: Leaving directory '/root/canboat/analyzer'
make: *** [Makefile:35: compile] Error 2
```

In fact, this was mentioned in a review comment recently, but seems to not have been addressed: https://github.com/canboat/canboat/commit/80660a6685ec4dc0471fd7d1e145215be1b03a92#r83381306

This PR addresses the suggestion in that comment.