### PR TITLE
chore: add a minimal continuous integration test as Github Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v2
+      - name: update & install tools
+        run: sudo apt-get update && sudo apt-get install -y xsltproc libxml2-utils
+      - name: make
+        run: make
+      - name: make generated
+        run: make generated
+      - name: check there is no git diff output
+        run: git diff --exit-code


### PR DESCRIPTION
Add a minimal 'continuous integration' test as Github Action:
- run `make` so that we check that things compile
- run `make generated` so that all generated output works
- check that nothing that is in git, like the generated files, is changed, so that the generated output files match the source of truth
