### PR TITLE
Use proper open and closing braces with -camel or -upper-camel

### DIFF
--- a/analyzer/analyzer.c
+++ b/analyzer/analyzer.c
@@ -1096,7 +1096,7 @@ bool printPgn(const RawMessage *msg, const uint8_t *data, int length, bool showD
   {
     if (pgn->camelDescription)
     {
-      mprintf("\"%s\":", pgn->camelDescription);
+      mprintf("{\"%s\":", pgn->camelDescription);
     }
     mprintf("{\"timestamp\":\"%s\",\"prio\":%u,\"src\":%u,\"dst\":%u,\"pgn\":%u,\"description\":\"%s\"",
             msg->timestamp,
@@ -1114,7 +1114,14 @@ bool printPgn(const RawMessage *msg, const uint8_t *data, int length, bool showD
       }
       mprintf("\"");
     }
-    strcpy(closingBraces, "}");
+    if (pgn->camelDescription)
+    {
+      strcpy(closingBraces, "}}");
+    } 
+    else 
+    {
+      strcpy(closingBraces, "}");
+    }
     sep = ",\"fields\":{";
   }
   else


### PR DESCRIPTION
When using the `-json` command line option along with `-camel` or `upper-camel` invalid JSON is produced.

Example:
```bash
$ analyzer -json < samples/126208.raw | jq
```
produces correct output whereas:
```bash
$ analyzer -json -camel < samples/126208.raw | jq
```
produces an error:
```json
{
  "version": "6.0.0-alpha",
  "units": "std",
  "showLookupValues": false
}
"nmeaCommandGroupFunction"
jq: parse error: Expected string key before ':' at line 2, column 27
```

This comes from a missing an open + closing brace outer pair. Looking at the unparsed output:

```json
"nmeaCommandGroupFunction": {
    "timestamp": "2020-04-19T00:35:55.571Z",
    "prio": 2,
    "src": 0,
    "dst": 67,
    "pgn": 126208,
    "description": "NMEA - Command group function",
    "fields": {
      // ...
    }
}
```
It should be:

```json
{
  "nmeaCommandGroupFunction": {
    "timestamp": "2020-04-19T00:35:55.571Z",
    "prio": 2,
    "src": 0,
    "dst": 67,
    "pgn": 126208,
    "description": "NMEA - Command group function",
    "fields": {
      // ...
    }
  }
}
```

