### PR TITLE
docs: add CONTRIBUTING guide and pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!--
+  The PR TITLE becomes the squash-merge commit message and drives the version
+  bump + CHANGELOG. Use Conventional Commits:  type(scope): summary
+  e.g.  fix(126993): correct transmit offset units
+  See CONTRIBUTING.md for the type table.
+-->
+
+## What does this PR do?
+
+
+
+## Checklist
+
+- [ ] PR **title** follows Conventional Commits (`feat` / `fix` / … — see [CONTRIBUTING.md](../CONTRIBUTING.md))
+- [ ] If I changed the PGN database (`analyzer/*.h`), I ran `make generated` and committed the regenerated `docs/` and `dbc-exporter/` files
+- [ ] Tests pass (`make tests`)
+- [ ] New or changed decodes are backed by a real capture (added to `samples/`) or public documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing to CANboat
+
+Thanks for helping improve CANboat! This guide covers how to get a change
+merged. For build instructions and the architecture of the PGN database, see
+**[AGENTS.md](AGENTS.md)**.
+
+## The cardinal rule: source and generated move together
+
+The NMEA 2000 PGN database is **hand-edited C** in `analyzer/pgn.h`,
+`analyzer/lookup.h` and `analyzer/fieldtype.h`. The files under `docs/`
+(`canboat.xml`, `canboat.html`, `canboat.json`) and `dbc-exporter/pgns.dbc` are
+**generated** from those headers and committed to git. If your change touches
+the database, regenerate the artifacts in the **same** commit:
+
+```sh
+make generated
+```
+
+`make generated` runs the full test suite first, so it also tells you if a
+golden output changed. Source and generated files must move together or CI
+will fail.
+
+## Pull request titles
+
+We **squash-merge** every pull request, so the **PR title becomes the commit
+message** on `master`. Our release tooling
+([release-please](https://github.com/googleapis/release-please)) parses that
+title to decide the next version number and to write `CHANGELOG.md`. A good
+title is therefore *required* — it is release metadata, not decoration.
+
+Use the [Conventional Commits](https://www.conventionalcommits.org) format:
+
+```
+type(scope): short summary in the imperative
+```
+
+- **type** — required, lowercase, from the table below.
+- **scope** — optional, in parentheses. Use a manufacturer (`navico`,
+  `mercury`), a PGN number (`126993`), an issue number (`693`), or a subsystem
+  (`json`, `socketcan-serial`).
+- **summary** — concise, lower-case start, no trailing period, imperative mood
+  ("add", not "added" or "adds").
+
+### Types and what they do
+
+| Type | Version bump | CHANGELOG section |
+|------|--------------|-------------------|
+| `feat` | **minor** (x.**Y**.z) | Added |
+| `fix` | **patch** (x.y.**Z**) | Fixed |
+| `perf`, `refactor` | none | Changed |
+| `revert` | none | Fixed |
+| `docs`, `ci`, `build`, `test`, `chore` | none | hidden |
+
+A PR whose title is only a hidden type (e.g. `chore:`) does **not** trigger a
+release on its own.
+
+### Breaking changes
+
+Add `!` after the type/scope for an incompatible change. This forces a
+**major** bump (X.y.z):
+
+```
+feat(navico)!: rework Simnet 130845/130846 Key/Parameter PGNs from firmware
+```
+
+### Examples (from this repo)
+
+```
+fix(126993): heartbeat "Data transmit offset" is in milliseconds
+feat(navico): decode 65313 Depth Quality and 130825 NDP2k Alert
+feat(693): NMEA 2000 gateway network status PGN — rename + emission
+feat(navico)!: rework Simnet 130845/130846 Key/Parameter PGNs from firmware
+chore: add real-world Fusion and Victron sample captures
+```
+
+### Common mistakes
+
+- **No type prefix** (`Improve B&G keys`) — release-please ignores it: no
+  version bump, no changelog entry.
+- **A type it does not recognise** (`navico(130824): …`) — also ignored. The
+  title must *start* with a known type; put the manufacturer in the **scope**:
+  `feat(navico): …`.
+- **Past tense, capitalised, or a trailing period** — works, but reads badly in
+  the changelog.
+- **Marking database work as `chore`** — new PGN/field support is `feat`; a
+  wrong decode is `fix`.
+
+## Database changes should be backed by evidence
+
+New or corrected decodes should be justified by a real capture (add it under
+`samples/` and cite it in a `pgn.h` comment) or by public documentation. The
+goal is a database that is reverse-engineered from observation, not guesswork.
+
+## Need help?
+
+Open an issue, or a draft PR to discuss an approach before polishing it.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ the [`samples/`](./samples) directory.
 In [Wiki](https://github.com/canboat/canboat/wiki) you can find instructions on how to build the programs on your own computer 
 and how to start extending the PGN database. Short instructions are also found in [BUILDING.md](./BUILDING.md).
 
+## Contributing
+
+Pull requests are welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to write your PR title
+(it becomes the release changelog entry), the source/generated lockstep rule, and what evidence a
+database change needs.
+
 ## Using the definitions in your own project
 
 If you just want to use the definitions in XML or JSON format, use the versions in the `docs` directory, e.g. (./docs/canboat.xml) or (./docs/canboat.json).

--- a/README.md
+++ b/README.md
@@ -77,9 +77,26 @@ See [Changelog](CHANGELOG.md).
 
 ## Related Projects
 
-- [canboatjs](https://github.com/canboat/canboatjs) Pure JavaScript NMEA 2000 decoder and encoder
-- [nmea2000](https://github.com/tomer-w/nmea2000) Pure Python NMEA 2000 decoder and encoder library based on canboat
-- [nmea2000 Home Assistant custom integration](https://github.com/tomer-w/ha-nmea2000) Expose NMEA2000 PGNs as Home Assistant devices and entities
+### Sibling projects (same authors)
+
+- [canboatjs](https://github.com/canboat/canboatjs) — pure JavaScript NMEA 2000 decoder and encoder
+- [canboat-rs](https://github.com/canboat/canboat-rs) — Rust NMEA 2000 library
+
+### Other projects using the CANboat PGN definitions
+
+- [go-nmea-client](https://github.com/aldas/go-nmea-client) — Go
+- [n2k](https://github.com/mbj4668/n2k) — Erlang
+- [NMEA2000-Analyzer](https://github.com/negrusti/NMEA2000-Analyzer) — Windows GUI
+- [nmea2000](https://github.com/tomer-w/nmea2000) — pure Python NMEA 2000 decoder and encoder library
+- [nmea2000 Home Assistant custom integration](https://github.com/tomer-w/ha-nmea2000) — expose NMEA 2000 PGNs as Home Assistant devices and entities
+
+### For non-technical sailors
+
+CANboat and its sibling [canboatjs](https://github.com/canboat/canboatjs) are command-line tools. If you
+just want to use your NMEA 2000 network, these projects build on them and provide a friendlier experience:
+
+- [OpenPlotter](https://openplotter.org/)
+- [Signal K](https://signalk.org/)
 
 ---
 


### PR DESCRIPTION
Adds a `CONTRIBUTING.md` and a `.github/pull_request_template.md`.

Motivation: PRs are squash-merged, so the **PR title becomes the commit message** that release-please parses for version bumps and the changelog. Contributors had no written guidance on this, so titles often miss the Conventional Commits format (or use a non-type prefix like `navico(130824):`) and get ignored by the release tooling.

**`CONTRIBUTING.md`** covers:
- the source → generated lockstep rule (`make generated`)
- PR titles: the `type(scope): summary` format, a type→version-bump→changelog table, breaking changes (`!`), real examples from this repo, and common mistakes
- the expectation that database changes are backed by a real capture or public docs

**`.github/pull_request_template.md`** adds a title reminder (in an HTML comment) and a short checklist (title format, `make generated`, tests, evidence).

Build/database untouched; docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)