### PR TITLE
feat: add Carling switchboard PGNs and fill in Maretron Windlass

### DIFF
--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -8034,6 +8034,27 @@ Pgn pgnList[] = {
      {COMPANY(137), BINARY_FIELD("Data", BYTES(221), ""), END_OF_FIELDS}}
 
     ,
+    {"Maretron: Windlass Operating Status",
+     130842,
+     PACKET_INCOMPLETE,
+     PACKET_FAST,
+     {COMPANY(137),
+      SIMPLE_FIELD("Windlass Operating Events", 6),
+      SIMPLE_FIELD("Windlass Instance", 4),
+      SIMPLE_FIELD("Windlass Direction Control", 4),
+      UINT8_FIELD("Speed Control"),
+      LOOKUP_FIELD("Power Enable", 2, OFF_ON),
+      LOOKUP_FIELD("Mechanical Enable", 2, OFF_ON),
+      LOOKUP_FIELD("Anchor Docking Control", 2, OFF_ON),
+      LOOKUP_FIELD("Deck and Anchor Wash", 2, OFF_ON),
+      LOOKUP_FIELD("Anchor Light", 2, OFF_ON),
+      LOOKUP_FIELD("Auxiliary A Control", 2, OFF_ON),
+      LOOKUP_FIELD("Auxiliary B Control", 2, OFF_ON),
+      LOOKUP_FIELD("Auxiliary C Control", 2, OFF_ON),
+      LOOKUP_FIELD("Auxiliary D Control", 2, OFF_ON),
+      END_OF_FIELDS}}
+
+    ,
     {"Simnet: AIS Class B static data (msg 24 Part A)",
      130842,
      PACKET_INCOMPLETE | PACKET_NOT_SEEN,
@@ -8088,25 +8109,11 @@ Pgn pgnList[] = {
       END_OF_FIELDS}}
 
     ,
-    {"Maretron: Windlass Operating Status",
+    {"Maretron: Windlass Control Command",
      130843,
      PACKET_INCOMPLETE,
      PACKET_FAST,
-     {COMPANY(137),
-      SIMPLE_FIELD("Windlass Operating Events", 6),
-      SIMPLE_FIELD("Windlass Instance", 4),
-      SIMPLE_FIELD("Windlass Direction Control", 4),
-      UINT8_FIELD("Speed Control"),
-      LOOKUP_FIELD("Power Enable", 2, OFF_ON),
-      LOOKUP_FIELD("Mechanical Enable", 2, OFF_ON),
-      LOOKUP_FIELD("Anchor Docking Control", 2, OFF_ON),
-      LOOKUP_FIELD("Deck and Anchor Wash", 2, OFF_ON),
-      LOOKUP_FIELD("Anchor Light", 2, OFF_ON),
-      LOOKUP_FIELD("Auxiliary A Control", 2, OFF_ON),
-      LOOKUP_FIELD("Auxiliary B Control", 2, OFF_ON),
-      LOOKUP_FIELD("Auxiliary C Control", 2, OFF_ON),
-      LOOKUP_FIELD("Auxiliary D Control", 2, OFF_ON),
-      END_OF_FIELDS}}
+     {COMPANY(137), BINARY_FIELD("Data", BYTES(221), ""), END_OF_FIELDS}}
 
     ,
     {"Furuno: Heel Angle, Roll Information",
@@ -8129,11 +8136,11 @@ Pgn pgnList[] = {
      {COMPANY(1857), END_OF_FIELDS}}
 
     ,
-    {"Maretron: Windlass Control Command",
+    {"Carling: Proprietary",
      130844,
      PACKET_INCOMPLETE,
      PACKET_FAST,
-     {COMPANY(137), BINARY_FIELD("Data", BYTES(221), ""), END_OF_FIELDS}}
+     {COMPANY(176), BINARY_FIELD("Data", BYTES(221), ""), END_OF_FIELDS}}
 
     ,
     {"Maretron: DC Energy",

--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -1930,6 +1930,20 @@ Pgn pgnList[] = {
      {COMPANY(295), BINARY_FIELD("Data", BYTES(6), ""), END_OF_FIELDS}}
 
     ,
+    {"Carling: Switchboard Status",
+     65300,
+     PACKET_INCOMPLETE,
+     PACKET_SINGLE,
+     {COMPANY(176),
+      UINT8_FIELD(PK("Message Type")),
+      BINARY_FIELD("Data", BYTES(5), "Payload varies by Message Type."),
+      END_OF_FIELDS},
+     .explanation = "Multi-purpose Carling digital switching PGN with 16+ message types: "
+                    "box status, breaker status, configuration, power information, "
+                    "AC GenII status, uptime reports, and solenoid profiles. "
+                    "The Message Type field selects the variant."}
+
+    ,
     {"BEP Marine: Proprietary PGN 65301",
      65301,
      PACKET_INCOMPLETE,
@@ -8078,7 +8092,21 @@ Pgn pgnList[] = {
      130843,
      PACKET_INCOMPLETE,
      PACKET_FAST,
-     {COMPANY(137), BINARY_FIELD("Data", BYTES(221), ""), END_OF_FIELDS}}
+     {COMPANY(137),
+      SIMPLE_FIELD("Windlass Operating Events", 6),
+      SIMPLE_FIELD("Windlass Instance", 4),
+      SIMPLE_FIELD("Windlass Direction Control", 4),
+      UINT8_FIELD("Speed Control"),
+      LOOKUP_FIELD("Power Enable", 2, OFF_ON),
+      LOOKUP_FIELD("Mechanical Enable", 2, OFF_ON),
+      LOOKUP_FIELD("Anchor Docking Control", 2, OFF_ON),
+      LOOKUP_FIELD("Deck and Anchor Wash", 2, OFF_ON),
+      LOOKUP_FIELD("Anchor Light", 2, OFF_ON),
+      LOOKUP_FIELD("Auxiliary A Control", 2, OFF_ON),
+      LOOKUP_FIELD("Auxiliary B Control", 2, OFF_ON),
+      LOOKUP_FIELD("Auxiliary C Control", 2, OFF_ON),
+      LOOKUP_FIELD("Auxiliary D Control", 2, OFF_ON),
+      END_OF_FIELDS}}
 
     ,
     {"Furuno: Heel Angle, Roll Information",
@@ -8526,6 +8554,21 @@ Pgn pgnList[] = {
       END_OF_FIELDS},
      .priority = 7,
      .interval = 1000}
+
+    ,
+    {"Carling: Breaker Status and Configuration",
+     130921,
+     PACKET_INCOMPLETE,
+     PACKET_FAST,
+     {COMPANY(176),
+      UINT8_FIELD(PK("Message Type")),
+      BINARY_FIELD("Data", BYTES(219), "Payload varies by Message Type."),
+      END_OF_FIELDS},
+     .explanation = "Multi-purpose Carling digital switching fast-packet PGN with 8+ message types: "
+                    "breaker status with electrical values, breaker configuration, "
+                    "discrete I/O configuration, solenoid drive sequence, "
+                    "system alarm and alert messages. "
+                    "The Message Type field selects the variant."}
 
     ,
     {"Airmar: POST",


### PR DESCRIPTION
## Summary

### Windlass PGN correction

The Maretron Windlass PGNs were assigned to incorrect PGN numbers:

| PGN | Was | Now |
|-----|-----|-----|
| 130842 | (no Maretron entry) | **Maretron: Windlass Operating Status** |
| 130843 | Maretron: Windlass Operating Status | **Maretron: Windlass Control Command** |
| 130844 | Maretron: Windlass Control Command | **Carling: Proprietary** (manufacturer code 176) |

PGN 130842 added with field layout: operating events (6b), windlass instance (4b), direction control (4b), speed control, power/mechanical/anchor docking/wash/light enables, auxiliary A-D controls (9 x 2-bit OFF_ON).

PGN 130843 renamed and reverted to binary stub.

PGN 130844 changed from Maretron (mfr 137) to Carling (mfr 176).

### New Carling PGNs

- **65300 Carling: Switchboard Status** (single-frame) — multi-purpose PGN with 16+ message types covering box/breaker status, configuration, power information, and diagnostics.
- **130921 Carling: Breaker Status and Configuration** (fast-packet) — 8+ message types for breaker status with electrical values, configuration, discrete I/O, and system alerts.

## Tests

``make``, ``make tests`` and ``make generated`` all pass.