### PR TITLE
Verify that the schema version is correct when a release is created

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,11 @@ jobs:
           grep -q "CANboat version v${CANBOAT_VERSION}" docs/canboat.xml
           echo "Checking if docs/canboat.xml contains \"<Version>${CANBOAT_VERSION}</Version>\""
           grep -q "<Version>${CANBOAT_VERSION}</Version>" docs/canboat.xml
+          export SCHEMA_VERSION=$(sed -En 's/.*\ SCHEMA_VERSION\ \"([0-9]+\.)([0-9]+\.)?([0-9]+)\"/\1\2\3/p' common/version.h)
+          echo "Checking if docs/canboat.xsd contains \"xs:version=\"${SCHEMA_VERSION}\""
+          grep -q "xs:schema version=\"${SCHEMA_VERSION}\"" docs/canboat.xsd
+          echo "Checking if docs/canboat.json contains version \"SchemaVersion\":\"${SCHEMA_VERSION}\""
+          grep -q "\"SchemaVersion\":\"${SCHEMA_VERSION}\"" docs/canboat.json
           echo "Github tag should match version in common/version.h"
           test "${GITHUB_REF##*/}" == "v${CANBOAT_VERSION}"
 


### PR DESCRIPTION
This PR adds checks for verifying the schema version in the new release-check script.

I am not sure that this script is the best solution, but as long as it is used I guess it should be as correct as possible.

For example, it doesn't correctly check the version in canboat.xml (that file has the version in two places), and it doesn't check the copyright and license, which also can get out of date... 