### PR TITLE
analyzer: Don't crash when presented with PGN of 0.

### DIFF
--- a/analyzer/pgn.c
+++ b/analyzer/pgn.c
@@ -56,6 +56,9 @@ Pgn *searchForPgn(int pgn)
     }
     if (pgn < pgnList[mid].pgn)
     {
+      if (mid == 0) {
+        return NULL;
+      }
       end = mid - 1;
     }
     else


### PR DESCRIPTION
The analyzer crashed on my log files.

An example of an input file causing the analyzer to crash:
2023-03-16-13:04:33.987,0,0,12,0,8,00,00,02,00,00,00,00,00
