### PR TITLE
Added SchemaVersion element to XSD/XML/JSON and removed Version attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Sections can be: Added Changed Deprecated Removed Fixed Security.
 ### Fixed
 - Fix #358: Repair heading and temperature lookups in NMEA0183.
 
+### Changed
+
+- #270: Added SchemaVersion element to the XSD and generated XML/JSON
+  files, and removed the old Version attribute.
+
 ## [4.9.2]
 
 ### Fixed

--- a/analyzer/analyzer-explain.c
+++ b/analyzer/analyzer-explain.c
@@ -975,9 +975,13 @@ static void explainXML(bool normal, bool actisense, bool ikonvert)
   {
     printf("<?xml-stylesheet type=\"text/xsl\" href=\"canboat.xsl\"?>\n");
   }
-  printf("<PGNDefinitions xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" "
-         "Version=\"0.1\">\n"
-         "  <Comment>See https://github.com/canboat/canboat for the full source code</Comment>\n"
+  if (!doV1) {
+      printf("<PGNDefinitions xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n"
+             "  <SchemaVersion>" SCHEMA_VERSION "</SchemaVersion>\n");
+  } else {
+      printf("<PGNDefinitions xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" Version=\"0.1\">\n");
+  }
+  printf("  <Comment>See https://github.com/canboat/canboat for the full source code</Comment>\n"
          "  <CreatorCode>Canboat NMEA2000 Analyzer</CreatorCode>\n"
          "  <License>Apache License Version 2.0</License>\n"
          "  <Version>" VERSION "</Version>\n");

--- a/common/version.h
+++ b/common/version.h
@@ -19,3 +19,4 @@ limitations under the License.
 */
 
 #define VERSION "4.9.2"
+#define SCHEMA_VERSION "2.0.0"

--- a/docs/canboat.json
+++ b/docs/canboat.json
@@ -1,5 +1,6 @@
 
   {
+    "SchemaVersion":"2.0.0",
     "Comment":"See https://github.com/canboat/canboat for the full source code",
     "CreatorCode":"Canboat NMEA2000 Analyzer",
     "License":"Apache License Version 2.0",

--- a/docs/canboat.xml
+++ b/docs/canboat.xml
@@ -22,7 +22,8 @@ limitations under the License.
 
 -->
 <?xml-stylesheet type="text/xsl" href="canboat.xsl"?>
-<PGNDefinitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Version="0.1">
+<PGNDefinitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <SchemaVersion>2.0.0</SchemaVersion>
   <Comment>See https://github.com/canboat/canboat for the full source code</Comment>
   <CreatorCode>Canboat NMEA2000 Analyzer</CreatorCode>
   <License>Apache License Version 2.0</License>

--- a/docs/canboat.xsd
+++ b/docs/canboat.xsd
@@ -1,4 +1,7 @@
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema version="2.0.0"
+           attributeFormDefault="unqualified"
+           elementFormDefault="qualified"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="PGNDefinitions" type="PGNDefinitions">
     <xs:annotation>
       <xs:documentation>
@@ -46,6 +49,15 @@ limitations under the License.
           The last element is the list of PGNs themselves.
         </xs:documentation>
       </xs:annotation>
+      <xs:element type="xs:string" name="SchemaVersion">
+        <xs:annotation>
+          <xs:documentation>
+            This is the version of the schema that the XML instance
+            document uses.  The version of the schema is found in the
+            version attribute in the xs:schema top-level element.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element type="xs:string" name="Comment"/>
       <xs:element type="xs:string" name="CreatorCode"/>
       <xs:element type="xs:string" name="License"/>
@@ -59,7 +71,6 @@ limitations under the License.
       <xs:element type="LookupBitEnumerations" name="LookupBitEnumerations"/>
       <xs:element type="PGNs" name="PGNs"/>
     </xs:sequence>
-    <xs:attribute type="xs:float" name="Version"/>
   </xs:complexType>
 
   <xs:complexType name="EnumPair">


### PR DESCRIPTION
One drawback with this PR is that the schema version string is defined in 2 source files; `version.h` and `canboat.xsd`.
And I note that `canboat.xsd` contains this:
```
CANboat version v2.0.0
```
which seems a bit old.

Perhaps `canboat.xsd` could be generated from `canboat.xsd.in` and the header files, so that each string is defined in a single source file (SCHEMA_VERSION and COPYRIGHT)? 