### PR TITLE
Fix executable permissions in make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ CONFDIR=$(SYSCONFDIR)/default
 ROOT_UID=0
 ROOT_GID=0
 ROOT_MOD=0644
+EXEC_MOD=0755
 
 all:	bin compile
 	@echo "The binaries are now built and are in $(BUILDDIR)"
@@ -80,7 +81,7 @@ clean:
 	-rm -R -f man $(BUILDDIR)
 
 install: $(BUILDDIR)/analyzer $(DESTDIR)$(BINDIR) $(DESTDIR)$(CONFDIR) $(DESTDIR)$(MANDIR)/man1
-	for i in $(BUILDDIR)/* util/* */*_monitor; do install -m $(ROOT_MOD) -b $$i $(DESTDIR)$(BINDIR); done
+	for i in $(BUILDDIR)/* util/* */*_monitor; do install -m $(EXEC_MOD) -b $$i $(DESTDIR)$(BINDIR); done
 	for i in config/*; do f=`basename $$i`; if [ ! -f "$(DESTDIR)/$(CONFDIR)/$$f" ]; then install -b -m $(ROOT_MOD) $$i $(DESTDIR)$(CONFDIR); fi; done
 ifeq ($(notdir $(HELP2MAN)),help2man)
 	for i in man/man1/*; do echo $$i; install -m $(ROOT_MOD) $$i $(DESTDIR)$(MANDIR)/man1; done


### PR DESCRIPTION
## Description
Fixes #587 

This PR fixes a regression introduced in commit 9bb492d5 where executables were being installed with 644 permissions instead of 755.

## Changes
- Added `EXEC_MOD=0755` variable for executable permissions
- Updated install target to use `$(EXEC_MOD)` for binaries instead of `$(ROOT_MOD)`
- Config files continue to use `ROOT_MOD=0644` as intended

## Testing
- Built with `make`
- Installed with `sudo make install`
- Verified executables have 755 permissions: `ls -la /usr/local/bin/analyzer`
- Verified executables run correctly: `/usr/local/bin/analyzer --help`
- Verified config files still have 644 permissions: `ls -la /etc/default/n2kd`

## Impact
This fix restores the ability to run installed binaries without manually fixing permissions.