### PR TITLE
chore(n2kd): deprecate n2kd in favour of canboat-rs (#674)

### DIFF
--- a/n2kd/main.c
+++ b/n2kd/main.c
@@ -1507,6 +1507,13 @@ int main(int argc, char **argv)
     argc--, argv++;
   }
 
+  logError("\n"
+           "**** DEPRECATION WARNING ****************************************************\n"
+           "* n2kd is DEPRECATED. The C implementation will be REMOVED in CANboat v7.0. *\n"
+           "* Switch to the Rust implementation from                                    *\n"
+           "* https://github.com/canboat/canboat-rs now. See issue #674.                *\n"
+           "****************************************************************************\n");
+
   // Read the first line from stdin, this must contain JSON from analyzer
   verifyStdin();
   setFdUsed(stdinfd, DATA_INPUT_STREAM);

--- a/n2kd/n2kd_monitor
+++ b/n2kd/n2kd_monitor
@@ -166,6 +166,12 @@ sub manageCanInterface($)
   return 1;
 }
 
+logText("**** DEPRECATION WARNING ****************************************************");
+logText("* n2kd (and this n2kd_monitor) is DEPRECATED. The C implementation will be  *");
+logText("* REMOVED in CANboat v7.0. Switch to the Rust implementation from           *");
+logText("* https://github.com/canboat/canboat-rs now. See issue #674.                *");
+logText("****************************************************************************");
+
 if ($#ARGV >= 0 && $ARGV[0] eq "-fg")
 {
   logText("Starting n2kd_monitor service");

--- a/n2kd/tests/ais-lookup.err
+++ b/n2kd/tests/ais-lookup.err
@@ -1,2 +1,8 @@
 INFO test-n2kd [n2kd] Timestamp fixed
+ERROR test-n2kd [n2kd] 
+**** DEPRECATION WARNING ****************************************************
+* n2kd is DEPRECATED. The C implementation will be REMOVED in CANboat v7.0. *
+* Switch to the Rust implementation from                                    *
+* https://github.com/canboat/canboat-rs now. See issue #674.                *
+****************************************************************************
 INFO test-n2kd [n2kd] N2KD stopping

--- a/n2kd/tests/nmea0183.err
+++ b/n2kd/tests/nmea0183.err
@@ -1,2 +1,8 @@
 INFO test-n2kd [n2kd] Timestamp fixed
+ERROR test-n2kd [n2kd] 
+**** DEPRECATION WARNING ****************************************************
+* n2kd is DEPRECATED. The C implementation will be REMOVED in CANboat v7.0. *
+* Switch to the Rust implementation from                                    *
+* https://github.com/canboat/canboat-rs now. See issue #674.                *
+****************************************************************************
 INFO test-n2kd [n2kd] N2KD stopping


### PR DESCRIPTION
Refs #674.

Marks the **`n2kd`** daemon as deprecated.

- **`n2kd`** prints a prominent `DEPRECATION WARNING` at startup (via `logError`, so it shows even in `-q`), stating the C implementation will be **removed in CANboat v7.0** and pointing at [canboat-rs](https://github.com/canboat/canboat-rs).
- **`n2kd_monitor`** logs the same warning when it launches (so it lands in the service log).
- `-version` output is unaffected (the warning is emitted only when the daemon actually starts).

## Why

Supporting the **primary-key abstraction** in `n2kd` requires consuming the **entire PGN definition** at runtime (field metadata, primary-key fields, repeating sets). That complexity is far easier and safer to maintain in the Rust implementation, which already has the full typed PGN model. See #674 for the full rationale.

## Notes

- No functional change to `n2kd` otherwise; it keeps working for existing setups until removal.
- Updated the `n2kd` golden `.err` fixtures to include the new warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)