### PR TITLE
Update pgn.h

### DIFF
--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -3404,7 +3404,7 @@ Pgn pgnList[] = {
      PACKET_COMPLETE,
      PACKET_SINGLE,
      {INSTANCE_FIELD,
-      VOLTAGE_U16_10MV_FIELD("Voltage"),
+      VOLTAGE_I16_10MV_FIELD("Voltage"),
       CURRENT_FIX16_DA_FIELD("Current"),
       TEMPERATURE_FIELD("Temperature"),
       UINT8_FIELD("SID"),


### PR DESCRIPTION
PGN127508 was incorrectly using an unsigned int/precision 10mv for votlage, correct field is signed int, precision 10mv