### PR TITLE
PGN 60928 - ISO Address Claim: add primary key to ISO Identity Number

### DIFF
--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -1214,7 +1214,7 @@ Pgn pgnList[] = {
      60928,
      PACKET_COMPLETE,
      PACKET_SINGLE,
-     {SIMPLE_DESC_FIELD("Unique Number", 21, "ISO Identity Number"),
+     {SIMPLE_DESC_PRIMARY_KEY_FIELD("Unique Number", 21, "ISO Identity Number"),
       MANUFACTURER_FIELD(NULL, NULL, false),
       SIMPLE_DESC_PRIMARY_KEY_FIELD("Device Instance Lower", 3, "ISO ECU Instance"),
       SIMPLE_DESC_PRIMARY_KEY_FIELD("Device Instance Upper", 5, "ISO Function Instance"),

--- a/docs/canboat.html
+++ b/docs/canboat.html
@@ -301,7 +301,7 @@ limitations under the License.
             </p><table><tr><th> Field # </th><th> Field Name </th><th> Description </th><th> Unit </th><th> Type </th><th> PartOfPrimaryKey </th></tr><tr><td>1</td><td>Unique Number</td><td>ISO Identity Number</td><td><div class="xs">0 .. 2097148</div></td><td>21 bits
                   
                         unsigned
-                      <a href="#ft-NUMBER">NUMBER</a></td><td/></tr><tr><td>2</td><td>Manufacturer Code</td><td/><td><div class="xs">0 .. 2044</div></td><td>11 bits
+                      <a href="#ft-NUMBER">NUMBER</a></td><td>true</td></tr><tr><td>2</td><td>Manufacturer Code</td><td/><td><div class="xs">0 .. 2044</div></td><td>11 bits
                   
                       lookup
                       <a href="#lookup-MANUFACTURER_CODE">MANUFACTURER_CODE</a></td><td>true</td></tr><tr><td>3</td><td>Device Instance Lower</td><td>ISO ECU Instance</td><td><div class="xs">0 .. 6</div></td><td>3 bits

--- a/docs/canboat.json
+++ b/docs/canboat.json
@@ -4481,7 +4481,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2097148,
-            "FieldType":"NUMBER"
+            "FieldType":"NUMBER",
+            "PartOfPrimaryKey":true
           },
           {
             "Order":2,

--- a/docs/canboat.xml
+++ b/docs/canboat.xml
@@ -3740,6 +3740,7 @@ limitations under the License.
           <RangeMin>0</RangeMin>
           <RangeMax>2097148</RangeMax>
           <FieldType>NUMBER</FieldType>
+          <PartOfPrimaryKey>true</PartOfPrimaryKey>
         </Field>
         <Field>
           <Order>2</Order>


### PR DESCRIPTION
The ISO Identity Number field is constant per device and therefore should be marked as primary key.