### PR TITLE
Create Release on new tag and add PGN databases as artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
       - name: update & install tools
         run: sudo apt-get update && sudo apt-get install -y xsltproc libxml2-utils
+
       - name: make
         run: make
+
       - name: make generated
         run: make generated
+
       - name: check there is no git diff output
         run: git diff --exit-code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,24 @@
+name: Upload release assets
+
+# this flow will be run only when new tags are pushed that match our pattern
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Add release assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            docs/canboat.json
+            docs/canboat.xml
+            docs/canboat.xsd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Version in common/version.h must match release tag
+        run: |
+          export CANBOAT_VERSION=$(sed -En 's/.*\ VERSION\ \"([0-9]+\.)([0-9]+\.)?([0-9]+)\"/\1\2\3/p' common/version.h)
+          echo "Checking if docs/canboat.json contains \"CANboat version v${CANBOAT_VERSION}\""
+          grep -q "CANboat version v${CANBOAT_VERSION}" docs/canboat.json
+          echo "Checking if docs/canboat.json contains version \"Version\":\"${CANBOAT_VERSION}\""
+          grep -q "\"Version\":\"${CANBOAT_VERSION}\"" docs/canboat.json
+          echo "Checking if docs/canboat.xml contains \"CANboat version v${CANBOAT_VERSION}\""
+          grep -q "CANboat version v${CANBOAT_VERSION}" docs/canboat.xml
+          echo "Checking if docs/canboat.xml contains \"<Version>${CANBOAT_VERSION}</Version>\""
+          grep -q "<Version>${CANBOAT_VERSION}</Version>" docs/canboat.xml
+          echo "Github tag should match version in common/version.h"
+          test "${GITHUB_REF##*/}" == "v${CANBOAT_VERSION}"
+
       - name: Add release assets
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
This is related to https://github.com/canboat/canboat/issues/325

This Github workflow is triggered when new Tag with pattern `v[0-9]+.[0-9]+.[0-9]+` is pushed/created.   As a result https://github.com/softprops/action-gh-release actions will create new Release with that tag name and attach following files as artifacts `docs/canboat.json`, `docs/canboat.xml`, `docs/canboat.xsd`.

Release will look like that:
![image](https://user-images.githubusercontent.com/2320301/216425933-be62e4ea-01cc-4f95-a3e5-709a5297f9de.png)
