### PR TITLE
ci: stop spurious red checks on the release-please branch

### DIFF
--- a/.github/workflows/autofix-generated.yml
+++ b/.github/workflows/autofix-generated.yml
@@ -9,6 +9,11 @@ name: Autofix generated files
 # fork from here anyway. Fork PRs fall through to the build-ubuntu gate, which
 # fails with a "run make generated" message for the contributor to fix locally.
 #
+# The release-please branch is ALSO skipped: the `regenerate` job in
+# release-please.yml already regenerates and pushes the version-stamped docs for
+# the release PR. Running both raced to push the same commit, and the loser
+# failed with "! [rejected] (fetch first)" on every release.
+#
 # Needs RELEASE_PLEASE_TOKEN (a PAT) so the auto-commit re-triggers CI on the PR;
 # with the default GITHUB_TOKEN the push would not re-run the required checks.
 
@@ -20,7 +25,8 @@ permissions:
 
 jobs:
   autofix:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository
+        && !startsWith(github.event.pull_request.head.ref, 'release-please--') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,15 @@ on:
   push:
   pull_request:
 
+# ci.yml triggers on both push and pull_request, so a branch with an open PR
+# otherwise runs CI twice per commit. Collapse those into one run per branch and
+# cancel superseded runs when a newer commit arrives (e.g. release-please's
+# regenerate job pushing the regenerated docs on top of the version bump).
+# master is excluded so every merge to the default branch gets its own full run.
+concurrency:
+  group: ci-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: ${{ github.ref_name != 'master' }}
+
 jobs:
   build-ubuntu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

Every release PR (e.g. #652 for 6.2.3) showed **3 failed checks**, even though it self-heals to green and is mergeable. When release-please commits the version bump (`VERSION` in `common/version.h`), the version-stamped generated files (`docs/canboat.{xsd,xml,json}`, `dbc-exporter/pgns.dbc`) go stale until the `regenerate` job in `release-please.yml` regenerates and pushes them. In that window:

| # | Failed check | Cause |
|---|---|---|
| 1 | **CI** (push event) | generated-files gate fails on the stale bump commit |
| 2 | **CI** (pull_request event) | *duplicate* of #1 — `ci.yml` triggers on both `push` and `pull_request` |
| 3 | **Autofix generated files** | `autofix` and `regenerate` both regenerated and pushed; the loser failed with `! [rejected] (fetch first)` |

## Fixes (two commits)

1. **Skip `autofix` on `release-please--*` branches.** `release-please.yml`'s `regenerate` job already owns regeneration for the release PR, so running `autofix` too just raced it. Removes failure **#3**.
2. **Add a `concurrency` group to `ci.yml`.** It triggers on both `push` and `pull_request`, so every PR branch runs CI twice per commit. Group by branch with `cancel-in-progress` so the two collapse into one and a newer commit cancels the superseded run. Removes failure **#2** (and saves CI minutes on every PR). `master` is excluded so each merge still gets a full run.

No behavioural change for normal contributor PRs (still auto-fixed, still fully built).

## Honest residual

Failure **#1** — a single CI run failing the generated-files gate on release-please's intermediate version-bump commit — can still occur transiently, because that run typically finishes (~40s) before the `regenerate` job pushes the corrected commit, so `cancel-in-progress` can't catch it. It lands on a **superseded commit**; the PR head ends up green and mergeable.

Fully eliminating #1 would mean either skipping the generated-files gate on the release branch (rejected — if regeneration ever failed, genuinely stale docs would ship green) or making release-please's bump + regeneration a single atomic commit (more invasive). Happy to do the atomic version as a follow-up if zero reds is wanted.

## Note

Does not block #652 — that already self-healed to green (`version.h` = 6.2.3, docs regenerated to match). This stops the noise recurring on future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)