### PR TITLE
avoid n2kd monitor forking every 30s

### DIFF
--- a/n2kd/n2kd_monitor
+++ b/n2kd/n2kd_monitor
@@ -96,13 +96,13 @@ my $child;
 my $stop = 0;
 my $last_monitor = 0;
 
+use POSIX();
 if ($MONITOR ne "true" && $MONITOR ne "yes")
 {
   # Disable the monitoring part. This is not open source yet, so disable it by default.
-  $last_monitor = LONG_MAX;
+  $last_monitor = POSIX::LONG_MAX;
 }
 
-use POSIX();
 
 sub logText($)
 {
@@ -251,6 +251,7 @@ for (;;)
         open STDOUT, '>>', $MONITOR_LOGFILE or die "Can't write to $MONITOR_LOGFILE $!";
         open STDERR, '>&STDOUT' or die "Can't dup stdout: $!";
         exec 'php5', '/usr/local/bin/n2k.php', '-monitor';
+	die "unable to exec monitor"
       }
       if (!$monitor)
       {


### PR DESCRIPTION
This issue has already been addressed by #152. But unfortunately the changes have been reverted back later on.
So the problem is still there - every 30 seconds a new n2kd_monitor is forked.
So I analyzed n2kd_monitor again.
Basically there are 2 issues:
(1) LONG_MAX (https://github.com/canboat/canboat/blob/357f0c9a161719272853dedcdf635386abcd8560/n2kd/n2kd_monitor#L102) does not work at all - you need to import POSIX before and by ommiting the POSIX imports with () you need the qualified Name POSIX::LONG_MAX
(2) handling if the php monitor does not start
You need to exit the forked process if it is unable to exec (https://github.com/canboat/canboat/blob/357f0c9a161719272853dedcdf635386abcd8560/n2kd/n2kd_monitor#L253).
By (1) this should not be executed at all - but to be prepared for MONITOR="yes"...

