### PR TITLE
Fixed bug in fixup of version in XSD and  added  fixup of schema version in XSD

### DIFF
--- a/analyzer/Makefile
+++ b/analyzer/Makefile
@@ -60,6 +60,7 @@ $(XMLFILE): $(ANALYZER_EXPLAIN_DEP)
 
 $(XML2FILE): $(ANALYZER_EXPLAIN_DEP) $(XSD2FILE) fixup-version.py
 	python3 fixup-version.py $(ANALYZER) $(XSD2FILE)
+	python3 fixup-version.py -s $(ANALYZER) $(XSD2FILE)
 	$(ANALYZER_EXPLAIN) -explain-xml -camel >$(XML2FILE)
 	xmllint --schema $(XSD2FILE) $(XML2FILE) --noout
 

--- a/analyzer/analyzer.c
+++ b/analyzer/analyzer.c
@@ -143,6 +143,11 @@ int main(int argc, char **argv)
       printf("%s\n", VERSION);
       exit(0);
     }
+    else if (strcasecmp(av[1], "-schema-version") == 0)
+    {
+      printf("%s\n", SCHEMA_VERSION);
+      exit(0);
+    }
     else if (strcasecmp(av[1], "-camel") == 0)
     {
       camelCase(false);

--- a/docs/canboat.xsd
+++ b/docs/canboat.xsd
@@ -5,7 +5,7 @@
   <xs:element name="PGNDefinitions" type="PGNDefinitions">
     <xs:annotation>
       <xs:documentation>
-CANboat version v2.0.0
+CANboat version v4.9.2
 
 (C) 2009-2021, Kees Verruijt, Harlingen, The Netherlands.
 For more information see https://github.com/canboat/canboat


### PR DESCRIPTION
This PR ensures that `make generated` fixes the CANboat version string and the schema version in the XSD.