### PR TITLE
fix(130830): correct field sizes for Maretron Dometic HVAC Status

### DIFF
--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -7760,13 +7760,13 @@ Pgn pgnList[] = {
      PACKET_RESOLUTION_UNKNOWN,
      PACKET_FAST,
      {COMPANY(137),
-      TEMPERATURE_FIELD("Additional Sensor Temperature"),
+      UINT8_FIELD("Additional Sensor Temperature"),
       UINT32_FIELD("CAN ID"),
       UINT8_FIELD("State"),
       UINT8_FIELD("Hardware Status"),
       UINT8_FIELD("Faults"),
-      VOLTAGE_U16_V_FIELD("Line Voltage"),
-      CURRENT_UFIX16_A_FIELD("Compressor Current"),
+      UINT8_FIELD("Line Voltage"),
+      UINT8_FIELD("Compressor Current"),
       END_OF_FIELDS},
      .priority = 5}
 


### PR DESCRIPTION
The Additional Sensor Temperature, Line Voltage and Compressor Current
fields were incorrectly defined as 16-bit typed fields but the actual
payload uses 8-bit fields for each. This made the PGN 130830 entry 3
bytes longer than the real frame (15 bytes instead of 12).

Changes all three from ``TEMPERATURE_FIELD`` / ``VOLTAGE_U16_V_FIELD`` /
``CURRENT_UFIX16_A_FIELD`` to ``UINT8_FIELD`` to match the frame layout.

``make``, ``make tests`` and ``make generated`` all pass.