### PR TITLE
chore: add .gitattributes to normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# Normalize line endings so checkouts are byte-stable across platforms
+# (regardless of the host's core.autocrlf). Text source is stored and checked
+# out as LF; the exceptions below preserve files that are intentionally CRLF
+# or are binary captures that must not be touched.
+
+* text=auto eol=lf
+
+# Generated DBC database is written with CRLF on purpose by the build
+# (analyzer/fixup-version.py -w). Treat it as binary so git stores the bytes
+# verbatim and never normalizes the CRLF away, so `make generated` produces no
+# spurious diff.
+dbc-exporter/pgns.dbc -text
+
+# Raw NMEA 2000 captures and other evidence: keep the bytes exactly as
+# committed (several contain CR and some are effectively binary).
+samples/** -text
+
+# Test fixtures that intentionally contain CR bytes; normalizing them would
+# break the golden-file comparison.
+analyzer/tests/mixed-format.in    -text
+analyzer/tests/recombine-frames.in -text
+n2kd/tests/ais-lookup.out         -text
+n2kd/tests/nmea0183.out           -text


### PR DESCRIPTION
## What

Adds a `.gitattributes` that stores text source as LF on checkout regardless of the host's `core.autocrlf`, keeping diffs clean across platforms.

## Why preserve some files

A blanket `* text=auto eol=lf` would corrupt files that are CRLF or binary on purpose, so they are explicitly excluded:

- `dbc-exporter/pgns.dbc` — generated with CRLF by `analyzer/fixup-version.py -w`; marked `-text` so git stores the bytes verbatim and `make generated` produces no spurious diff.
- `samples/**` — raw NMEA 2000 captures (several contain CR, some are effectively binary); kept byte-stable.
- A few golden-file test fixtures that intentionally contain CR (`analyzer/tests/mixed-format.in`, `recombine-frames.in`, `n2kd/tests/{ais-lookup,nmea0183}.out`) — normalizing them would break the test comparison.

## Verification

`git add --renormalize .` rewrites zero tracked files; the `pgns.dbc` blob stays byte-identical to its committed version.