### PR TITLE
Fix NULL function pointer crash in analyzer-explain XML output

### DIFF
--- a/analyzer/analyzer-explain.c
+++ b/analyzer/analyzer-explain.c
@@ -839,7 +839,7 @@ static void explainPGNXML(Pgn pgn)
       {
         printXML(10, "Description", f.description);
       }
-      else if (f.unit && f.unit[0] == '=')
+      else if (f.unit && f.unit[0] == '=' && f.lookup.function.pairEnumerator != NULL)
       {
         g_lookupValue = (size_t) strtol(f.unit + 1, 0, 10);
         printf("          <Description>");


### PR DESCRIPTION
## Summary

`analyzer-explain -explain-xml` segfaults during `make generated` whenever a PGN definition contains a `MATCH_FIELD(name, len, id, NULL)` — i.e. a `Match` field with no description and no enum lookup. The first branch (line 838) requires a non-NULL description, so control falls through to the `else if (f.unit && f.unit[0] == '=')` branch (line 842), which calls `f.lookup.function.pairEnumerator(filterPair)` unconditionally — but `pairEnumerator` is NULL for fields without a lookup, producing a NULL function-pointer call.

The four other `pairEnumerator` callsites in this file (lines 560, 928, 945, 965) already guard with a non-NULL check; this one was missed.

## Fix

Match the existing pattern: NULL-check before the call.

```diff
-      else if (f.unit && f.unit[0] == '=')
+      else if (f.unit && f.unit[0] == '=' && f.lookup.function.pairEnumerator != NULL)
```

## Verification

- Generated XML against current master is byte-identical with and without the fix (`diff` produces no output, 66978 lines), so no regression for existing PGN definitions — the guard only kicks in where the original code would have crashed.
- Verified that #624 (which exposes the crash via `MATCH_FIELD(..., NULL)` calls) builds cleanly and produces a complete XML (67502 lines, exit 0) when this fix is applied.

## Why now

PR #624 hits this latent bug. Fixing it caller-side in that PR is also valid, but the callee-side guard prevents anyone else from tripping the same landmine in future PGN definitions.