### PR TITLE
fix: drop CAN 1.0 (11-bit) standard frames

### DIFF
--- a/candump2analyzer/candump2analyzer.c
+++ b/candump2analyzer/candump2analyzer.c
@@ -184,6 +184,14 @@ int main(int argc, char **argv)
       }
     }
 
+    // NMEA 2000 always uses 29-bit extended CAN identifiers. CAN 1.0 / 2.0A
+    // standard frames use an 11-bit identifier (max 0x7ff) and cannot be NMEA
+    // 2000, so the analyzer can't decode them -- skip them.
+    if (canid <= 0x7ff)
+    {
+      continue;
+    }
+
     unsigned int pri = 0;
     unsigned int src = 0;
     unsigned int dst = 255;

--- a/socketcan-serial/socketcan-serial.c
+++ b/socketcan-serial/socketcan-serial.c
@@ -580,6 +580,10 @@ static int readCan(int sock)
     {
       continue; /* error frame, not a real message */
     }
+    if ((frame.can_id & CAN_EFF_FLAG) == 0)
+    {
+      continue; /* CAN 1.0 / 2.0A standard (11-bit) frame, not NMEA 2000 */
+    }
 
     for (cmsg = CMSG_FIRSTHDR(&msg); cmsg != NULL; cmsg = CMSG_NXTHDR(&msg, cmsg))
     {


### PR DESCRIPTION
## Problem

`analyzer` only decodes NMEA 2000, which always uses **29-bit extended** CAN identifiers. The tools that feed it currently pass along **CAN 1.0 / 2.0A standard frames** (11-bit identifier, max `0x7ff`), which cannot be NMEA 2000 and the analyzer can't decode.

Fixes #400.

## Changes

- **`candump2analyzer`**: after the per-format parsing and before output, skip any frame whose CAN id is `<= 0x7ff`. A single guard covers all five input formats since they share the downstream code, and format auto-detection still works when a standard frame is the first line (it sets the format, then the line is dropped).
- **`socketcan-serial`**: at the read site, skip frames without `CAN_EFF_FLAG` set — the kernel's authoritative signal for an extended frame. The check must be here because `CAN_EFF_MASK` strips the flag before `handleFrame()`.

## Testing

`candump2analyzer` built and exercised on mixed input:

```
   can0  09F8027F   [8]  00 FC FF FF 00 00 FF FF   -> PGN 129026 (passed)
   can0  00000123   [8]  11 22 33 44 55 66 77 88   -> dropped (11-bit)
   can0  18EEFF01   [8]  05 a0 be 1c 00 a0 a0 c0   -> PGN 60928 (passed)
```

`socketcan-serial` is Linux-only and not compiled on the dev machine (darwin), but `CAN_EFF_FLAG` is already used elsewhere in the file, so it is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)