### PR TITLE
Fix #478: Obsolete v1 files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,14 @@ Sections can be: Added Changed Deprecated Removed Fixed Security.
 
 ## [Unreleased]
 
+### [6.0.0]
+
+The reason for the semver major version change is that analyzer/pgns.xml and analyzer/pgns.json have been
+moved to the obsolete directory.
+
 ### Fixed
 
+- #478: Make pgns.xml and pgns.json obsolete.
 - Updated copyrights to 2025.
 - #475: FieldType VARIABLE should have the VariableSize attribute set to True.
 - #474: PGN updates

--- a/analyzer/Makefile
+++ b/analyzer/Makefile
@@ -24,20 +24,21 @@ ANALYZER_J1939=$(TARGETDIR)/analyzer-j1939
 ANALYZER_EXPLAIN=$(TARGETDIR)/analyzer-explain
 ANALYZER_EXPLAIN_J1939=$(TARGETDIR)/analyzer-explain-j1939
 TARGETS=$(ANALYZER) $(ANALYZER_J1939) $(ANALYZER_EXPLAIN) $(ANALYZER_EXPLAIN_J1939)
-XMLFILE=pgns.xml
-XMLFILE_J1939=pgns-j1939.xml
-JSONFILE=pgns.json
-JSONFILE_J1939=pgns-j1939.json
+XMLFILE=../obsolete/pgns.xml
+XMLFILE_J1939=../obsolete/pgns-j1939.xml
+JSONFILE=../obsolete/pgns.json
+JSONFILE_J1939=../obsolete/pgns-j1939.json
 XSL2FILE=../docs/canboat.xsl
 XML2FILE=../docs/canboat.xml
 XSD2FILE=../docs/canboat.xsd
 JSON2FILE=../docs/canboat.json
 HTML2FILE=../docs/canboat.html
-NGTXMLFILE=pgns-ngt.xml
-NGTJSONFILE=pgns-ngt.json
-IKXMLFILE=pgns-ik.xml
-IKJSONFILE=pgns-ik.json
-NPMFILE=package.json
+NGTXMLFILE=../obsolete/pgns-ngt.xml
+NGTJSONFILE=../obsolete/pgns-ngt.json
+IKXMLFILE=../obsolete/pgns-ik.xml
+IKJSONFILE=../obsolete/pgns-ik.json
+NPMFILE=../obsolete/package.json
+NPM2FILE=../docs/package.json
 HEADERS=analyzer.h pgn.h lookup.h fieldtype.h
 HEADERS_J1939=analyzer.h pgn-j1939.h lookup.h fieldtype.h
 COMMONDIR=../common
@@ -114,7 +115,10 @@ $(IKJSONFILE): $(IKXMLFILE) pgns2json.xslt validate-json.py
 $(NPMFILE): ../common/version.h $(ANALYZER) fixup-version.py
 	python3 fixup-version.py $(ANALYZER) $(NPMFILE)
 
-generated: $(JSONFILE) $(JSON2FILE) $(NGTJSONFILE) $(IKJSONFILE) $(NPMFILE) $(HTML2FILE)
+$(NPM2FILE): ../common/version.h $(ANALYZER) fixup-version.py
+	python3 fixup-version.py $(ANALYZER) $(NPM2FILE)
+
+generated: $(JSONFILE) $(JSON2FILE) $(NGTJSONFILE) $(IKJSONFILE) $(NPMFILE) $(NPM2FILE) $(HTML2FILE)
 
 clean:
 	-rm -f $(TARGETS) *.elf *.gdb

--- a/common/version.h
+++ b/common/version.h
@@ -18,5 +18,5 @@ limitations under the License.
 
 */
 
-#define VERSION "5.1.3"
+#define VERSION "6.0.0"
 #define SCHEMA_VERSION "2.1.1"

--- a/dbc-exporter/Makefile
+++ b/dbc-exporter/Makefile
@@ -10,8 +10,8 @@ VENV=$(TARGETDIR)/venv
 
 all: pgns.dbc
 
-pgns.dbc: dbc-exporter ../analyzer/pgns.json
-	"$(VENV)/bin/canboat-dbc-exporter" ../analyzer/pgns.json pgns.dbc
+pgns.dbc: dbc-exporter ../obsolete/pgns.json
+	"$(VENV)/bin/canboat-dbc-exporter" ../obsolete/pgns.json pgns.dbc
 	"$(VENV)/bin/python3" ../analyzer/fixup-version.py -w $(TARGETDIR)/analyzer pgns.dbc
 
 dbc-exporter: $(VENV)

--- a/dbc-exporter/pgns.dbc
+++ b/dbc-exporter/pgns.dbc
@@ -1,4 +1,4 @@
-VERSION "5.1.3"
+VERSION "6.0.0"
 
 
 NS_ : 

--- a/docs/canboat.html
+++ b/docs/canboat.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta charset="UTF-8"/><meta name="description" content="CANBoat PGN documentation"/><link rel="stylesheet" type="text/css" href="canboat.css"/><script src="canboat.js"></script><link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@300&amp;display=swap" rel="stylesheet"/></head><body><div id="sidenav" class="sidenav"><a class="closebtn" onclick="closeNav(event)">×</a><a href="#main">Top</a><a href="#pgn-list">PGN list</a><a href="#physical-quantities">Physical Quantities</a><a href="#field-types">Field Types</a><a href="#lookup-enumerations">Lookup enumerations</a><a href="#indirect-lookup-enumerations">Indirect lookup enumerations</a><a href="#bitfield-enumerations">Bitfield enumerations</a><a href="#lookupfieldtype-enumerations">Lookup with FieldType enumerations</a><a href="#notes">Notes</a></div><div id="sidenav-closed" class="sidenav"><a onclick="openNav(event)" id="hamburger"><span></span><span></span><span></span></a></div><div id="main"><p>
             The CANBoat project PGN documentation version
-            5.1.3.
-          </p><h3>Copyright</h3><p class="xs">CANboat version v5.1.3
+            6.0.0.
+          </p><h3>Copyright</h3><p class="xs">CANboat version v6.0.0
 
 (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
 For more information see https://github.com/canboat/canboat

--- a/docs/canboat.json
+++ b/docs/canboat.json
@@ -4,8 +4,8 @@
     "Comment":"See https://github.com/canboat/canboat for the full source code",
     "CreatorCode":"Canboat NMEA2000 Analyzer",
     "License":"Apache License Version 2.0",
-    "Version":"5.1.3",
-    "Copyright":"CANboat version v5.1.3\n\n(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.\nFor more information see https://github.com/canboat/canboat\n\nThis file is part of CANboat.\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n    http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n\n\n",
+    "Version":"6.0.0",
+    "Copyright":"CANboat version v6.0.0\n\n(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.\nFor more information see https://github.com/canboat/canboat\n\nThis file is part of CANboat.\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n    http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n\n\n",
     "PhysicalQuantities":[
     {
         "Name":"ELECTRICAL_CURRENT",

--- a/docs/canboat.xml
+++ b/docs/canboat.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-CANboat version v5.1.3
+CANboat version v6.0.0
 
 (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
 For more information see https://github.com/canboat/canboat
@@ -27,8 +27,8 @@ limitations under the License.
   <Comment>See https://github.com/canboat/canboat for the full source code</Comment>
   <CreatorCode>Canboat NMEA2000 Analyzer</CreatorCode>
   <License>Apache License Version 2.0</License>
-  <Version>5.1.3</Version>
-  <Copyright>CANboat version v5.1.3
+  <Version>6.0.0</Version>
+  <Copyright>CANboat version v6.0.0
 
 (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
 For more information see https://github.com/canboat/canboat

--- a/docs/canboat.xsd
+++ b/docs/canboat.xsd
@@ -5,7 +5,7 @@
   <xs:element name="PGNDefinitions" type="PGNDefinitions">
     <xs:annotation>
       <xs:documentation>
-CANboat version v5.1.3
+CANboat version v6.0.0
 
 (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
 For more information see https://github.com/canboat/canboat

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@canboat/pgns2",
+  "version": "6.0.0",
+  "description": "JSON description of canboat supported pgns",
+  "main": "canboat.json",
+  "scripts": {
+    "test": "mocha --exit",
+    "changelog": "github-changes -o canboat -r pgns2 -a --only-pulls --use-commit-body --data=pulls  --tag-name=v$npm_package_version",
+    "release": "git tag -d v$npm_package_version; npm run changelog && git add CHANGELOG.md && git commit -m 'chore: update changelog' && git tag v$npm_package_version && git push --tags && git push"
+  },
+  "author": "Scott Bender <scott@scottbender.net>",
+  "contributors": [
+    {
+      "name": "Kees Verruijt",
+      "email": "kees@verruijt.net"
+    },
+    {
+      "name": "Teppo Kurki",
+      "email": "teppo.kurki@iki.fi"
+    },
+    {
+      "name": "Jouni Hartikainen",
+      "email": "jouni.hartikainen@iki.fi"
+    }
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/canboat/canboat.git"
+  }
+}

--- a/obsolete/README.md
+++ b/obsolete/README.md
@@ -1,0 +1,12 @@
+
+### WARNING ###
+
+These files should not be used in new projects.
+
+| Old         | New                |
+|=============|====================|
+| `pgns.xml`  | `docs/canboat.xml` |
+| `pgns.json` | `docs/canboat.xml` |
+
+The new files are more rigourously defined, there is a `.xsd` file that defines the XML schema and a `.xslt` file 
+that is used to generate the documentation. Read both!

--- a/obsolete/package.json
+++ b/obsolete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canboat/pgns",
-  "version": "5.1.3",
+  "version": "6.0.0",
   "description": "Json description of canboat supported pgns",
   "main": "pgns.json",
   "scripts": {

--- a/obsolete/pgns-ik.json
+++ b/obsolete/pgns-ik.json
@@ -2,7 +2,7 @@
     "Comment":"WARNING: DO NOT USE THIS FILE. IT IS INCLUDED FOR HISTORICAL DOWNSTREAM PROJECTS. See https://github.com/canboat/canboat for the full source code and the recommended new file to use.",
     "CreatorCode":"Canboat NMEA2000 Analyzer",
     "License":"Apache License Version 2.0",
-    "Version":"5.1.3",
+    "Version":"6.0.0",
     "PGNs": [
     
       {

--- a/obsolete/pgns-ik.xml
+++ b/obsolete/pgns-ik.xml
@@ -4,7 +4,7 @@
      Please use docs/canboat.xml which is a much more complete format.
 -->
 <!--
-CANboat version v5.1.3
+CANboat version v6.0.0
 
 (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
 For more information see https://github.com/canboat/canboat
@@ -29,7 +29,7 @@ limitations under the License.
   <Comment>WARNING: DO NOT USE THIS FILE. IT IS INCLUDED FOR HISTORICAL DOWNSTREAM PROJECTS. See https://github.com/canboat/canboat for the full source code and the recommended new file to use.</Comment>
   <CreatorCode>Canboat NMEA2000 Analyzer</CreatorCode>
   <License>Apache License Version 2.0</License>
-  <Version>5.1.3</Version>
+  <Version>6.0.0</Version>
   <PGNs>
     <PGNInfo>
       <PGN>262400</PGN>

--- a/obsolete/pgns-ngt.json
+++ b/obsolete/pgns-ngt.json
@@ -2,7 +2,7 @@
     "Comment":"WARNING: DO NOT USE THIS FILE. IT IS INCLUDED FOR HISTORICAL DOWNSTREAM PROJECTS. See https://github.com/canboat/canboat for the full source code and the recommended new file to use.",
     "CreatorCode":"Canboat NMEA2000 Analyzer",
     "License":"Apache License Version 2.0",
-    "Version":"5.1.3",
+    "Version":"6.0.0",
     "PGNs": [
     
       {

--- a/obsolete/pgns-ngt.xml
+++ b/obsolete/pgns-ngt.xml
@@ -4,7 +4,7 @@
      Please use docs/canboat.xml which is a much more complete format.
 -->
 <!--
-CANboat version v5.1.3
+CANboat version v6.0.0
 
 (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
 For more information see https://github.com/canboat/canboat
@@ -29,7 +29,7 @@ limitations under the License.
   <Comment>WARNING: DO NOT USE THIS FILE. IT IS INCLUDED FOR HISTORICAL DOWNSTREAM PROJECTS. See https://github.com/canboat/canboat for the full source code and the recommended new file to use.</Comment>
   <CreatorCode>Canboat NMEA2000 Analyzer</CreatorCode>
   <License>Apache License Version 2.0</License>
-  <Version>5.1.3</Version>
+  <Version>6.0.0</Version>
   <PGNs>
     <PGNInfo>
       <PGN>262161</PGN>

--- a/obsolete/pgns.json
+++ b/obsolete/pgns.json
@@ -2,7 +2,7 @@
     "Comment":"WARNING: DO NOT USE THIS FILE. IT IS INCLUDED FOR HISTORICAL DOWNSTREAM PROJECTS. See https://github.com/canboat/canboat for the full source code and the recommended new file to use.",
     "CreatorCode":"Canboat NMEA2000 Analyzer",
     "License":"Apache License Version 2.0",
-    "Version":"5.1.3",
+    "Version":"6.0.0",
     "PGNs": [
     
       {

--- a/obsolete/pgns.xml
+++ b/obsolete/pgns.xml
@@ -4,7 +4,7 @@
      Please use docs/canboat.xml which is a much more complete format.
 -->
 <!--
-CANboat version v5.1.3
+CANboat version v6.0.0
 
 (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
 For more information see https://github.com/canboat/canboat
@@ -29,7 +29,7 @@ limitations under the License.
   <Comment>WARNING: DO NOT USE THIS FILE. IT IS INCLUDED FOR HISTORICAL DOWNSTREAM PROJECTS. See https://github.com/canboat/canboat for the full source code and the recommended new file to use.</Comment>
   <CreatorCode>Canboat NMEA2000 Analyzer</CreatorCode>
   <License>Apache License Version 2.0</License>
-  <Version>5.1.3</Version>
+  <Version>6.0.0</Version>
   <PGNs>
     <PGNInfo>
       <PGN>59392</PGN>


### PR DESCRIPTION
This moves the old v1 generated files to an `obsolete/` directory, so that hopefully devs will use the files in `docs/` instead (maybe the name of that directory needs to change?)

As this breaks downstream packages it bumps the version to 6.0.0.