### PR TITLE
poc: WebAssembly with emscripten

### DIFF
--- a/analyzer/Makefile
+++ b/analyzer/Makefile
@@ -43,13 +43,15 @@ ANALYZER_EXPLAIN_DEP=$(ANALYZER_EXPLAIN) $(ANALYZER_EXPLAIN_SOURCES)
 CFLAGS?=-Wall -O2
 LDLIBS=-lm
 
+CC=emcc
+
 all: $(TARGETS)
 
 analyzer: $(ANALYZER)
 
 $(ANALYZER): analyzer.c pgn.c lookup.c print.c fieldtype.c $(HEADERS) $(COMMON) Makefile
 	@mkdir -p $(TARGETDIR)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(ANALYZER) -I$(COMMONDIR) pgn.c analyzer.c lookup.c print.c fieldtype.c $(COMMONDIR)/common.c $(COMMONDIR)/parse.c $(COMMONDIR)/utf.c $(LDLIBS$(LDLIBS-$(@)))
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o analyzer.html -I$(COMMONDIR) pgn.c analyzer.c lookup.c print.c fieldtype.c $(COMMONDIR)/common.c $(COMMONDIR)/parse.c $(COMMONDIR)/utf.c $(LDLIBS$(LDLIBS-$(@)))
 
 $(ANALYZER_EXPLAIN): $(ANALYZER_EXPLAIN_SOURCES)
 	@mkdir -p $(TARGETDIR)


### PR DESCRIPTION
Not meant to be merged as is, but check this out: canboat compiled to WebAssembly, launched under Node (but works in browser also):
```
% echo '2014-08-15T19:00:00.045Z,3,129033,160,255,8,a9,3f,fc,ed,c4,28,b4,00' |  node analyzer.js -json  -si
{"version":"4.9.2","units":"si","showLookupValues":false}
INFO 2022-12-06T21:27:46.468Z [analyzer.js] Assuming normal format with one line per frame
{"timestamp":"2014-08-15T19:00:00.045Z","prio":3,"src":160,"dst":255,"pgn":129033,"description":"Time & Date","fields":{"Date":"2014.08.15","Time":"18:59:59.4620","Local Offset":"03:00:00"}}
```

Once you install [Empscripten](https://emscripten.org/docs/getting_started/downloads.html)`make` produces 
- analyzer.wasm (the actual web assembly)
- analyzer.js (js to launch wasm and handle io)
- analyzer.html that provides io in browser (naive window.prompt for input and a crude console like window)

Node.js has been able to run wasm for some while already.