### PR TITLE
feat: add BEP Marine / CZone proprietary PGN stubs

### DIFF
--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -1641,6 +1641,13 @@ Pgn pgnList[] = {
      {COMPANY(137), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
 
     ,
+    {"BEP Marine: Proprietary",
+     65281,
+     PACKET_INCOMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(295), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
+
+    ,
     {"Maretron: Number of Channels",
      65282,
      PACKET_COMPLETE,
@@ -1652,6 +1659,13 @@ Pgn pgnList[] = {
       END_OF_FIELDS},
      .priority = 6}
 
+
+    ,
+    {"BEP Marine: Proprietary",
+     65283,
+     PACKET_INCOMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(295), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
     ,
     {"Maretron: Proprietary DC Breaker Current",
      65284,
@@ -1872,6 +1886,55 @@ Pgn pgnList[] = {
      {COMPANY(641), INSTANCE_FIELD, RESERVED_FIELD(BYTES(1)), UINT32_FIELD("Load Cell"), END_OF_FIELDS},
      .priority = 2}
 
+
+    ,
+    {"BEP Marine: Proprietary",
+     65294,
+     PACKET_INCOMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(295), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
+
+    ,
+    {"BEP Marine: Proprietary",
+     65295,
+     PACKET_INCOMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(295), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
+
+    ,
+    {"BEP Marine: Proprietary",
+     65296,
+     PACKET_INCOMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(295), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
+
+    ,
+    {"BEP Marine: Proprietary",
+     65297,
+     PACKET_INCOMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(295), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
+
+    ,
+    {"BEP Marine: Proprietary",
+     65299,
+     PACKET_INCOMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(295), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
+
+    ,
+    {"BEP Marine: Proprietary",
+     65300,
+     PACKET_INCOMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(295), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
+
+    ,
+    {"BEP Marine: Proprietary",
+     65301,
+     PACKET_INCOMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(295), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
     ,
     {"Simnet: AP Unknown 1",
      65302,
@@ -1888,6 +1951,13 @@ Pgn pgnList[] = {
      .explanation = "Seen as sent by AC-42 only so far.",
      .priority    = 7}
 
+
+    ,
+    {"BEP Marine: Proprietary",
+     65304,
+     PACKET_INCOMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(295), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
     ,
     {"Simnet: Device Status",
      65305,
@@ -1959,6 +2029,20 @@ Pgn pgnList[] = {
      .interval    = 1000,
      .explanation = "This PGN has been seen to be reported by a Sailing Processor."}
 
+
+    ,
+    {"BEP Marine: Proprietary",
+     65306,
+     PACKET_INCOMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(295), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
+
+    ,
+    {"BEP Marine: Proprietary",
+     65308,
+     PACKET_INCOMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(295), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
     ,
     {"Navico: Wireless Battery Status",
      65309,
@@ -1972,6 +2056,20 @@ Pgn pgnList[] = {
       END_OF_FIELDS},
      .priority = 7}
 
+
+    ,
+    {"BEP Marine: Proprietary",
+     65310,
+     PACKET_INCOMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(295), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
+
+    ,
+    {"BEP Marine: Proprietary",
+     65311,
+     PACKET_INCOMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(295), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
     ,
     {"Navico: Wireless Signal Status",
      65312,
@@ -1980,6 +2078,27 @@ Pgn pgnList[] = {
      {COMPANY(275), UINT8_FIELD("Unknown"), PERCENTAGE_U8_FIELD("Signal Strength"), RESERVED_FIELD(BYTES(4)), END_OF_FIELDS},
      .priority = 7}
 
+
+    ,
+    {"BEP Marine: Proprietary",
+     65314,
+     PACKET_INCOMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(295), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
+
+    ,
+    {"BEP Marine: Proprietary",
+     65316,
+     PACKET_INCOMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(295), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
+
+    ,
+    {"BEP Marine: Proprietary",
+     65325,
+     PACKET_INCOMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(295), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
     ,
     {"Simnet: AP Unknown 2",
      65340,


### PR DESCRIPTION
## Summary

Adds 17 BEP Marine (manufacturer code 295) proprietary single-frame PGN stubs: 65281, 65283, 65294-65297, 65299-65301, 65304, 65306, 65308, 65310-65311, 65314, 65316, 65325.

These PGNs are used by Mastervolt/BEP/CZone digital switching and power distribution systems. Adding stubs with the correct manufacturer code match ensures the analyzer identifies the source manufacturer instead of falling through to the generic proprietary PGN fallback.

Field layouts are left as BINARY pending further documentation. The stubs follow the same pattern used for the Maretron proprietary PGN stubs added in #598.

## Tests

``make`` and ``make tests`` both pass.