### PR TITLE
Add instructions how to build/test with Docker

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -12,6 +12,20 @@ Optional if you want to re-generate the JSON, XML and DBC files:
 * `xmllint`
 * `python3`
 
+
+### Building everything in [Docker](https://www.docker.com/)
+
+```bash
+make docker-build
+```
+
+or
+
+```bash
+docker build -t canboat-builder .
+docker run -it --rm -v $(pwd)/:/project canboat-builder clean generated
+```
+
 ### Building the binaries on Linux
 
 The first line is for use with Debian/Ubuntu/PopOS! etc.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# https://hub.docker.com/_/ubuntu/tags
+FROM ubuntu:22.04
+
+RUN apt update && \
+    apt install build-essential python3 python3-pip python3-venv xsltproc libxml2-utils -y --no-install-recommends
+
+WORKDIR /project
+ENTRYPOINT ["make"]

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,11 @@ generated: tests
 	$(MAKE) -C analyzer generated
 	$(MAKE) -C dbc-exporter
 
+# Builder image can be removed with `docker image rm canboat-builder`
+docker-build: ## runs `make clean generated` in `ubuntu:22.04` Docker image
+	@docker build -t canboat-builder .
+	@docker run -it --rm -v $(shell pwd):/project canboat-builder clean generated
+
 bin:	$(BUILDDIR)
 
 $(BUILDDIR):

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ To use the programs included in this project you may need a supported CAN interf
 
 For more information go to the [CANBoat Wiki](http://github.com/canboat/canboat/wiki).
 
-where you can find instructions on how to build the programs on your own computer and how to start 
-extending the PGN database.
-Short build instructions are also found in [BUILDING.md].
+## Building, Development and Testing
+
+In [Wiki](https://github.com/canboat/canboat/wiki) you can find instructions on how to build the programs on your own computer 
+and how to start extending the PGN database. Short instructions are also found in [BUILDING.md](./BUILDING.md).
 
 ## Version history
 
@@ -26,6 +27,7 @@ See [Changelog](CHANGELOG.md).
 ## Related Projects
 
 - [canboatjs](https://github.com/canboat/canboatjs) Pure JavaScript NMEA 2000 decoder and encoder
+
 
 ---
 


### PR DESCRIPTION
# Add instructions how to build/test with Docker

This python stuff is really annoying for people like me that do not know `venv` and python package management at all. I just did clean Ubuntu 22.10 reinstall and struggled to get `make generate` work.  Having ability to run everything through Docker helps and I do not need to mess around with Canboat dependencies and python problems. Only thing you need is "docker" to be installed.