### PR TITLE
Make Wind Data Reference field part of primary key

### DIFF
--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -5369,7 +5369,7 @@ Pgn pgnList[] = {
      {UINT8_FIELD("SID"),
       SPEED_U16_CM_FIELD("Wind Speed"),
       ANGLE_U16_FIELD("Wind Angle", NULL),
-      LOOKUP_FIELD("Reference", 3, WIND_REFERENCE),
+      LOOKUP_PRIMARY_KEY_FIELD("Reference", 3, WIND_REFERENCE),
       RESERVED_FIELD(5 + BYTES(2)),
       END_OF_FIELDS},
      .priority = 2,

--- a/docs/canboat.html
+++ b/docs/canboat.html
@@ -9475,7 +9475,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
                       <a href="#ft-NUMBER">NUMBER</a></td><td/></tr><tr><td>4</td><td>Reference</td><td/><td><div class="xs">0 .. 6</div></td><td>3 bits
                   
                       lookup
-                      <a href="#lookup-WIND_REFERENCE">WIND_REFERENCE</a></td><td/></tr><tr><td>5</td><td>Reserved</td><td/><td/><td>21 bits
+                      <a href="#lookup-WIND_REFERENCE">WIND_REFERENCE</a></td><td>true</td></tr><tr><td>5</td><td>Reserved</td><td/><td/><td>21 bits
                   <a href="#ft-RESERVED">RESERVED</a></td><td/></tr></table><p>
               Source:
               <a href="http://askjackrabbit.typepad.com/ask_jack_rabbit/page/7/">http://askjackrabbit.typepad.com/ask_jack_rabbit/page/7/</a></p><h3 id="pgn-130310">0x1FD06:

--- a/docs/canboat.json
+++ b/docs/canboat.json
@@ -35175,7 +35175,8 @@
             "RangeMin":0,
             "RangeMax":6,
             "FieldType":"LOOKUP",
-            "LookupEnumeration":"WIND_REFERENCE"
+            "LookupEnumeration":"WIND_REFERENCE",
+            "PartOfPrimaryKey":true
           },
           {
             "Order":5,

--- a/docs/canboat.xml
+++ b/docs/canboat.xml
@@ -34949,6 +34949,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <RangeMax>6</RangeMax>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>WIND_REFERENCE</LookupEnumeration>
+          <PartOfPrimaryKey>true</PartOfPrimaryKey>
         </Field>
         <Field>
           <Order>5</Order>


### PR DESCRIPTION
The reference field (true, apparent, ...) is part of the primary key as the wind speed and angle is impacted by it. 