### PR TITLE
feat: fill in Maretron Alert family PGNs 130820/130821/130822 identity headers

### DIFF
--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -7454,16 +7454,16 @@ Pgn pgnList[] = {
     ,
     {"Maretron: Annunciator",
      130824,
-     PACKET_COMPLETE,
+     PACKET_INCOMPLETE,
      PACKET_FAST,
      {COMPANY(137),
-      UINT8_FIELD(PK("Annunciator Instance")),
-      UINT8_FIELD("Annunciator Volume"),
-      UINT16_FIELD("Annunciator Tone"),
-      UINT8_FIELD("Alert Source Instance"),
-      UINT16_FIELD("Alert Id"),
+      UINT8_FIELD("Field 4"),
+      UINT8_FIELD("Field 5"),
+      UINT16_FIELD("Field 6"),
+      UINT8_FIELD("Field 7"),
+      UINT16_FIELD("Field 8"),
       END_OF_FIELDS},
-     .priority = 2}
+     .priority = 7}
 
     ,
     {"Maretron: Data Instance Channel Correlation",

--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -6857,7 +6857,19 @@ Pgn pgnList[] = {
      130819,
      PACKET_INCOMPLETE,
      PACKET_FAST,
-     {COMPANY(137), BINARY_FIELD("Data", BYTES(221), ""), END_OF_FIELDS}}
+     {COMPANY(137),
+      LOOKUP_FIELD("Alert Type", 4, ALERT_TYPE),
+      LOOKUP_FIELD("Alert Category", 4, ALERT_CATEGORY),
+      UINT8_FIELD("Alert System"),
+      UINT8_FIELD("Alert Sub-System"),
+      UINT16_FIELD("Alert ID"),
+      ISO_NAME_FIELD("Data Source Network ID NAME"),
+      UINT8_FIELD(PK("Data Source Instance")),
+      UINT8_FIELD("Data Source Index-Source"),
+      UINT8_FIELD("Alert Occurrence Number"),
+      BINARY_FIELD("Maretron Extension", BYTES(16), "Maretron-specific payload following the standard Alert identity header."),
+      END_OF_FIELDS},
+     .priority = 7}
 
     ,
     {"Simnet: Reprogram Status",

--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -7377,7 +7377,21 @@ Pgn pgnList[] = {
      130820,
      PACKET_INCOMPLETE,
      PACKET_FAST,
-     {COMPANY(137), BINARY_FIELD("Data", BYTES(221), ""), END_OF_FIELDS}}
+     {COMPANY(137),
+      LOOKUP_FIELD("Alert Type", 4, ALERT_TYPE),
+      LOOKUP_FIELD("Alert Category", 4, ALERT_CATEGORY),
+      UINT8_FIELD("Alert System"),
+      UINT8_FIELD("Alert Sub-System"),
+      UINT16_FIELD("Alert ID"),
+      ISO_NAME_FIELD("Data Source Network ID NAME"),
+      UINT8_FIELD(PK("Data Source Instance")),
+      UINT8_FIELD("Data Source Index-Source"),
+      UINT8_FIELD("Alert Occurrence Number"),
+      ISO_NAME_FIELD("Acknowledge Source Network ID NAME"),
+      LOOKUP_FIELD("Response Command", 2, ALERT_RESPONSE_COMMAND),
+      RESERVED_FIELD(6),
+      END_OF_FIELDS},
+     .priority = 7}
 
     // NAC-3 sends this once a second, with (decoded) data like this:
     // \r\n1720.0,3,0.0,0.1,0.0,1.8,0.00,358.0,0.00,359.9,0.36,0.09,4.1,4.0,0,1.71,0.0,0.50,0.90,51.00,17.10,4.00,-7.43,231.28,4.06,1.8,0.00,0.0,0.0,0.0,0.0,
@@ -7414,7 +7428,21 @@ Pgn pgnList[] = {
      130821,
      PACKET_INCOMPLETE,
      PACKET_FAST,
-     {COMPANY(137), BINARY_FIELD("Data", BYTES(221), ""), END_OF_FIELDS}}
+     {COMPANY(137),
+      LOOKUP_FIELD("Alert Type", 4, ALERT_TYPE),
+      LOOKUP_FIELD("Alert Category", 4, ALERT_CATEGORY),
+      UINT8_FIELD("Alert System"),
+      UINT8_FIELD("Alert Sub-System"),
+      UINT16_FIELD("Alert ID"),
+      ISO_NAME_FIELD("Data Source Network ID NAME"),
+      UINT8_FIELD(PK("Data Source Instance")),
+      UINT8_FIELD("Data Source Index-Source"),
+      UINT8_FIELD("Alert Occurrence Number"),
+      LOOKUP_FIELD("Language ID", BYTES(1), ALERT_LANGUAGE_ID),
+      STRINGLAU_FIELD("Alert Text Description"),
+      STRINGLAU_FIELD("Alert Location Text Description"),
+      END_OF_FIELDS},
+     .priority = 7}
 
     ,
     {"Navico: Unknown 1",
@@ -7429,7 +7457,19 @@ Pgn pgnList[] = {
      130822,
      PACKET_INCOMPLETE,
      PACKET_FAST,
-     {COMPANY(137), BINARY_FIELD("Data", BYTES(221), ""), END_OF_FIELDS}}
+     {COMPANY(137),
+      LOOKUP_FIELD("Alert Type", 4, ALERT_TYPE),
+      LOOKUP_FIELD("Alert Category", 4, ALERT_CATEGORY),
+      UINT8_FIELD("Alert System"),
+      UINT8_FIELD("Alert Sub-System"),
+      UINT16_FIELD("Alert ID"),
+      ISO_NAME_FIELD("Data Source Network ID NAME"),
+      UINT8_FIELD(PK("Data Source Instance")),
+      UINT8_FIELD("Data Source Index-Source"),
+      UINT8_FIELD("Alert Occurrence Number"),
+      BINARY_FIELD("Maretron Extension", BYTES(16), "Maretron-specific payload following the standard Alert identity header."),
+      END_OF_FIELDS},
+     .priority = 7}
 
     ,
     {"Maretron: Proprietary Temperature High Range",

--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -1624,9 +1624,14 @@ Pgn pgnList[] = {
     ,
     {"Maretron: Number of Channels",
      65282,
-     PACKET_INCOMPLETE,
+     PACKET_COMPLETE,
      PACKET_SINGLE,
-     {COMPANY(137), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
+     {COMPANY(137),
+      PGN_FIELD("PGN", "PGN for which the number of channels is reported"),
+      UINT8_FIELD("Number of Channels"),
+      RESERVED_FIELD(BYTES(2)),
+      END_OF_FIELDS},
+     .priority = 6}
 
     ,
     {"Maretron: Proprietary DC Breaker Current",
@@ -1693,9 +1698,16 @@ Pgn pgnList[] = {
     ,
     {"Maretron: Fluid Flow Rate",
      65286,
-     PACKET_INCOMPLETE,
+     PACKET_RESOLUTION_UNKNOWN,
      PACKET_SINGLE,
-     {COMPANY(137), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
+     {COMPANY(137),
+      UINT8_FIELD("SID"),
+      UINT8_FIELD(PK("Flow Rate Instance")),
+      LOOKUP_FIELD("Fluid Type", 4, TANK_TYPE),
+      RESERVED_FIELD(4),
+      SIMPLE_SIGNED_FIELD("Fluid Flow Rate", BYTES(3)),
+      END_OF_FIELDS},
+     .priority = 5}
 
     ,
     {"Airmar: Access Level",
@@ -1722,9 +1734,16 @@ Pgn pgnList[] = {
     ,
     {"Maretron: Trip Volume",
      65287,
-     PACKET_INCOMPLETE,
+     PACKET_RESOLUTION_UNKNOWN,
      PACKET_SINGLE,
-     {COMPANY(137), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
+     {COMPANY(137),
+      UINT8_FIELD("SID"),
+      UINT8_FIELD(PK("Volume Instance")),
+      LOOKUP_FIELD("Fluid Type", 4, TANK_TYPE),
+      RESERVED_FIELD(4),
+      SIMPLE_FIELD("Trip Volume", BYTES(3)),
+      END_OF_FIELDS},
+     .priority = 5}
 
     ,
     {"Seatalk: Alarm",
@@ -1742,9 +1761,15 @@ Pgn pgnList[] = {
 
     {"Maretron: 4-20 mA",
      65288,
-     PACKET_INCOMPLETE,
+     PACKET_RESOLUTION_UNKNOWN,
      PACKET_SINGLE,
-     {COMPANY(137), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
+     {COMPANY(137),
+      UINT8_FIELD("SID"),
+      UINT8_FIELD(PK("Data Instance")),
+      UINT16_FIELD("4-20 mA Data"),
+      RESERVED_FIELD(BYTES(2)),
+      END_OF_FIELDS},
+     .priority = 5}
 
     ,
     {"Simnet: Trim Tab Sensor Calibration",
@@ -1756,9 +1781,15 @@ Pgn pgnList[] = {
     ,
     {"Maretron: 0-10 V",
      65289,
-     PACKET_INCOMPLETE,
+     PACKET_RESOLUTION_UNKNOWN,
      PACKET_SINGLE,
-     {COMPANY(137), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
+     {COMPANY(137),
+      UINT8_FIELD("SID"),
+      UINT8_FIELD(PK("Data Instance")),
+      UINT16_FIELD("0-10 V Data"),
+      RESERVED_FIELD(BYTES(2)),
+      END_OF_FIELDS},
+     .priority = 5}
 
     ,
     {"Simnet: Paddle Wheel Speed Configuration",
@@ -1770,16 +1801,28 @@ Pgn pgnList[] = {
     ,
     {"Maretron: Rotational Rate",
      65290,
-     PACKET_INCOMPLETE,
+     PACKET_RESOLUTION_UNKNOWN,
      PACKET_SINGLE,
-     {COMPANY(137), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
+     {COMPANY(137),
+      UINT8_FIELD("SID"),
+      UINT8_FIELD(PK("Data Instance")),
+      SIMPLE_SIGNED_FIELD("Rotational Rate", BYTES(2)),
+      RESERVED_FIELD(BYTES(2)),
+      END_OF_FIELDS},
+     .priority = 5}
 
     ,
     {"Maretron: Resistance",
      65291,
-     PACKET_INCOMPLETE,
+     PACKET_RESOLUTION_UNKNOWN,
      PACKET_SINGLE,
-     {COMPANY(137), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
+     {COMPANY(137),
+      UINT8_FIELD("SID"),
+      UINT8_FIELD(PK("Data Instance")),
+      UINT16_FIELD("Resistance"),
+      RESERVED_FIELD(BYTES(2)),
+      END_OF_FIELDS},
+     .priority = 5}
 
     ,
     {"Simnet: Clear Fluid Level Warnings",
@@ -6771,9 +6814,16 @@ Pgn pgnList[] = {
     ,
     {"Maretron: Label",
      130818,
-     PACKET_INCOMPLETE,
+     PACKET_COMPLETE,
      PACKET_FAST,
-     {COMPANY(137), BINARY_FIELD("Data", BYTES(221), ""), END_OF_FIELDS}}
+     {COMPANY(137),
+      UINT8_FIELD(PK("Instance")),
+      UINT8_FIELD("Data Source"),
+      UINT8_FIELD("Data Indicator"),
+      STRINGLAU_FIELD("Label"),
+      UINT8_FIELD("Hardware Channel"),
+      END_OF_FIELDS},
+     .priority = 7}
 
     ,
     {"Simnet: Request Reprogram",
@@ -7385,23 +7435,30 @@ Pgn pgnList[] = {
     ,
     {"Maretron: Annunciator",
      130824,
-     PACKET_INCOMPLETE,
+     PACKET_COMPLETE,
      PACKET_FAST,
      {COMPANY(137),
-      UINT8_FIELD("Field 4"),
-      UINT8_FIELD("Field 5"),
-      UINT16_FIELD("Field 6"),
-      UINT8_FIELD("Field 7"),
-      UINT16_FIELD("Field 8"),
+      UINT8_FIELD(PK("Annunciator Instance")),
+      UINT8_FIELD("Annunciator Volume"),
+      UINT16_FIELD("Annunciator Tone"),
+      UINT8_FIELD("Alert Source Instance"),
+      UINT16_FIELD("Alert Id"),
       END_OF_FIELDS},
-     .priority = 7}
+     .priority = 2}
 
     ,
     {"Maretron: Data Instance Channel Correlation",
      130825,
-     PACKET_INCOMPLETE,
+     PACKET_COMPLETE,
      PACKET_FAST,
-     {COMPANY(137), BINARY_FIELD("Data", BYTES(221), ""), END_OF_FIELDS}}
+     {COMPANY(137),
+      PGN_FIELD("PGN", "PGN for which the correlation is reported"),
+      UINT8_FIELD(PK("Hardware Channel")),
+      UINT8_FIELD("Instance"),
+      UINT8_FIELD("Data Source"),
+      UINT8_FIELD("Data Indicator"),
+      END_OF_FIELDS},
+     .priority = 6}
 
     ,
     {"Navico: Unknown 2",
@@ -7413,9 +7470,20 @@ Pgn pgnList[] = {
     ,
     {"Maretron: Switch Indicator Status",
      130826,
-     PACKET_INCOMPLETE,
+     PACKET_COMPLETE,
      PACKET_FAST,
-     {COMPANY(137), BINARY_FIELD("Data", BYTES(221), ""), END_OF_FIELDS}}
+     {COMPANY(137),
+      UINT8_FIELD(PK("Indicator Bank Instance")),
+      UINT8_FIELD("Number of Status Fields"),
+      UINT8_FIELD("Indicator Status"),
+      END_OF_FIELDS},
+     .priority        = 2,
+     .repeatingField1 = 5,
+     .repeatingCount1 = 1,
+     .repeatingStart1 = 6,
+     .explanation     = "Broadcast by Maretron switching devices alongside PGN 127501. "
+                        "Each indicator status byte carries the state of one switch channel, "
+                        "encoded as 0 = Off, 1 = On, 2 = Tripped, 3 = Unknown."}
 
     /* Uwe Lovas has seen this from EP-70R */
     ,
@@ -7434,6 +7502,22 @@ Pgn pgnList[] = {
 
     ,
     {"Simnet: Set Serial Number", 130828, PACKET_INCOMPLETE | PACKET_NOT_SEEN, PACKET_FAST, {COMPANY(1857), END_OF_FIELDS}}
+
+    ,
+    {"Maretron: Dometic HVAC Status",
+     130830,
+     PACKET_RESOLUTION_UNKNOWN,
+     PACKET_FAST,
+     {COMPANY(137),
+      TEMPERATURE_FIELD("Additional Sensor Temperature"),
+      UINT32_FIELD("CAN ID"),
+      UINT8_FIELD("State"),
+      UINT8_FIELD("Hardware Status"),
+      UINT8_FIELD("Faults"),
+      VOLTAGE_U16_V_FIELD("Line Voltage"),
+      CURRENT_UFIX16_A_FIELD("Compressor Current"),
+      END_OF_FIELDS},
+     .priority = 5}
 
     ,
     {"Maretron: Universal Configuration FP",

--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -1236,6 +1236,25 @@ Pgn pgnList[] = {
      PACKET_SINGLE,
      {COMPANY(358), UINT16_FIELD("Register Id"), SIMPLE_FIELD("Payload", BYTES(4)), END_OF_FIELDS}}
 
+    ,
+    {"Carling: Breaker Command",
+     61184,
+     PACKET_COMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(176),
+      MATCH_FIELD(PK("Message Type"), BYTES(1), 2, "Breaker Command"),
+      UINT8_FIELD("Breaker Mapping 1"),
+      UINT8_FIELD("Breaker Mapping 2"),
+      RESERVED_FIELD(5),
+      SIMPLE_FIELD("Breaker Mapping 3", 3),
+      UINT8_FIELD("Breaker Command"),
+      UINT8_FIELD("Dim Value"),
+      END_OF_FIELDS},
+     .priority    = 2,
+     .explanation = "Addresses up to 19 breakers on a Carling digital switching panel via three bitmap fields. "
+                    "Breakers 1 to 8 are in Breaker Mapping 1, 9 to 16 in Breaker Mapping 2, "
+                    "and 17 to 19 in Breaker Mapping 3."}
+
     /* PDU2 non-addressed single-frame PGN range 0xF000 - 0xFEFF (61440 - 65279) */
 
     ,


### PR DESCRIPTION
## Summary

Extends the Maretron Alert Transmission pattern introduced in #604 to the three remaining Alert family PGNs. Each of them wraps the standard NMEA 2000 Alert identity header (same first nine fields as PGN 126983 Alert) inside the Maretron proprietary envelope.

- **130820 Maretron Alert Response**: identity header + acknowledge source NAME + 2-bit ``Response Command`` (using the existing ``ALERT_RESPONSE_COMMAND`` lookup). Mirrors the layout of the standard PGN 126984.
- **130821 Maretron Alert Text**: identity header + ``Language ID`` (``ALERT_LANGUAGE_ID`` lookup) + two STRINGLAU fields for ``Alert Text Description`` and ``Alert Location Text Description``. Mirrors PGN 126985.
- **130822 Maretron Alert Control**: identity header + 16-byte Maretron-specific binary extension, mirroring the 130819 pattern for the Maretron proprietary tail.

All three entries are marked ``PACKET_INCOMPLETE`` because only the identity header is confirmed; the Maretron-specific trailing bytes (where present) are kept as ``BINARY``.

## Depends on

- #604 (this branch is stacked on top of #604 so the first four commits are the same). Once #604 merges, this PR will reduce to the single commit ``feat: fill in Maretron Alert family PGNs 130820/130821/130822 identity headers``.

## Tests

``make`` and ``make tests`` both pass. analyzer-explain renders the three entries with correct byte lengths (130820 = 27 bytes, 130821 variable ≥ 19 bytes, 130822 = 34 bytes), matching the respective standard Alert PGN layouts.