### PR TITLE
feat(540): per-field-type .sentinels + lookup top-of-range markers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,12 +306,21 @@ Essential facts before editing:
   ≥8 bit, 2 for 4-7, 1 for 2-3, 0 for 1) and drives both the published
   `RangeMax`/`<UnknownValue>`/`<OutOfRangeValue>`/`<ReservedValue>` and the
   decoder's sentinel stripping — keep them in lockstep; don't reintroduce a
-  separate per-decoder count. When a field genuinely uses **all** its values
-  (e.g. a 3-bit instance where 7 is valid), declare **`SPECIAL_VALUES(0, "Name")`**
-  so it reserves none; `SPECIAL_VALUES(n, …)` sets any explicit count. The "all
-  values valid" idiom is also recognised automatically when a field's `.rangeMax`
-  reaches the full unsigned width. (Source for the three-value convention:
-  Cassidy, *NMEA 2000 Explained*.)
+  separate per-decoder count. The resolved count is `reservedCount = clamp(rawMax −
+  rawRangeMax, 0, byWidth)`: it follows a pulled-up `.rangeMax`, so the "all values
+  valid" idiom (`.rangeMax` reaches the full unsigned width) reserves none, and a
+  **LOOKUP** whose enumeration names value(s) in the sentinel region keeps only the
+  sentinels above the named values. Declare **`SPECIAL_VALUES(0, "Name")`** to force
+  none, `SPECIAL_VALUES(n, …)` to force an explicit count. (Source for the
+  three-value convention: Cassidy, *NMEA 2000 Explained*.)
+- **`.sentinels` per field type:** every FieldType declares a `Sentinels` enum
+  (`fieldtype.h`) emitted as `<Sentinels>` in the FieldTypes section: `TopOfRange`
+  (numbers and lookups — the per-field `UnknownValue`/… above), `EmptyString`
+  (STRING_*), `NaN` (FLOAT), `Variable` (DYNAMIC_FIELD_VALUE), or `None`
+  (identifiers like PGN/MMSI, filler like RESERVED, structured like ISO_NAME). This
+  is the single source of truth for which fields emit top-of-range markers — the
+  per-field emission keys off `.sentinels == TopOfRange`, so don't add a separate
+  exclusion list.
 - **`Id` is the frozen contract; `Name` is the display label.** Each field emits
   `<Id>` (the camelCase `.camelName`, the key downstream decoders use as the
   property name) and `<Name>` (the human label, `.name`). `Id` is normally

--- a/analyzer/analyzer-explain.c
+++ b/analyzer/analyzer-explain.c
@@ -707,21 +707,18 @@ static const char *getV2Type(const FieldType *ft)
   return NULL;
 }
 
-// Whether a field type advertises top-of-range special values. Excludes non-integers
-// (FLOAT/DECIMAL), the structured ISO_NAME identity, and the identifier-like numbers
-// (PGN/MMSI/FIELD_INDEX), which carry an id rather than a measurement that reserves sentinels.
-static bool emitsSpecialValues(const char *v2type)
+// The sentinel convention of a field, resolved from its root base field type (the .sentinels
+// member). Drives both the type-level <Sentinels> and the per-field top-of-range markers.
+static Sentinels sentinelsForFieldType(const FieldType *ft)
 {
-  static const char *const excluded[] = {"FLOAT", "DECIMAL", "ISO_NAME", "PGN", "MMSI", "FIELD_INDEX"};
-
-  for (size_t i = 0; i < sizeof(excluded) / sizeof(excluded[0]); i++)
+  for (; ft != NULL; ft = ft->baseFieldTypePtr)
   {
-    if (strcmp(v2type, excluded[i]) == 0)
+    if (ft->baseFieldTypePtr == NULL)
     {
-      return false;
+      return ft->sentinels;
     }
   }
-  return true;
+  return SENTINEL_NONE;
 }
 
 static void explainPGNXML(Pgn pgn)
@@ -985,13 +982,14 @@ static void explainPGNXML(Pgn pgn)
         printf("          <RangeMax>%.15g</RangeMax>\n", (double) ((UINT64_C(1) << f.size) - 1));
       }
 
-      // Explicit non-data sentinels for integer numbers (NMEA 2000 reserves the top of the
-      // range): Unknown (most positive), OutOfRange (max-1), Reserved (max-2). Only for plain
-      // numeric measurement fields -- not lookups, reserved/spare/string (no range), match fields,
-      // or the types emitsSpecialValues() rejects. 64-bit fields are excluded: their sentinels
-      // exceed JSON's safe integer range.
-      if (!doV1 && f.reservedCount > 0 && f.size < 64 && !isnan(f.rangeMin) && f.lookup.type == LOOKUP_TYPE_NONE
-          && !(f.unit != NULL && f.unit[0] == '=') && emitsSpecialValues(getV2Type(ft)))
+      // Explicit non-data sentinels for integer fields (NMEA 2000 reserves the top of the
+      // range): Unknown (most positive), OutOfRange (max-1), Reserved (max-2). Emitted for the
+      // field types whose .sentinels is TopOfRange (numbers AND lookups); a lookup that names a
+      // value in the sentinel region has had its reservedCount reduced accordingly, so the named
+      // value is not advertised as a sentinel. Excludes match fields (unit '=') and 64-bit fields
+      // (their sentinels exceed JSON's safe integer range).
+      if (!doV1 && f.reservedCount > 0 && f.size < 64 && !isnan(f.rangeMin) && !(f.unit != NULL && f.unit[0] == '=')
+          && sentinelsForFieldType(ft) == SENTINEL_TOP_OF_RANGE)
       {
         uint32_t highbit = (ft->hasSign == True && f.offset == 0) ? (f.size - 1) : f.size;
         uint64_t raw     = (UINT64_C(1) << highbit) - 1;
@@ -1194,6 +1192,8 @@ static void explainFieldTypesXML(void)
     {
       printf("      <RangeMax>%.15g</RangeMax>\n", ft->rangeMax);
     }
+
+    printf("      <Sentinels>%s</Sentinels>\n", sentinelsName(ft->sentinels));
 
     printf("    </FieldType>\n");
   }

--- a/analyzer/fieldtype.c
+++ b/analyzer/fieldtype.c
@@ -88,8 +88,31 @@ static uint8_t reservedCountForSize(uint32_t size)
   return (size >= 8) ? 3 : (size >= 4) ? 2 : (size >= 2) ? 1 : 0;
 }
 
-static double getMaxRange(
-    const char *name, uint32_t size, double resolution, bool sign, int32_t offset, LookupInfo *lookup, uint8_t specialvalues)
+extern const char *sentinelsName(Sentinels s)
+{
+  switch (s)
+  {
+    case SENTINEL_TOP_OF_RANGE:
+      return "TopOfRange";
+    case SENTINEL_NAN:
+      return "NaN";
+    case SENTINEL_EMPTY_STRING:
+      return "EmptyString";
+    case SENTINEL_VARIABLE:
+      return "Variable";
+    case SENTINEL_NONE:
+    default:
+      return "None";
+  }
+}
+
+static double getMaxRange(const char *name,
+                          uint32_t    size,
+                          double      resolution,
+                          bool        sign,
+                          int32_t     offset,
+                          LookupInfo *lookup,
+                          uint8_t     specialvalues)
 {
   uint32_t highbit = (sign && offset == 0) ? (size - 1) : size;
   uint64_t maxValue;
@@ -292,8 +315,8 @@ extern void fillFieldType(bool doUnitFixup)
     if (ft->size != 0 && ft->resolution != 0.0 && ft->hasSign != Null && ft->rangeMax == 0.0)
     {
       ft->rangeMin = getMinRange(ft->name, ft->size, ft->resolution, ft->hasSign == True, ft->offset);
-      ft->rangeMax = getMaxRange(
-          ft->name, ft->size, ft->resolution, ft->hasSign == True, ft->offset, NULL, reservedCountForSize(ft->size));
+      ft->rangeMax
+          = getMaxRange(ft->name, ft->size, ft->resolution, ft->hasSign == True, ft->offset, NULL, reservedCountForSize(ft->size));
     }
     else
     {
@@ -412,20 +435,26 @@ extern void fillFieldType(bool doUnitFixup)
       }
 
       // Number of top-of-range sentinels (Unknown / OutOfRange / Reserved). An explicit
-      // SPECIAL_VALUES() override wins; otherwise a field whose value range spans the full unsigned
-      // bit width reserves none (the "all values valid" idiom, e.g. ISO device instance with
-      // .rangeMax = 7). The check compares against the UNSIGNED raw maximum (2^size - 1) so it is
-      // independent of display units -- a signed angle shown as 0..2pi rad (SI) or 0..360 deg
-      // (user) both stay below it, while a genuinely full field reaches it. 64-bit fields can't be
+      // SPECIAL_VALUES() override wins. Otherwise the count is the gap between the raw bit-width
+      // maximum and the field's raw rangeMax, capped at the width-derived count. This makes it
+      // follow a rangeMax that was pulled up: a field spanning its full UNSIGNED width reserves
+      // none (the "all values valid" idiom), and a LOOKUP whose enumeration names values in the
+      // sentinel region (getMaxRange raised its rangeMax for them) reserves only the sentinels left
+      // above the named values. The threshold is the full UNSIGNED width (2^size - 1) so it is
+      // independent of sign and of display-unit fixups: a signed field, or a field whose rangeMax
+      // was clamped to a rounder display value (e.g. an angle to 360 deg), never reaches it and so
+      // keeps its full count -- matching the value the decoder strips. 64-bit fields can't be
       // distinguished by double precision, so they rely on the override.
       if (f->reservedOverride != 0)
       {
         f->reservedCount = count;
       }
-      else if (f->size != 0 && f->size < 64 && f->resolution > 0.0 && !isnan(f->rangeMax)
-               && (uint64_t) (f->rangeMax / f->resolution + 0.5) >= (UINT64_C(1) << f->size) - 1)
+      else if (f->size != 0 && f->size < 64 && f->resolution > 0.0 && !isnan(f->rangeMax))
       {
-        f->reservedCount = 0;
+        uint64_t rawMax      = (UINT64_C(1) << f->size) - 1;
+        uint64_t rawRangeMax = (uint64_t) (f->rangeMax / f->resolution + 0.5);
+
+        f->reservedCount = (rawRangeMax >= rawMax) ? 0 : (uint8_t) CB_MIN(rawMax - rawRangeMax, (uint64_t) bySize);
       }
       else
       {

--- a/analyzer/fieldtype.h
+++ b/analyzer/fieldtype.h
@@ -157,6 +157,20 @@ typedef enum Bool
   True
 } Bool;
 
+// How a field type signals "data not available" (and, for integers, out-of-range/reserved).
+// Emitted per field type as <Sentinels>; for TOP_OF_RANGE the actual reserved raw values are
+// given per field as <UnknownValue>/<OutOfRangeValue>/<ReservedValue> (they vary by bit width).
+typedef enum Sentinels
+{
+  SENTINEL_NONE = 0,     // No unavailable encoding (identifier, filler, or structured field)
+  SENTINEL_TOP_OF_RANGE, // The top 1-3 raw integer values are reserved (Unknown/OutOfRange/Reserved)
+  SENTINEL_NAN,          // IEEE-754 Not-a-Number
+  SENTINEL_EMPTY_STRING, // An empty string (after trimming end-of-string bytes) means unavailable
+  SENTINEL_VARIABLE      // Depends on the data type resolved through the companion DYNAMIC_FIELD_KEY
+} Sentinels;
+
+extern const char *sentinelsName(Sentinels s);
+
 typedef struct PhysicalQuantity
 {
   const char *name;        // Name, UPPERCASE_WITH_UNDERSCORE
@@ -457,6 +471,9 @@ struct FieldType
   double rangeMin;
   double rangeMax;
 
+  // How this field type signals "data not available"
+  Sentinels sentinels;
+
   // How to print this field
   FieldPrintFunctionType  pf;
   const PhysicalQuantity *physical;
@@ -469,6 +486,7 @@ struct FieldType
 FieldType fieldTypeList[] = {
     // Numeric types
     {.name        = "NUMBER",
+     .sentinels   = SENTINEL_TOP_OF_RANGE,
      .description = "Number",
      .encodingDescription
      = "Binary numbers are little endian. Number fields that are at least two bits in length use the highest positive value to "
@@ -569,6 +587,7 @@ FieldType fieldTypeList[] = {
      .baseFieldType = "UNSIGNED_FIXED_POINT_NUMBER"},
 
     {.name        = "FLOAT",
+     .sentinels   = SENTINEL_NAN,
      .description = "32 bit IEEE-754 floating point number",
      .size        = 32,
      .hasSign     = True,
@@ -602,6 +621,7 @@ FieldType fieldTypeList[] = {
      .pf                  = fieldPrintDecimal},
 
     {.name                = "LOOKUP",
+     .sentinels           = SENTINEL_TOP_OF_RANGE,
      .description         = "Number value where each value encodes for a distinct meaning",
      .encodingDescription = "Each lookup has a LookupEnumeration defining what the possible values mean",
      .comment = "For almost all lookups the list of values is known with some precision, but it is quite possible that a value "
@@ -614,7 +634,8 @@ FieldType fieldTypeList[] = {
      .pf      = fieldPrintLookup,
      .v1Type  = "Lookup table"},
 
-    {.name = "INDIRECT_LOOKUP",
+    {.name      = "INDIRECT_LOOKUP",
+     .sentinels = SENTINEL_TOP_OF_RANGE,
      .description
      = "Number value where each value encodes for a distinct meaning but the meaning also depends on the value in another field",
      .encodingDescription = "Each lookup has a LookupIndirectEnumeration defining what the possible values mean",
@@ -634,6 +655,7 @@ FieldType fieldTypeList[] = {
      .v1Type  = "Bitfield"},
 
     {.name        = "DYNAMIC_FIELD_KEY",
+     .sentinels   = SENTINEL_TOP_OF_RANGE,
      .description = "Number value where each value encodes for a distinct meaning including a fieldtype of the next variable "
                     "field; generally followed by an optional DYNAMIC_FIELD_LENGTH and a DYNAMIC_FIELD_VALUE field; when there is "
                     "no DYNAMIC_FIELD_LENGTH field the length is contained in the lookup table",
@@ -644,11 +666,13 @@ FieldType fieldTypeList[] = {
      .pf      = fieldPrintLookup},
 
     {.name        = "DYNAMIC_FIELD_LENGTH",
+     .sentinels   = SENTINEL_TOP_OF_RANGE,
      .description = "Number value that indicates the length of the following DYNAMIC_FIELD_VALUE field",
      .hasSign     = False,
      .pf          = fieldPrintNumber},
 
     {.name        = "DYNAMIC_FIELD_VALUE",
+     .sentinels   = SENTINEL_VARIABLE,
      .description = "Variable field whose type and length is dynamic",
      .encodingDescription
      = "The type definition of the field is defined by an earlier LookupFieldTypeEnumeration field. The length is defined by "
@@ -682,7 +706,10 @@ FieldType fieldTypeList[] = {
      .resolution    = 0.001,
      .baseFieldType = "UFIX16"},
 
-    {.name = "UFIX8_2", .description = "Fixed point unsigned with 2 digits resolution", .resolution = 0.01, .baseFieldType = "UFIX8"},
+    {.name          = "UFIX8_2",
+     .description   = "Fixed point unsigned with 2 digits resolution",
+     .resolution    = 0.01,
+     .baseFieldType = "UFIX8"},
 
     {.name          = "UFIX16_6",
      .description   = "Fixed point unsigned with 6 digits resolution",
@@ -913,9 +940,19 @@ FieldType fieldTypeList[] = {
 
     {.name = "VOLUME_UFIX32_DML", .description = "Volume", .resolution = 0.0001, .physical = &VOLUME, .baseFieldType = "UFIX32"},
 
-    {.name = "TIME", .description = "Time", .physical = &TIME, .pf = fieldPrintTime, .v1Type = "Time"},
+    {.name        = "TIME",
+     .sentinels   = SENTINEL_TOP_OF_RANGE,
+     .description = "Time",
+     .physical    = &TIME,
+     .pf          = fieldPrintTime,
+     .v1Type      = "Time"},
 
-    {.name = "DURATION", .description = "Duration", .physical = &DURATION, .pf = fieldPrintTime, .v1Type = "Time"},
+    {.name        = "DURATION",
+     .sentinels   = SENTINEL_TOP_OF_RANGE,
+     .description = "Duration",
+     .physical    = &DURATION,
+     .pf          = fieldPrintTime,
+     .v1Type      = "Time"},
 
     {.name          = "DURATION_UFIX32",
      .description   = "Duration",
@@ -1045,6 +1082,7 @@ FieldType fieldTypeList[] = {
      .v1Type        = "Integer"},
 
     {.name                = "DATE",
+     .sentinels           = SENTINEL_TOP_OF_RANGE,
      .description         = "Date",
      .encodingDescription = "The date, in days since 1 January 1970.",
      .physical            = &DATE,
@@ -1137,7 +1175,11 @@ FieldType fieldTypeList[] = {
      .physical      = &ELECTRICAL_CURRENT,
      .baseFieldType = "FIX32"},
 
-    {.name = "CURRENT_UFIX16_CA", .description = "Electrical current", .resolution = 0.01, .physical = &ELECTRICAL_CURRENT, .baseFieldType = "UFIX16"},
+    {.name          = "CURRENT_UFIX16_CA",
+     .description   = "Electrical current",
+     .resolution    = 0.01,
+     .physical      = &ELECTRICAL_CURRENT,
+     .baseFieldType = "UFIX16"},
 
     {.name          = "VOLTAGE_FIX32_10MV",
      .description   = "Voltage",
@@ -1152,17 +1194,43 @@ FieldType fieldTypeList[] = {
      .physical      = &ELECTRICAL_CHARGE,
      .baseFieldType = "FIX32"},
 
-    {.name = "ENERGY_UFIX32_CKWH", .description = "Electrical energy", .resolution = 0.01, .physical = &ELECTRICAL_ENERGY, .baseFieldType = "UFIX32"},
+    {.name          = "ENERGY_UFIX32_CKWH",
+     .description   = "Electrical energy",
+     .resolution    = 0.01,
+     .physical      = &ELECTRICAL_ENERGY,
+     .baseFieldType = "UFIX32"},
 
-    {.name = "POWER_UFIX16_CW", .description = "Electrical power", .resolution = 0.01, .physical = &ELECTRICAL_POWER, .baseFieldType = "UFIX16"},
+    {.name          = "POWER_UFIX16_CW",
+     .description   = "Electrical power",
+     .resolution    = 0.01,
+     .physical      = &ELECTRICAL_POWER,
+     .baseFieldType = "UFIX16"},
 
-    {.name = "POWER_UFIX32_CW", .description = "Electrical power", .resolution = 0.01, .physical = &ELECTRICAL_POWER, .baseFieldType = "UFIX32"},
+    {.name          = "POWER_UFIX32_CW",
+     .description   = "Electrical power",
+     .resolution    = 0.01,
+     .physical      = &ELECTRICAL_POWER,
+     .baseFieldType = "UFIX32"},
 
-    {.name = "POWER_FIX16", .description = "Electrical power", .resolution = 1, .physical = &ELECTRICAL_POWER, .baseFieldType = "FIX16"},
+    {.name          = "POWER_FIX16",
+     .description   = "Electrical power",
+     .resolution    = 1,
+     .physical      = &ELECTRICAL_POWER,
+     .baseFieldType = "FIX16"},
 
-    {.name = "DURATION_UFIX16_CHOUR", .description = "Time duration, 0.01 hour resolution", .resolution = 36, .size = 16, .hasSign = False, .baseFieldType = "DURATION"},
+    {.name          = "DURATION_UFIX16_CHOUR",
+     .description   = "Time duration, 0.01 hour resolution",
+     .resolution    = 36,
+     .size          = 16,
+     .hasSign       = False,
+     .baseFieldType = "DURATION"},
 
-    {.name = "DURATION_UFIX16_CDAY", .description = "Time duration, 0.01 day resolution", .resolution = 864, .size = 16, .hasSign = False, .baseFieldType = "DURATION"},
+    {.name          = "DURATION_UFIX16_CDAY",
+     .description   = "Time duration, 0.01 day resolution",
+     .resolution    = 864,
+     .size          = 16,
+     .hasSign       = False,
+     .baseFieldType = "DURATION"},
 
     {.name          = "PERCENTAGE_UFIX16_D",
      .description   = "Percentage, unsigned, 0.1% resolution",
@@ -1282,11 +1350,23 @@ FieldType fieldTypeList[] = {
      .physical      = &ELECTRICAL_REACTIVE_POWER,
      .baseFieldType = "UINT32"},
 
-    {.name = "PERCENTAGE_UINT8", .description = "Percentage, unsigned", .unit = "%", .physical = &DIMENSIONLESS_RATIO, .baseFieldType = "UINT8"},
+    {.name          = "PERCENTAGE_UINT8",
+     .description   = "Percentage, unsigned",
+     .unit          = "%",
+     .physical      = &DIMENSIONLESS_RATIO,
+     .baseFieldType = "UINT8"},
 
-    {.name = "PERCENTAGE_UINT8_HIGHRES", .description = "Percentage, unsigned", .unit = "%", .physical = &DIMENSIONLESS_RATIO, .baseFieldType = "UINT8"},
+    {.name          = "PERCENTAGE_UINT8_HIGHRES",
+     .description   = "Percentage, unsigned",
+     .unit          = "%",
+     .physical      = &DIMENSIONLESS_RATIO,
+     .baseFieldType = "UINT8"},
 
-    {.name = "PERCENTAGE_INT8", .description = "Percentage", .unit = "%", .physical = &DIMENSIONLESS_RATIO, .baseFieldType = "INT8"},
+    {.name          = "PERCENTAGE_INT8",
+     .description   = "Percentage",
+     .unit          = "%",
+     .physical      = &DIMENSIONLESS_RATIO,
+     .baseFieldType = "INT8"},
 
     {.name          = "PERCENTAGE_FIX16",
      .description   = "Percentage, high precision",
@@ -1570,10 +1650,15 @@ FieldType fieldTypeList[] = {
      .baseFieldType = "UNSIGNED_ALMANAC_PARAMETER"},
 
     // Stringy types
-    {.name                = "STRING_FIX",
-     .description         = "A fixed length string containing single byte codepoints.",
-     .encodingDescription = "The length of the string is determined by the PGN field definition. Trailing bytes have been observed "
-                            "as '@', ' ', 0x0 or 0xff.",
+    {.name        = "STRING_FIX",
+     .sentinels   = SENTINEL_EMPTY_STRING,
+     .description = "A fixed length string containing single byte codepoints.",
+     .encodingDescription
+     = "This always takes up as many bytes as defined in the field definition. "
+       "Three end-of-string characters are seen: 0xff (255), the standard NMEA 2000 \"Unknown\" value. '@', the standard "
+       "AIS \"Unknown\" value for strings. 0x00, the standard C end-of-string marker. "
+       "It is encouraged to stop the string at the first such character (and not make it part of the string). An empty "
+       "string can be considered to make the entire field \"Unknown\".",
      .comment
      = "It is unclear what character sets are allowed/supported. Possibly UTF-8 but it could also be that only ASCII values "
        "are supported.",
@@ -1581,6 +1666,7 @@ FieldType fieldTypeList[] = {
      .v1Type = "ASCII text"},
 
     {.name        = "STRING_LZ",
+     .sentinels   = SENTINEL_EMPTY_STRING,
      .description = "A varying length string containing single byte codepoints encoded with a length byte and terminating zero.",
      .encodingDescription = "The length of the string is determined by a starting length byte. It also contains a terminating "
                             "zero byte. The length byte includes neither the zero byte or itself. The character encoding is UTF-8.",
@@ -1591,7 +1677,8 @@ FieldType fieldTypeList[] = {
      .pf           = fieldPrintStringLZ,
      .v1Type       = "ASCII string starting with length byte"},
 
-    {.name = "STRING_LAU",
+    {.name      = "STRING_LAU",
+     .sentinels = SENTINEL_EMPTY_STRING,
      .description
      = "A varying length string containing double or single byte codepoints encoded with a length byte and terminating zero.",
      .encodingDescription = "The length of the string is determined by a starting length byte. This count includes the length and "
@@ -1641,12 +1728,13 @@ FieldType fieldTypeList[] = {
      .pf           = fieldPrintVariable},
 
     {.name                = "FIELD_INDEX",
+     .sentinels           = SENTINEL_TOP_OF_RANGE,
      .description         = "Field Index",
      .resolution          = 1,
      .size                = 8,
      .hasSign             = False,
-     .rangeMin            = 1, // Minimum field index (.Order)
-     .rangeMax            = 253,
+     .rangeMin            = 0,   // Order - 1
+     .rangeMax            = 252, // 255 minus the 3 top-of-range sentinels (Unknown/OutOfRange/Reserved)
      .encodingDescription = "Index of the specified field in the PGN referenced.",
      .pf                  = fieldPrintNumber}};
 

--- a/common/version.h
+++ b/common/version.h
@@ -21,4 +21,4 @@ limitations under the License.
 // x-release-please-start-version
 #define VERSION "7.0.0"
 // x-release-please-end-version
-#define SCHEMA_VERSION "2.4.0"
+#define SCHEMA_VERSION "2.5.0"

--- a/docs/canboat.html
+++ b/docs/canboat.html
@@ -21357,6 +21357,14 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
     <h3 id="ft-NUMBER">NUMBER - Number</h3><p/><p>
             Encoding:
             Binary numbers are little endian. Number fields that are at least two bits in length use the highest positive value to represent unknown. Number fields with at least 7 as maximum (3 bits unsigned, 4 bits signed) use the highest value minus one as an error indicator. This is likely also true for numbers where 3 is the maximum value, but there are few fields that have this length -- certainly as a number, there are a lot of lookup fields of two bits length.  For signed numbers the maximum values are the maximum positive value and that minus 1, not the all-ones bit encoding which is the maximum negative value.</p><p>
+          Unavailable value:
+          
+              the top of the integer range is reserved. The most positive value means
+              "data not available"; depending on the bit width the next one or two values
+              below it mean "out of range" and "reserved". Each individual field lists its
+              actual reserved values as Unknown, OutOfRange and Reserved. For a lookup, a
+              value that the enumeration names explicitly is a real value and is not reserved.
+            </p><p>
           For more information see:
           <a href="https://en.wikipedia.org/wiki/Binary_number">https://en.wikipedia.org/wiki/Binary_number</a></p><h3 id="ft-FLOAT">FLOAT - 32 bit IEEE-754 floating point number</h3><p/><p>32 bits
             
@@ -21364,22 +21372,89 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
               
             number
             </p><p>
+          Unavailable value:
+          
+              the IEEE-754 Not-a-Number value means the field is unavailable.
+            </p><p>
           For more information see:
           <a href="https://en.wikipedia.org/wiki/IEEE_754">https://en.wikipedia.org/wiki/IEEE_754</a></p><h3 id="ft-DECIMAL">DECIMAL - An unsigned numeric value where each byte holds the binary value of two decimal digits (0..99)</h3><p/><p>
             Encoding:
-            Each byte contains the binary value of two decimal digits, so 1234 is represented by 2 bytes containing 0x0c (=12) and 0x22 (=34). This is NOT BCD. A value with an odd number of digits is padded with a trailing zero, e.g. the 9-digit MMSI 512000953 is encoded as 5120009530 (5 bytes).</p><h3 id="ft-LOOKUP">LOOKUP - Number value where each value encodes for a distinct meaning</h3><p>For almost all lookups the list of values is known with some precision, but it is quite possible that a value occurs that has no corresponding textual explanation. Generally the same special values for Error (max value - 1) and Unknown (max value) that are used for plain numbers are also valid for lookups, but some lookups define a lookup key/value pair for the maximum possible value in that field. In fact, recent additions to PGNs such as alerts have two bit lookup fields that specify four actual valid values. This makes it impossible to send an unknown value for these fields. </p><p>
+            Each byte contains the binary value of two decimal digits, so 1234 is represented by 2 bytes containing 0x0c (=12) and 0x22 (=34). This is NOT BCD. A value with an odd number of digits is padded with a trailing zero, e.g. the 9-digit MMSI 512000953 is encoded as 5120009530 (5 bytes).</p><p>
+          Unavailable value:
+          
+              none. This field type has no unavailable encoding (it is an identifier, filler
+              or structured field).
+            </p><h3 id="ft-LOOKUP">LOOKUP - Number value where each value encodes for a distinct meaning</h3><p>For almost all lookups the list of values is known with some precision, but it is quite possible that a value occurs that has no corresponding textual explanation. Generally the same special values for Error (max value - 1) and Unknown (max value) that are used for plain numbers are also valid for lookups, but some lookups define a lookup key/value pair for the maximum possible value in that field. In fact, recent additions to PGNs such as alerts have two bit lookup fields that specify four actual valid values. This makes it impossible to send an unknown value for these fields. </p><p>
             Encoding:
-            Each lookup has a LookupEnumeration defining what the possible values mean</p><h3 id="ft-INDIRECT_LOOKUP">INDIRECT_LOOKUP - Number value where each value encodes for a distinct meaning but the meaning also depends on the value in another field</h3><p>For almost all lookups the list of values is known with some precision, but it is quite possible that a value occurs that has no corresponding textual explanation.</p><p>
+            Each lookup has a LookupEnumeration defining what the possible values mean</p><p>
+          Unavailable value:
+          
+              the top of the integer range is reserved. The most positive value means
+              "data not available"; depending on the bit width the next one or two values
+              below it mean "out of range" and "reserved". Each individual field lists its
+              actual reserved values as Unknown, OutOfRange and Reserved. For a lookup, a
+              value that the enumeration names explicitly is a real value and is not reserved.
+            </p><h3 id="ft-INDIRECT_LOOKUP">INDIRECT_LOOKUP - Number value where each value encodes for a distinct meaning but the meaning also depends on the value in another field</h3><p>For almost all lookups the list of values is known with some precision, but it is quite possible that a value occurs that has no corresponding textual explanation.</p><p>
             Encoding:
-            Each lookup has a LookupIndirectEnumeration defining what the possible values mean</p><h3 id="ft-BITLOOKUP">BITLOOKUP - Number value where each bit value encodes for a distinct meaning</h3><p>For almost all lookups the list of values is known with some precision, but it is quite possible that a value occurs that has no corresponding textual explanation.</p><p>
+            Each lookup has a LookupIndirectEnumeration defining what the possible values mean</p><p>
+          Unavailable value:
+          
+              the top of the integer range is reserved. The most positive value means
+              "data not available"; depending on the bit width the next one or two values
+              below it mean "out of range" and "reserved". Each individual field lists its
+              actual reserved values as Unknown, OutOfRange and Reserved. For a lookup, a
+              value that the enumeration names explicitly is a real value and is not reserved.
+            </p><h3 id="ft-BITLOOKUP">BITLOOKUP - Number value where each bit value encodes for a distinct meaning</h3><p>For almost all lookups the list of values is known with some precision, but it is quite possible that a value occurs that has no corresponding textual explanation.</p><p>
             Encoding:
-            Each LookupBit has a LookupBitEnumeration defining what the possible values mean. A bitfield can have any combination of bits set.</p><h3 id="ft-DYNAMIC_FIELD_KEY">DYNAMIC_FIELD_KEY - Number value where each value encodes for a distinct meaning including a fieldtype of the next variable field; generally followed by an optional DYNAMIC_FIELD_LENGTH and a DYNAMIC_FIELD_VALUE field; when there is no DYNAMIC_FIELD_LENGTH field the length is contained in the lookup table</h3><p>These values have been determined by reverse engineering, given the known values it is anticipated that there are unkown enumeration values and some known values have incorrect datatypes</p><p>
+            Each LookupBit has a LookupBitEnumeration defining what the possible values mean. A bitfield can have any combination of bits set.</p><p>
+          Unavailable value:
+          
+              none. This field type has no unavailable encoding (it is an identifier, filler
+              or structured field).
+            </p><h3 id="ft-DYNAMIC_FIELD_KEY">DYNAMIC_FIELD_KEY - Number value where each value encodes for a distinct meaning including a fieldtype of the next variable field; generally followed by an optional DYNAMIC_FIELD_LENGTH and a DYNAMIC_FIELD_VALUE field; when there is no DYNAMIC_FIELD_LENGTH field the length is contained in the lookup table</h3><p>These values have been determined by reverse engineering, given the known values it is anticipated that there are unkown enumeration values and some known values have incorrect datatypes</p><p>
             Encoding:
-            Each lookup has a LookupFieldTypeEnumeration defining what the possible values mean</p><h3 id="ft-DYNAMIC_FIELD_LENGTH">DYNAMIC_FIELD_LENGTH - Number value that indicates the length of the following DYNAMIC_FIELD_VALUE field</h3><p/><h3 id="ft-DYNAMIC_FIELD_VALUE">DYNAMIC_FIELD_VALUE - Variable field whose type and length is dynamic</h3><p/><p>
+            Each lookup has a LookupFieldTypeEnumeration defining what the possible values mean</p><p>
+          Unavailable value:
+          
+              the top of the integer range is reserved. The most positive value means
+              "data not available"; depending on the bit width the next one or two values
+              below it mean "out of range" and "reserved". Each individual field lists its
+              actual reserved values as Unknown, OutOfRange and Reserved. For a lookup, a
+              value that the enumeration names explicitly is a real value and is not reserved.
+            </p><h3 id="ft-DYNAMIC_FIELD_LENGTH">DYNAMIC_FIELD_LENGTH - Number value that indicates the length of the following DYNAMIC_FIELD_VALUE field</h3><p/><p>
+          Unavailable value:
+          
+              the top of the integer range is reserved. The most positive value means
+              "data not available"; depending on the bit width the next one or two values
+              below it mean "out of range" and "reserved". Each individual field lists its
+              actual reserved values as Unknown, OutOfRange and Reserved. For a lookup, a
+              value that the enumeration names explicitly is a real value and is not reserved.
+            </p><h3 id="ft-DYNAMIC_FIELD_VALUE">DYNAMIC_FIELD_VALUE - Variable field whose type and length is dynamic</h3><p/><p>
             Encoding:
-            The type definition of the field is defined by an earlier LookupFieldTypeEnumeration field. The length is defined by the preceding length field or the length determined by the lookup value.</p><h3 id="ft-TIME">TIME - Time</h3><p/><p>
+            The type definition of the field is defined by an earlier LookupFieldTypeEnumeration field. The length is defined by the preceding length field or the length determined by the lookup value.</p><p>
+          Unavailable value:
+          
+              depends on the data type that is resolved at run time through the companion
+              DYNAMIC_FIELD_KEY field.
+            </p><h3 id="ft-TIME">TIME - Time</h3><p/><p>
+          Unavailable value:
+          
+              the top of the integer range is reserved. The most positive value means
+              "data not available"; depending on the bit width the next one or two values
+              below it mean "out of range" and "reserved". Each individual field lists its
+              actual reserved values as Unknown, OutOfRange and Reserved. For a lookup, a
+              value that the enumeration names explicitly is a real value and is not reserved.
+            </p><p>
           For more information see:
-          <a href="https://en.wikipedia.org/wiki/Time">https://en.wikipedia.org/wiki/Time</a></p><h3 id="ft-DURATION">DURATION - Duration</h3><p/><h3 id="ft-DATE">DATE - Date</h3><p/><p>16 bits
+          <a href="https://en.wikipedia.org/wiki/Time">https://en.wikipedia.org/wiki/Time</a></p><h3 id="ft-DURATION">DURATION - Duration</h3><p/><p>
+          Unavailable value:
+          
+              the top of the integer range is reserved. The most positive value means
+              "data not available"; depending on the bit width the next one or two values
+              below it mean "out of range" and "reserved". Each individual field lists its
+              actual reserved values as Unknown, OutOfRange and Reserved. For a lookup, a
+              value that the enumeration names explicitly is a real value and is not reserved.
+            </p><h3 id="ft-DATE">DATE - Date</h3><p/><p>16 bits
             
                 unsigned
               
@@ -21387,29 +21462,77 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
             </p><p>
             Encoding:
             The date, in days since 1 January 1970.</p><p>
+          Unavailable value:
+          
+              the top of the integer range is reserved. The most positive value means
+              "data not available"; depending on the bit width the next one or two values
+              below it mean "out of range" and "reserved". Each individual field lists its
+              actual reserved values as Unknown, OutOfRange and Reserved. For a lookup, a
+              value that the enumeration names explicitly is a real value and is not reserved.
+            </p><p>
           For more information see:
           <a href="https://en.wikipedia.org/wiki/Calendar_date">https://en.wikipedia.org/wiki/Calendar_date</a></p><h3 id="ft-PGN">PGN - Parameter Group Number</h3><p/><p>
             Encoding:
-            A 24 bit number referring to a PGN</p><h3 id="ft-ISO_NAME">ISO_NAME - ISO NAME field</h3><p/><p>64 bits
+            A 24 bit number referring to a PGN</p><p>
+          Unavailable value:
+          
+              none. This field type has no unavailable encoding (it is an identifier, filler
+              or structured field).
+            </p><h3 id="ft-ISO_NAME">ISO_NAME - ISO NAME field</h3><p/><p>64 bits
             
                 unsigned
               
             number
             </p><p>
             Encoding:
-            A 64 bit field containing the ISO name, e.g. all fields produced by PGN 60928. Use the definition of PGN 60928 to explain the subfields.</p><h3 id="ft-STRING_FIX">STRING_FIX - A fixed length string containing single byte codepoints.</h3><p>It is unclear what character sets are allowed/supported. Possibly UTF-8 but it could also be that only ASCII values are supported.</p><p>
+            A 64 bit field containing the ISO name, e.g. all fields produced by PGN 60928. Use the definition of PGN 60928 to explain the subfields.</p><p>
+          Unavailable value:
+          
+              none. This field type has no unavailable encoding (it is an identifier, filler
+              or structured field).
+            </p><h3 id="ft-STRING_FIX">STRING_FIX - A fixed length string containing single byte codepoints.</h3><p>It is unclear what character sets are allowed/supported. Possibly UTF-8 but it could also be that only ASCII values are supported.</p><p>
             Encoding:
-            The length of the string is determined by the PGN field definition. Trailing bytes have been observed as '@', ' ', 0x0 or 0xff.</p><h3 id="ft-STRING_LZ">STRING_LZ - A varying length string containing single byte codepoints encoded with a length byte and terminating zero.</h3><p>This type of string is found only in SonicHub and Fusion brand specific PGNs. SonicHub is no longer produced. The use of the Fusion specific PGNs is no longer very prevalent now that there are generic PGNs for audio/media devices.</p><p>
+            This always takes up as many bytes as defined in the field definition. Three end-of-string characters are seen: 0xff (255), the standard NMEA 2000 "Unknown" value. '@', the standard AIS "Unknown" value for strings. 0x00, the standard C end-of-string marker. It is encouraged to stop the string at the first such character (and not make it part of the string). An empty string can be considered to make the entire field "Unknown".</p><p>
+          Unavailable value:
+          
+              an empty string (after trimming end-of-string bytes such as 0xff, 0x00 and '@')
+              means the whole field is unavailable.
+            </p><h3 id="ft-STRING_LZ">STRING_LZ - A varying length string containing single byte codepoints encoded with a length byte and terminating zero.</h3><p>This type of string is found only in SonicHub and Fusion brand specific PGNs. SonicHub is no longer produced. The use of the Fusion specific PGNs is no longer very prevalent now that there are generic PGNs for audio/media devices.</p><p>
             Encoding:
-            The length of the string is determined by a starting length byte. It also contains a terminating zero byte. The length byte includes neither the zero byte or itself. The character encoding is UTF-8.</p><h3 id="ft-STRING_LAU">STRING_LAU - A varying length string containing double or single byte codepoints encoded with a length byte and terminating zero.</h3><p/><p>
+            The length of the string is determined by a starting length byte. It also contains a terminating zero byte. The length byte includes neither the zero byte or itself. The character encoding is UTF-8.</p><p>
+          Unavailable value:
+          
+              an empty string (after trimming end-of-string bytes such as 0xff, 0x00 and '@')
+              means the whole field is unavailable.
+            </p><h3 id="ft-STRING_LAU">STRING_LAU - A varying length string containing double or single byte codepoints encoded with a length byte and terminating zero.</h3><p/><p>
             Encoding:
-            The length of the string is determined by a starting length byte. This count includes the length and type bytes, so any empty string contains count 2. The 2nd byte contains 0 for UNICODE or 1 for ASCII.</p><h3 id="ft-BINARY">BINARY - Binary field</h3><p/><p>
+            The length of the string is determined by a starting length byte. This count includes the length and type bytes, so any empty string contains count 2. The 2nd byte contains 0 for UNICODE or 1 for ASCII.</p><p>
+          Unavailable value:
+          
+              an empty string (after trimming end-of-string bytes such as 0xff, 0x00 and '@')
+              means the whole field is unavailable.
+            </p><h3 id="ft-BINARY">BINARY - Binary field</h3><p/><p>
             Encoding:
-            Unspecified content consisting of any number of bits.</p><h3 id="ft-RESERVED">RESERVED - Reserved field</h3><p>NMEA reserved for future expansion and/or to align next data on byte boundary</p><p>
+            Unspecified content consisting of any number of bits.</p><p>
+          Unavailable value:
+          
+              none. This field type has no unavailable encoding (it is an identifier, filler
+              or structured field).
+            </p><h3 id="ft-RESERVED">RESERVED - Reserved field</h3><p>NMEA reserved for future expansion and/or to align next data on byte boundary</p><p>
             Encoding:
-            All reserved bits shall be 1</p><h3 id="ft-SPARE">SPARE - Spare field</h3><p>This is like a reserved field but originates from other sources where unused fields shall be 0, like the AIS ITU-1371 standard.</p><p>
+            All reserved bits shall be 1</p><p>
+          Unavailable value:
+          
+              none. This field type has no unavailable encoding (it is an identifier, filler
+              or structured field).
+            </p><h3 id="ft-SPARE">SPARE - Spare field</h3><p>This is like a reserved field but originates from other sources where unused fields shall be 0, like the AIS ITU-1371 standard.</p><p>
             Encoding:
-            All spare bits shall be 0</p><h3 id="ft-MMSI">MMSI - MMSI</h3><p/><p>32 bits
+            All spare bits shall be 0</p><p>
+          Unavailable value:
+          
+              none. This field type has no unavailable encoding (it is an identifier, filler
+              or structured field).
+            </p><h3 id="ft-MMSI">MMSI - MMSI</h3><p/><p>32 bits
             
                 unsigned
               
@@ -21417,17 +21540,35 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
             </p><p>
             Encoding:
             The MMSI is encoded as a 32 bit number, but is always printed as a 9 digit number and should be considered as a string. The first three or four digits are special, see the USCG link for a detailed explanation.</p><p>
+          Unavailable value:
+          
+              none. This field type has no unavailable encoding (it is an identifier, filler
+              or structured field).
+            </p><p>
           For more information see:
           <a href="https://navcen.uscg.gov/maritime-mobile-service-identity">https://navcen.uscg.gov/maritime-mobile-service-identity</a></p><h3 id="ft-VARIABLE">VARIABLE - Variable</h3><p/><p>
             Encoding:
-            The definition of the field is that of the reference PGN and reference field, this is totally variable.</p><h3 id="ft-FIELD_INDEX">FIELD_INDEX - Field Index</h3><p/><p>8 bits
+            The definition of the field is that of the reference PGN and reference field, this is totally variable.</p><p>
+          Unavailable value:
+          
+              none. This field type has no unavailable encoding (it is an identifier, filler
+              or structured field).
+            </p><h3 id="ft-FIELD_INDEX">FIELD_INDEX - Field Index</h3><p/><p>8 bits
             
                 unsigned
               
             number
             </p><p>
             Encoding:
-            Index of the specified field in the PGN referenced.</p><h2 id="lookup-enumerations">Lookup enumerations</h2><h3 id="lookup-LIGHTING_COMMAND">LIGHTING_COMMAND
+            Index of the specified field in the PGN referenced.</p><p>
+          Unavailable value:
+          
+              the top of the integer range is reserved. The most positive value means
+              "data not available"; depending on the bit width the next one or two values
+              below it mean "out of range" and "reserved". Each individual field lists its
+              actual reserved values as Unknown, OutOfRange and Reserved. For a lookup, a
+              value that the enumeration names explicitly is a real value and is not reserved.
+            </p><h2 id="lookup-enumerations">Lookup enumerations</h2><h3 id="lookup-LIGHTING_COMMAND">LIGHTING_COMMAND
         (0 - 7)
       </h3><table><tr><th>Value</th><th>Description</th></tr><tr><td>0</td><td>Idle</td></tr><tr><td>1</td><td>Detect Devices</td></tr><tr><td>2</td><td>Reboot</td></tr><tr><td>3</td><td>Factory Reset</td></tr><tr><td>4</td><td>Powering Up</td></tr></table><h3 id="lookup-INDUSTRY_CODE">INDUSTRY_CODE
         (0 - 7)

--- a/docs/canboat.json
+++ b/docs/canboat.json
@@ -1,6 +1,6 @@
 
   {
-    "SchemaVersion":"2.4.0",
+    "SchemaVersion":"2.5.0",
     "Comment":"See https://github.com/canboat/canboat for the full source code",
     "CreatorCode":"Canboat NMEA2000 Analyzer",
     "License":"Apache License Version 2.0",
@@ -241,68 +241,79 @@
         "Name":"NUMBER",
       "Description":"Number",
       "EncodingDescription":"Binary numbers are little endian. Number fields that are at least two bits in length use the highest positive value to represent unknown. Number fields with at least 7 as maximum (3 bits unsigned, 4 bits signed) use the highest value minus one as an error indicator. This is likely also true for numbers where 3 is the maximum value, but there are few fields that have this length -- certainly as a number, there are a lot of lookup fields of two bits length.  For signed numbers the maximum values are the maximum positive value and that minus 1, not the all-ones bit encoding which is the maximum negative value.",
-      "URL":"https://en.wikipedia.org/wiki/Binary_number"
+      "URL":"https://en.wikipedia.org/wiki/Binary_number",
+      "Sentinels":"TopOfRange"
       },
     {
         "Name":"FLOAT",
       "Description":"32 bit IEEE-754 floating point number",
       "URL":"https://en.wikipedia.org/wiki/IEEE_754",
       "Bits":32,
-      "Signed":true
+      "Signed":true,
+      "Sentinels":"NaN"
       },
     {
         "Name":"DECIMAL",
       "Description":"An unsigned numeric value where each byte holds the binary value of two decimal digits (0..99)",
       "EncodingDescription":"Each byte contains the binary value of two decimal digits, so 1234 is represented by 2 bytes containing 0x0c (=12) and 0x22 (=34). This is NOT BCD. A value with an odd number of digits is padded with a trailing zero, e.g. the 9-digit MMSI 512000953 is encoded as 5120009530 (5 bytes).",
-      "Signed":false
+      "Signed":false,
+      "Sentinels":"None"
       },
     {
         "Name":"LOOKUP",
       "Description":"Number value where each value encodes for a distinct meaning",
       "EncodingDescription":"Each lookup has a LookupEnumeration defining what the possible values mean",
       "Comment":"For almost all lookups the list of values is known with some precision, but it is quite possible that a value occurs that has no corresponding textual explanation. Generally the same special values for Error (max value - 1) and Unknown (max value) that are used for plain numbers are also valid for lookups, but some lookups define a lookup key/value pair for the maximum possible value in that field. In fact, recent additions to PGNs such as alerts have two bit lookup fields that specify four actual valid values. This makes it impossible to send an unknown value for these fields. ",
-      "Signed":false
+      "Signed":false,
+      "Sentinels":"TopOfRange"
       },
     {
         "Name":"INDIRECT_LOOKUP",
       "Description":"Number value where each value encodes for a distinct meaning but the meaning also depends on the value in another field",
       "EncodingDescription":"Each lookup has a LookupIndirectEnumeration defining what the possible values mean",
       "Comment":"For almost all lookups the list of values is known with some precision, but it is quite possible that a value occurs that has no corresponding textual explanation.",
-      "Signed":false
+      "Signed":false,
+      "Sentinels":"TopOfRange"
       },
     {
         "Name":"BITLOOKUP",
       "Description":"Number value where each bit value encodes for a distinct meaning",
       "EncodingDescription":"Each LookupBit has a LookupBitEnumeration defining what the possible values mean. A bitfield can have any combination of bits set.",
-      "Comment":"For almost all lookups the list of values is known with some precision, but it is quite possible that a value occurs that has no corresponding textual explanation."
+      "Comment":"For almost all lookups the list of values is known with some precision, but it is quite possible that a value occurs that has no corresponding textual explanation.",
+      "Sentinels":"None"
       },
     {
         "Name":"DYNAMIC_FIELD_KEY",
       "Description":"Number value where each value encodes for a distinct meaning including a fieldtype of the next variable field; generally followed by an optional DYNAMIC_FIELD_LENGTH and a DYNAMIC_FIELD_VALUE field; when there is no DYNAMIC_FIELD_LENGTH field the length is contained in the lookup table",
       "EncodingDescription":"Each lookup has a LookupFieldTypeEnumeration defining what the possible values mean",
       "Comment":"These values have been determined by reverse engineering, given the known values it is anticipated that there are unkown enumeration values and some known values have incorrect datatypes",
-      "Signed":false
+      "Signed":false,
+      "Sentinels":"TopOfRange"
       },
     {
         "Name":"DYNAMIC_FIELD_LENGTH",
       "Description":"Number value that indicates the length of the following DYNAMIC_FIELD_VALUE field",
-      "Signed":false
+      "Signed":false,
+      "Sentinels":"TopOfRange"
       },
     {
         "Name":"DYNAMIC_FIELD_VALUE",
       "Description":"Variable field whose type and length is dynamic",
-      "EncodingDescription":"The type definition of the field is defined by an earlier LookupFieldTypeEnumeration field. The length is defined by the preceding length field or the length determined by the lookup value."
+      "EncodingDescription":"The type definition of the field is defined by an earlier LookupFieldTypeEnumeration field. The length is defined by the preceding length field or the length determined by the lookup value.",
+      "Sentinels":"Variable"
       },
     {
         "Name":"TIME",
       "Description":"Time",
       "URL":"https://en.wikipedia.org/wiki/Time",
-      "Unit":"s"
+      "Unit":"s",
+      "Sentinels":"TopOfRange"
       },
     {
         "Name":"DURATION",
       "Description":"Duration",
-      "Unit":"s"
+      "Unit":"s",
+      "Sentinels":"TopOfRange"
       },
     {
         "Name":"DATE",
@@ -311,54 +322,63 @@
       "URL":"https://en.wikipedia.org/wiki/Calendar_date",
       "Bits":16,
       "Unit":"d",
-      "Signed":false
+      "Signed":false,
+      "Sentinels":"TopOfRange"
       },
     {
         "Name":"PGN",
       "Description":"Parameter Group Number",
-      "EncodingDescription":"A 24 bit number referring to a PGN"
+      "EncodingDescription":"A 24 bit number referring to a PGN",
+      "Sentinels":"None"
       },
     {
         "Name":"ISO_NAME",
       "Description":"ISO NAME field",
       "EncodingDescription":"A 64 bit field containing the ISO name, e.g. all fields produced by PGN 60928. Use the definition of PGN 60928 to explain the subfields.",
-      "Bits":64
+      "Bits":64,
+      "Sentinels":"None"
       },
     {
         "Name":"STRING_FIX",
       "Description":"A fixed length string containing single byte codepoints.",
-      "EncodingDescription":"The length of the string is determined by the PGN field definition. Trailing bytes have been observed as '@', ' ', 0x0 or 0xff.",
-      "Comment":"It is unclear what character sets are allowed/supported. Possibly UTF-8 but it could also be that only ASCII values are supported."
+      "EncodingDescription":"This always takes up as many bytes as defined in the field definition. Three end-of-string characters are seen: 0xff (255), the standard NMEA 2000 \"Unknown\" value. '@', the standard AIS \"Unknown\" value for strings. 0x00, the standard C end-of-string marker. It is encouraged to stop the string at the first such character (and not make it part of the string). An empty string can be considered to make the entire field \"Unknown\".",
+      "Comment":"It is unclear what character sets are allowed/supported. Possibly UTF-8 but it could also be that only ASCII values are supported.",
+      "Sentinels":"EmptyString"
       },
     {
         "Name":"STRING_LZ",
       "Description":"A varying length string containing single byte codepoints encoded with a length byte and terminating zero.",
       "EncodingDescription":"The length of the string is determined by a starting length byte. It also contains a terminating zero byte. The length byte includes neither the zero byte or itself. The character encoding is UTF-8.",
       "Comment":"This type of string is found only in SonicHub and Fusion brand specific PGNs. SonicHub is no longer produced. The use of the Fusion specific PGNs is no longer very prevalent now that there are generic PGNs for audio/media devices.",
-      "VariableSize":true
+      "VariableSize":true,
+      "Sentinels":"EmptyString"
       },
     {
         "Name":"STRING_LAU",
       "Description":"A varying length string containing double or single byte codepoints encoded with a length byte and terminating zero.",
       "EncodingDescription":"The length of the string is determined by a starting length byte. This count includes the length and type bytes, so any empty string contains count 2. The 2nd byte contains 0 for UNICODE or 1 for ASCII.",
-      "VariableSize":true
+      "VariableSize":true,
+      "Sentinels":"EmptyString"
       },
     {
         "Name":"BINARY",
       "Description":"Binary field",
-      "EncodingDescription":"Unspecified content consisting of any number of bits."
+      "EncodingDescription":"Unspecified content consisting of any number of bits.",
+      "Sentinels":"None"
       },
     {
         "Name":"RESERVED",
       "Description":"Reserved field",
       "EncodingDescription":"All reserved bits shall be 1",
-      "Comment":"NMEA reserved for future expansion and/or to align next data on byte boundary"
+      "Comment":"NMEA reserved for future expansion and/or to align next data on byte boundary",
+      "Sentinels":"None"
       },
     {
         "Name":"SPARE",
       "Description":"Spare field",
       "EncodingDescription":"All spare bits shall be 0",
-      "Comment":"This is like a reserved field but originates from other sources where unused fields shall be 0, like the AIS ITU-1371 standard."
+      "Comment":"This is like a reserved field but originates from other sources where unused fields shall be 0, like the AIS ITU-1371 standard.",
+      "Sentinels":"None"
       },
     {
         "Name":"MMSI",
@@ -366,20 +386,23 @@
       "EncodingDescription":"The MMSI is encoded as a 32 bit number, but is always printed as a 9 digit number and should be considered as a string. The first three or four digits are special, see the USCG link for a detailed explanation.",
       "URL":"https://navcen.uscg.gov/maritime-mobile-service-identity",
       "Bits":32,
-      "Signed":false
+      "Signed":false,
+      "Sentinels":"None"
       },
     {
         "Name":"VARIABLE",
       "Description":"Variable",
       "EncodingDescription":"The definition of the field is that of the reference PGN and reference field, this is totally variable.",
-      "VariableSize":true
+      "VariableSize":true,
+      "Sentinels":"None"
       },
     {
         "Name":"FIELD_INDEX",
       "Description":"Field Index",
       "EncodingDescription":"Index of the specified field in the PGN referenced.",
       "Bits":8,
-      "Signed":false
+      "Signed":false,
+      "Sentinels":"TopOfRange"
       }
     ],
     "MissingEnumerations":[
@@ -5643,6 +5666,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ISO_CONTROL"
           },
@@ -6214,6 +6240,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2044,
+            "UnknownValue":2047,
+            "OutOfRangeValue":2046,
+            "ReservedValue":2045,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MANUFACTURER_CODE"
           },
@@ -6257,6 +6286,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"INDIRECT_LOOKUP",
             "LookupIndirectEnumeration":"DEVICE_FUNCTION",
             "LookupIndirectEnumerationFieldOrder":7
@@ -6282,6 +6314,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":125,
+            "UnknownValue":127,
+            "OutOfRangeValue":126,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DEVICE_CLASS"
           },
@@ -6312,6 +6346,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"INDUSTRY_CODE"
           },
@@ -6356,6 +6391,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2044,
+            "UnknownValue":2047,
+            "OutOfRangeValue":2046,
+            "ReservedValue":2045,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MANUFACTURER_CODE"
           },
@@ -6380,6 +6418,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"INDUSTRY_CODE"
           },
@@ -6705,6 +6744,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":65532,
+            "UnknownValue":65535,
+            "OutOfRangeValue":65534,
+            "ReservedValue":65533,
             "FieldType":"DYNAMIC_FIELD_KEY",
             "LookupFieldTypeEnumeration":"VICTRON_VREG",
             "PartOfPrimaryKey":true
@@ -6906,6 +6948,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2044,
+            "UnknownValue":2047,
+            "OutOfRangeValue":2046,
+            "ReservedValue":2045,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MANUFACTURER_CODE"
           },
@@ -6930,6 +6975,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"INDUSTRY_CODE"
           },
@@ -7365,6 +7411,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"POWER_FACTOR"
           },
@@ -7576,6 +7623,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"POWER_FACTOR"
           },
@@ -7788,6 +7836,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"POWER_FACTOR"
           },
@@ -8000,6 +8049,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"POWER_FACTOR"
           },
@@ -8262,6 +8312,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"POWER_FACTOR"
           },
@@ -8474,6 +8525,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"POWER_FACTOR"
           },
@@ -8686,6 +8738,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"POWER_FACTOR"
           },
@@ -8898,6 +8951,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"POWER_FACTOR"
           },
@@ -9086,6 +9140,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2044,
+            "UnknownValue":2047,
+            "OutOfRangeValue":2046,
+            "ReservedValue":2045,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MANUFACTURER_CODE"
           },
@@ -9129,6 +9186,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"INDIRECT_LOOKUP",
             "LookupIndirectEnumeration":"DEVICE_FUNCTION",
             "LookupIndirectEnumerationFieldOrder":7
@@ -9154,6 +9214,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":125,
+            "UnknownValue":127,
+            "OutOfRangeValue":126,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DEVICE_CLASS"
           },
@@ -9184,6 +9246,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"INDUSTRY_CODE"
           },
@@ -9239,6 +9302,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2044,
+            "UnknownValue":2047,
+            "OutOfRangeValue":2046,
+            "ReservedValue":2045,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MANUFACTURER_CODE"
           },
@@ -9263,6 +9329,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"INDUSTRY_CODE"
           },
@@ -10784,6 +10851,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"BOOT_STATE"
           },
@@ -10863,6 +10931,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"TEMPERATURE_SOURCE",
             "PartOfPrimaryKey":true
@@ -11278,6 +11349,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"TANK_TYPE"
           },
@@ -11390,6 +11463,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ACCESS_LEVEL"
           },
@@ -11585,6 +11659,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"TANK_TYPE"
           },
@@ -11697,6 +11773,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SEATALK_ALARM_STATUS"
           },
@@ -11711,6 +11790,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SEATALK_ALARM_ID"
           },
@@ -11725,6 +11807,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SEATALK_ALARM_GROUP"
           },
@@ -12911,6 +12996,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":65532,
+            "UnknownValue":65535,
+            "OutOfRangeValue":65534,
+            "ReservedValue":65533,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"CZONE_ALARM_TYPE"
           },
@@ -14032,6 +14120,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DEVICE_MODEL"
           },
@@ -14062,6 +14153,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_AP_STATUS"
           },
@@ -14141,6 +14235,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DEVICE_MODEL"
           },
@@ -14238,6 +14335,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DEVICE_MODEL"
           },
@@ -14346,6 +14446,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DEVICE_MODEL"
           },
@@ -14443,6 +14546,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DEVICE_MODEL"
           },
@@ -15966,6 +16072,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_AUTOPILOT_MODE_CLASS"
           },
@@ -15980,6 +16089,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_AUTOPILOT_MODE"
           },
@@ -16118,6 +16230,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_AP_MODE"
           },
@@ -16907,6 +17022,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SEATALK_ALARM_ID"
           },
@@ -16921,6 +17039,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SEATALK_ALARM_GROUP"
           },
@@ -17283,6 +17404,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":65532,
+            "UnknownValue":65535,
+            "OutOfRangeValue":65534,
+            "ReservedValue":65533,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SEATALK_PILOT_MODE_16"
           },
@@ -17552,6 +17676,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIRMAR_DEPTH_QUALITY_FACTOR"
           },
@@ -18408,6 +18534,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"FIELD_INDEX"
           },
           {
@@ -18478,6 +18607,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"PRIORITY"
           },
@@ -18520,6 +18651,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"FIELD_INDEX"
           },
           {
@@ -18590,6 +18724,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"PGN_ERROR_CODE"
           },
@@ -18604,6 +18740,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"TRANSMISSION_INTERVAL"
           },
@@ -18634,6 +18772,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"PARAMETER_FIELD"
           }
@@ -18702,6 +18842,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2044,
+            "UnknownValue":2047,
+            "OutOfRangeValue":2046,
+            "ReservedValue":2045,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MANUFACTURER_CODE"
           },
@@ -18726,6 +18869,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"INDUSTRY_CODE"
           },
@@ -18781,6 +18925,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"FIELD_INDEX"
           },
           {
@@ -18800,6 +18947,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"FIELD_INDEX"
           }
         ]
@@ -18865,6 +19015,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2044,
+            "UnknownValue":2047,
+            "OutOfRangeValue":2046,
+            "ReservedValue":2045,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MANUFACTURER_CODE"
           },
@@ -18889,6 +19042,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"INDUSTRY_CODE"
           },
@@ -18944,6 +19098,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"FIELD_INDEX"
           },
           {
@@ -18963,6 +19120,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"FIELD_INDEX"
           },
           {
@@ -19035,6 +19195,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2044,
+            "UnknownValue":2047,
+            "OutOfRangeValue":2046,
+            "ReservedValue":2045,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MANUFACTURER_CODE"
           },
@@ -19059,6 +19222,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"INDUSTRY_CODE"
           },
@@ -19114,6 +19278,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"FIELD_INDEX"
           },
           {
@@ -19133,6 +19300,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"FIELD_INDEX"
           },
           {
@@ -19205,6 +19375,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2044,
+            "UnknownValue":2047,
+            "OutOfRangeValue":2046,
+            "ReservedValue":2045,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MANUFACTURER_CODE"
           },
@@ -19229,6 +19402,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"INDUSTRY_CODE"
           },
@@ -19284,6 +19458,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"FIELD_INDEX"
           },
           {
@@ -19303,6 +19480,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"FIELD_INDEX"
           },
           {
@@ -19338,6 +19518,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"PGN_LIST_FUNCTION"
           },
@@ -19911,6 +20094,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2044,
+            "UnknownValue":2047,
+            "OutOfRangeValue":2046,
+            "ReservedValue":2045,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MANUFACTURER_CODE"
           },
@@ -19935,6 +20121,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"INDUSTRY_CODE"
           },
@@ -20075,6 +20262,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SEATALK_PILOT_MODE"
           },
@@ -20224,6 +20414,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SEATALK_PILOT_HULL_TYPE"
           },
@@ -20347,6 +20540,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -20361,6 +20557,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -20501,6 +20700,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SEATALK_DEVICE_ID"
           }
@@ -20604,6 +20806,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SEATALK_NETWORK_GROUP"
           },
@@ -20618,6 +20823,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SEATALK_SHARED"
           },
@@ -20764,6 +20972,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SEATALK_NETWORK_GROUP"
           },
@@ -20803,6 +21014,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SEATALK_DISPLAY_COLOR"
           },
@@ -20949,6 +21163,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SEATALK_KEYSTROKE"
           },
@@ -21078,6 +21295,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"FUSION_COMMAND"
           }
@@ -21180,6 +21400,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"FUSION_SIRIUS_COMMAND"
           },
@@ -21442,6 +21665,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"FUSION_MUTE_COMMAND"
           }
@@ -21768,6 +21994,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"FUSION_POWER_STATE"
           }
@@ -21985,6 +22214,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIRMAR_CALIBRATE_FUNCTION"
           },
@@ -21999,6 +22231,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIRMAR_CALIBRATE_STATUS"
           },
@@ -22266,6 +22501,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -22362,6 +22598,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -22687,6 +22924,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIRMAR_TEMPERATURE_INSTANCE",
             "PartOfPrimaryKey":true
@@ -23303,6 +23541,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIRMAR_TRANSMISSION_INTERVAL"
           },
@@ -23455,6 +23694,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":65532,
+            "UnknownValue":65535,
+            "OutOfRangeValue":65534,
+            "ReservedValue":65533,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MARETRON_PRODUCT_CODE"
           },
@@ -23501,6 +23743,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MARETRON_STATUS_DEVIATION"
           }
@@ -23689,6 +23934,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":65532,
+            "UnknownValue":65535,
+            "OutOfRangeValue":65534,
+            "ReservedValue":65533,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MARETRON_PRODUCT_CODE"
           },
@@ -23719,6 +23967,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MARETRON_OPCODE"
           },
@@ -24240,6 +24491,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"GARMIN_BACKLIGHT_LEVEL"
           }
@@ -24405,6 +24659,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"GARMIN_BACKLIGHT_LEVEL"
           }
@@ -24570,6 +24827,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"GARMIN_COLOR"
           }
@@ -24622,6 +24882,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_TYPE"
           },
@@ -24636,6 +24898,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_CATEGORY"
           },
@@ -24865,6 +25129,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_TRIGGER_CONDITION"
           },
@@ -24879,6 +25145,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_THRESHOLD_STATUS"
           },
@@ -24909,6 +25177,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_STATE"
           }
@@ -24936,6 +25207,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_TYPE"
           },
@@ -24950,6 +25223,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_CATEGORY"
           },
@@ -25122,6 +25397,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_TYPE"
           },
@@ -25136,6 +25413,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_CATEGORY"
           },
@@ -25259,6 +25538,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_LANGUAGE_ID"
           },
@@ -25302,6 +25584,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_TYPE"
           },
@@ -25316,6 +25600,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_CATEGORY"
           },
@@ -25541,6 +25827,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_TYPE"
           },
@@ -25555,6 +25843,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_CATEGORY"
           },
@@ -25772,6 +26062,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_TYPE"
           },
@@ -25786,6 +26078,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_CATEGORY"
           },
@@ -26002,6 +26296,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SYSTEM_TIME",
             "PartOfPrimaryKey":true
@@ -26113,6 +26409,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"CONTROLLER_STATE"
           },
@@ -26127,6 +26424,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"CONTROLLER_STATE"
           },
@@ -26141,6 +26439,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"EQUIPMENT_STATUS"
           },
@@ -26248,6 +26547,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"CERTIFICATION_LEVEL"
           },
@@ -26363,6 +26665,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MOB_STATUS"
           },
@@ -26405,6 +26708,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MOB_POSITION_SOURCE"
           },
@@ -26501,6 +26805,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DIRECTION_REFERENCE"
           },
@@ -26575,6 +26880,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"LOW_BATTERY"
           },
@@ -26612,6 +26918,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -26626,6 +26933,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -26640,6 +26948,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -26654,6 +26963,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -26668,6 +26978,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"STEERING_MODE"
           },
@@ -26682,6 +26993,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"TURN_MODE"
           },
@@ -26696,6 +27008,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DIRECTION_REFERENCE"
           },
@@ -26720,6 +27033,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DIRECTION_RUDDER"
           },
@@ -26926,6 +27240,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DIRECTION_RUDDER"
           },
@@ -27079,6 +27394,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DIRECTION_REFERENCE"
           },
@@ -27340,6 +27656,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MAGNETIC_VARIATION",
             "PartOfPrimaryKey":true
@@ -27424,6 +27742,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENGINE_INSTANCE",
             "PartOfPrimaryKey":true
@@ -27516,6 +27837,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENGINE_INSTANCE",
             "PartOfPrimaryKey":true
@@ -28092,6 +28416,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENGINE_INSTANCE",
             "PartOfPrimaryKey":true
@@ -28107,6 +28434,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"GEAR_STATUS"
           },
@@ -28786,6 +29114,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENGINE_INSTANCE",
             "PartOfPrimaryKey":true
@@ -28886,6 +29217,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENGINE_INSTANCE",
             "PartOfPrimaryKey":true
@@ -29108,6 +29442,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29122,6 +29457,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29136,6 +29472,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29150,6 +29487,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29164,6 +29502,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29178,6 +29517,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29192,6 +29532,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29206,6 +29547,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29220,6 +29562,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29234,6 +29577,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29248,6 +29592,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29262,6 +29607,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29276,6 +29622,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29290,6 +29637,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29304,6 +29652,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29318,6 +29667,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29332,6 +29682,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29346,6 +29697,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29360,6 +29712,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29374,6 +29727,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29388,6 +29742,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29402,6 +29757,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29416,6 +29772,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29430,6 +29787,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29444,6 +29802,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29458,6 +29817,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29472,6 +29832,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -29486,6 +29847,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           }
@@ -29973,6 +30335,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AC_LINE"
           },
@@ -30186,6 +30549,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"LINE"
           },
@@ -30200,6 +30564,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"WAVEFORM"
           },
@@ -30379,6 +30744,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"TANK_TYPE"
           },
@@ -30485,6 +30852,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DC_SOURCE",
             "PartOfPrimaryKey":true
@@ -30638,6 +31008,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"CHARGER_STATE"
           },
@@ -30652,6 +31024,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"CHARGER_MODE"
           },
@@ -30666,6 +31040,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -30680,6 +31055,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -30888,6 +31264,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"INVERTER_STATE"
           },
@@ -30902,6 +31280,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -30973,6 +31352,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -31015,6 +31395,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"CHARGING_ALGORITHM"
           },
@@ -31029,6 +31411,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"CHARGER_MODE"
           },
@@ -31044,6 +31428,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DEVICE_TEMP_STATE"
           },
@@ -31058,6 +31444,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -31072,6 +31459,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -31168,6 +31556,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -31182,6 +31571,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"INVERTER_MODE"
           },
@@ -31196,6 +31587,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -31295,6 +31687,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AGS_MODE"
           },
@@ -31349,6 +31743,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"BATTERY_TYPE"
           },
@@ -31363,6 +31759,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -31387,6 +31784,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"BATTERY_VOLTAGE"
           },
@@ -31401,6 +31800,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"BATTERY_CHEMISTRY"
           },
@@ -31532,6 +31933,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AGS_OPERATING_STATE"
           },
@@ -31546,6 +31949,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AGS_GENERATING_STATE"
           },
@@ -31560,6 +31965,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AGS_ON_REASON"
           },
@@ -31574,6 +31982,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AGS_OFF_REASON"
           }
@@ -32173,6 +32584,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"CONVERTER_STATE"
           },
@@ -32187,6 +32601,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"GOOD_WARNING_ERROR"
           },
@@ -32201,6 +32616,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"GOOD_WARNING_ERROR"
           },
@@ -32215,6 +32631,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"GOOD_WARNING_ERROR"
           },
@@ -32229,6 +32646,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"GOOD_WARNING_ERROR"
           },
@@ -32778,6 +33196,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"THRUSTER_DIRECTION_CONTROL"
           },
@@ -32792,6 +33212,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -32806,6 +33227,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"THRUSTER_RETRACT_CONTROL"
           },
@@ -32916,6 +33338,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"THRUSTER_MOTOR_TYPE"
           },
@@ -33171,6 +33595,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"WATER_REFERENCE"
           },
@@ -33473,6 +33900,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DIRECTION_REFERENCE"
           },
@@ -33631,6 +34059,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -34378,6 +34807,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"WINDLASS_DIRECTION"
           },
@@ -34392,6 +34822,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -34406,6 +34837,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SPEED_TYPE"
           },
@@ -34441,6 +34873,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -34455,6 +34888,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -34469,6 +34903,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -34483,6 +34918,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -34585,6 +35021,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"WINDLASS_DIRECTION"
           },
@@ -34599,6 +35036,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"WINDLASS_MOTION"
           },
@@ -34613,6 +35051,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"RODE_TYPE"
           },
@@ -34673,6 +35112,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DOCKING_STATUS"
           },
@@ -35006,6 +35446,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DIRECTION_REFERENCE"
           },
@@ -35208,6 +35649,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"GNS_METHOD"
           },
@@ -35222,6 +35665,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DIRECTION_REFERENCE"
           },
@@ -35396,6 +35840,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"GNS"
           },
@@ -35410,6 +35856,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"GNS_METHOD"
           },
@@ -35535,6 +35983,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"GNS"
           },
@@ -35664,6 +36114,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -35832,6 +36284,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -35883,6 +36337,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":14,
+            "UnknownValue":15,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"NAV_STATUS"
           },
@@ -35971,6 +36426,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -36138,6 +36595,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -36316,6 +36775,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -36502,6 +36963,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SHIP_TYPE"
           },
@@ -36544,6 +37008,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"POSITION_FIX_DEVICE"
           },
@@ -36677,6 +37143,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -36715,6 +37183,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -36973,6 +37443,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"POSITION_FIX_DEVICE"
           },
@@ -37008,6 +37480,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -37333,6 +37807,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"RESIDUAL_MODE"
           },
@@ -37357,6 +37833,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -37446,6 +37923,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DIRECTION_REFERENCE"
           },
@@ -37460,6 +37938,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -37474,6 +37953,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -37488,6 +37968,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"BEARING_MODE"
           },
@@ -37740,6 +38221,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DIRECTION"
           },
@@ -37754,6 +38236,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -37877,6 +38360,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DIRECTION_REFERENCE"
           },
@@ -37995,6 +38479,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MARK_TYPE"
           },
@@ -38065,6 +38551,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DIRECTION_REFERENCE"
           },
@@ -38079,6 +38566,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"BEARING_MODE"
           },
@@ -38139,6 +38627,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MARK_TYPE"
           },
@@ -38153,6 +38643,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MARK_TYPE"
           },
@@ -38284,6 +38776,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"GNSS_MODE"
           },
@@ -38298,6 +38791,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DGNSS_MODE"
           },
@@ -38312,6 +38806,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -38362,6 +38857,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -38415,6 +38911,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"GNSS_MODE"
           },
@@ -38429,6 +38926,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"GNSS_MODE"
           },
@@ -38536,6 +39034,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"RANGE_RESIDUAL_MODE"
           },
@@ -38664,6 +39163,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SATELLITE_STATUS"
           },
@@ -39577,6 +40078,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"GNS"
           },
@@ -39609,6 +40112,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"STATION_HEALTH"
           },
@@ -39766,6 +40271,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SERIAL_BIT_RATE"
           },
@@ -39780,6 +40287,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SERIAL_DETECTION_MODE"
           },
@@ -39794,6 +40302,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DIFFERENTIAL_SOURCE"
           },
@@ -39808,6 +40318,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DIFFERENTIAL_MODE"
           },
@@ -39932,6 +40444,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"GNS"
           },
@@ -39962,6 +40476,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SERIAL_BIT_RATE"
           },
@@ -39976,6 +40492,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SERIAL_DETECTION_MODE"
           },
@@ -39990,6 +40507,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -40014,6 +40532,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DIFFERENTIAL_SOURCE"
           },
@@ -40321,6 +40841,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -40373,6 +40895,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -40494,6 +41018,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -40639,6 +41165,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -40681,6 +41209,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"POSITION_FIX_DEVICE"
           }
@@ -40709,6 +41239,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -40785,6 +41317,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SHIP_TYPE"
           },
@@ -40948,6 +41483,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"POSITION_FIX_DEVICE"
           },
@@ -40986,6 +41523,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -41024,6 +41563,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -41076,6 +41617,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -41194,6 +41737,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -41246,6 +41791,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -41321,6 +41868,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -41373,6 +41922,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -41440,6 +41991,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -41608,6 +42161,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -41762,6 +42317,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"TELEPHONE_MODE"
           },
@@ -41810,6 +42368,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -41862,6 +42422,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -41916,6 +42478,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -41968,6 +42532,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -42068,6 +42634,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -42120,6 +42688,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -42169,6 +42739,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -42221,6 +42793,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -42269,6 +42843,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -42309,6 +42885,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -42383,6 +42961,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -42465,6 +43045,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -42517,6 +43099,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -42675,6 +43259,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -42727,6 +43313,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -42835,6 +43423,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -42887,6 +43477,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -42967,6 +43559,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"TX_RX_MODE"
           },
@@ -43115,6 +43709,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ZONE_SIZE"
           },
@@ -43165,6 +43760,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -43217,6 +43814,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"TX_RX_MODE"
           },
@@ -43313,6 +43912,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"STATION_TYPE"
           },
@@ -43337,6 +43938,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SHIP_TYPE"
           },
@@ -43371,6 +43975,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"REPORTING_INTERVAL"
           },
@@ -43441,6 +44047,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DSC_FORMAT"
           },
@@ -43485,6 +44094,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DSC_NATURE"
           },
@@ -43499,6 +44111,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DSC_SECOND_TELECOMMAND"
           },
@@ -43611,6 +44226,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -43691,6 +44307,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DSC_EXPANSION_DATA"
           },
@@ -43730,6 +44349,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DSC_FORMAT"
           },
@@ -43744,6 +44366,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DSC_CATEGORY"
           },
@@ -43772,6 +44397,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DSC_FIRST_TELECOMMAND"
           },
@@ -43786,6 +44414,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DSC_SECOND_TELECOMMAND"
           },
@@ -43898,6 +44529,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -43978,6 +44610,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DSC_EXPANSION_DATA"
           },
@@ -44013,6 +44648,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -44064,6 +44701,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -44118,6 +44757,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -44160,6 +44801,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SHIP_TYPE"
           },
@@ -44298,6 +44942,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"POSITION_FIX_DEVICE"
           },
@@ -44312,6 +44958,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -44382,6 +45030,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -44461,6 +45111,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -44548,6 +45200,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -44627,6 +45281,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -44765,6 +45421,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -44871,6 +45529,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":14,
+            "UnknownValue":15,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"NAV_STATUS"
           },
@@ -44944,6 +45603,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -44998,6 +45659,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -45087,6 +45750,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -45172,6 +45837,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -45308,6 +45975,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -45392,6 +46061,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_MESSAGE_ID"
           },
@@ -45444,6 +46115,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":29,
+            "UnknownValue":31,
+            "OutOfRangeValue":30,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIS_TRANSCEIVER"
           },
@@ -45740,6 +46413,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"RESIDUAL_MODE"
           },
@@ -45983,6 +46658,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"RESIDUAL_MODE"
           },
@@ -46519,6 +47196,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"WP_POSITION_RESOLUTION"
           },
@@ -46694,6 +47373,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"WP_IDENTIFICATION_METHOD"
           },
@@ -46706,6 +47386,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"WP_ROUTE_STATUS"
           }
@@ -46840,6 +47522,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"WP_NAVIGATION_METHOD"
           },
@@ -46852,6 +47535,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"WP_IDENTIFICATION_METHOD"
           },
@@ -46864,6 +47548,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"WP_ROUTE_STATUS"
           },
@@ -47298,6 +47984,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"WP_NAVIGATION_METHOD"
           },
@@ -47980,6 +48667,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"WIND_REFERENCE",
             "PartOfPrimaryKey":true
@@ -48129,6 +48817,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"TEMPERATURE_SOURCE",
             "PartOfPrimaryKey":true
@@ -48144,6 +48834,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"HUMIDITY_SOURCE"
           },
@@ -48258,6 +48949,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"TEMPERATURE_SOURCE",
             "PartOfPrimaryKey":true
@@ -48365,6 +49059,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"HUMIDITY_SOURCE",
             "PartOfPrimaryKey":true
@@ -48472,6 +49169,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"PRESSURE_SOURCE",
             "PartOfPrimaryKey":true
@@ -48561,6 +49261,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"PRESSURE_SOURCE",
             "PartOfPrimaryKey":true
@@ -48651,6 +49354,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"TEMPERATURE_SOURCE",
             "PartOfPrimaryKey":true
@@ -48715,6 +49421,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"RESIDUAL_MODE"
           },
@@ -48729,6 +49437,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"TIDE"
           },
@@ -48894,6 +49603,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"RESIDUAL_MODE"
           },
@@ -49054,6 +49765,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"RESIDUAL_MODE"
           },
@@ -49068,6 +49781,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"FLOOD_STATE"
           },
@@ -49269,6 +49983,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"RESIDUAL_MODE"
           },
@@ -49401,6 +50117,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"WIND_REFERENCE"
           },
@@ -49511,6 +50228,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"RESIDUAL_MODE"
           },
@@ -49643,6 +50362,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"WIND_REFERENCE"
           },
@@ -49881,6 +50601,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -50263,6 +50984,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"LIGHTING_COMMAND"
           },
@@ -50681,6 +51403,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -51124,6 +51847,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -51469,6 +52193,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":61,
+            "UnknownValue":63,
+            "OutOfRangeValue":62,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"WATERMAKER_STATE"
           },
@@ -51483,6 +52209,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -51497,6 +52224,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -51511,6 +52239,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -51525,6 +52254,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -51539,6 +52269,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -51553,6 +52284,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OK_WARNING"
           },
@@ -51567,6 +52299,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -51581,6 +52314,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OK_WARNING"
           },
@@ -51595,6 +52329,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OK_WARNING"
           },
@@ -51609,6 +52344,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OK_WARNING"
           },
@@ -51623,6 +52359,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OK_WARNING"
           },
@@ -51637,6 +52374,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OK_WARNING"
           },
@@ -51837,6 +52575,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_SOURCE"
           },
@@ -51917,6 +52658,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_ZONE"
           },
@@ -51931,6 +52675,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_SOURCE"
           },
@@ -51979,6 +52726,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_PLAY_STATUS"
           },
@@ -52029,6 +52779,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_REPEAT_STATUS"
           },
@@ -52043,6 +52795,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_SHUFFLE_STATUS"
           },
@@ -52091,6 +52845,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_LIKE_STATUS"
           },
@@ -52205,6 +52962,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_SOURCE"
           },
@@ -52253,6 +53013,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_TYPE"
           },
@@ -52346,6 +53109,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_ZONE"
           },
@@ -52358,6 +53124,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -52370,6 +53137,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -52430,6 +53198,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_SOURCE"
           },
@@ -52461,6 +53232,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_TYPE"
           },
@@ -52475,6 +53249,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_ZONE"
           },
@@ -52557,6 +53334,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_ID_TYPE"
           },
@@ -52617,6 +53397,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_SOURCE"
           },
@@ -52665,6 +53448,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_GROUP"
           },
@@ -52686,6 +53472,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_GROUP"
           },
@@ -52705,6 +53494,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_GROUP"
           },
@@ -52811,6 +53603,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_SOURCE"
           },
@@ -52871,6 +53666,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -52883,6 +53679,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -52989,6 +53786,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_ZONE"
           },
@@ -53026,6 +53826,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_SOURCE"
           },
@@ -53201,6 +54004,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"RESIDUAL_MODE"
           },
@@ -53215,6 +54020,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"DIRECTION_REFERENCE"
           },
@@ -53497,6 +54303,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -53511,6 +54318,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_DEFAULT_SETTINGS"
           },
@@ -53525,6 +54333,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_REGIONS"
           },
@@ -53555,6 +54365,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"VIDEO_PROTOCOLS"
           },
@@ -53592,6 +54404,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -53606,6 +54419,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_DEFAULT_SETTINGS"
           },
@@ -53620,6 +54434,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_REGIONS"
           },
@@ -53717,6 +54533,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_ZONE"
           },
@@ -53753,6 +54572,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_ZONE"
           },
@@ -53786,6 +54608,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_VOLUME_CONTROL"
           },
@@ -53800,6 +54623,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -53824,6 +54648,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_CHANNEL"
           },
@@ -53913,6 +54740,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_EQ"
           },
@@ -54011,6 +54841,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"BLUETOOTH_STATUS"
           },
@@ -54079,6 +54912,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"BLUETOOTH_SOURCE_STATUS"
           },
@@ -54093,6 +54928,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -54107,6 +54943,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -54144,6 +54981,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_ZONE"
           },
@@ -54284,6 +55124,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_EQ"
           },
@@ -54298,6 +55141,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_FILTER"
           },
@@ -54348,6 +55194,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ENTERTAINMENT_CHANNEL"
           }
@@ -54377,6 +55226,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2044,
+            "UnknownValue":2047,
+            "OutOfRangeValue":2046,
+            "ReservedValue":2045,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MANUFACTURER_CODE"
           },
@@ -54401,6 +55253,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"INDUSTRY_CODE"
           },
@@ -54508,6 +55361,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_CONTROL"
           },
@@ -54637,6 +55493,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_CONTROL"
           },
@@ -54651,6 +55510,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_TUNING"
           },
@@ -54814,6 +55676,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_CONTROL"
           },
@@ -54927,6 +55792,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_CONTROL"
           },
@@ -54941,6 +55809,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_SOURCE"
           }
@@ -55038,6 +55909,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_CONTROL"
           },
@@ -55176,6 +56050,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_CONTROL"
           },
@@ -55190,6 +56067,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"FUSION_MUTE_COMMAND"
           }
@@ -55287,6 +56167,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_CONTROL"
           },
@@ -55301,6 +56184,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_TUNING"
           },
@@ -55464,6 +56350,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_CONTROL"
           },
@@ -55478,6 +56367,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_PLAYLIST"
           },
@@ -55659,6 +56551,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_CONTROL"
           },
@@ -55781,6 +56676,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_CONTROL"
           },
@@ -55903,6 +56801,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_CONTROL"
           },
@@ -56025,6 +56926,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_CONTROL"
           },
@@ -56195,6 +57099,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_CONTROL"
           },
@@ -56308,6 +57215,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_CONTROL"
           },
@@ -56437,6 +57347,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_CONTROL"
           },
@@ -56566,6 +57479,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_CONTROL"
           }
@@ -56663,6 +57579,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_CONTROL"
           },
@@ -56778,6 +57697,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SONICHUB_CONTROL"
           },
@@ -57890,6 +58812,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AUTOMATIC_MANUAL"
           },
@@ -57904,6 +58829,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SBAS_SV"
           },
@@ -59007,6 +59935,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_TYPE"
           },
@@ -59021,6 +59951,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_CATEGORY"
           },
@@ -59243,6 +60175,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -60307,6 +61240,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"FUSION_SOURCE_TYPE"
           },
@@ -60524,6 +61460,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":65532,
+            "UnknownValue":65535,
+            "OutOfRangeValue":65534,
+            "ReservedValue":65533,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"FUSION_PLAY_STATUS"
           },
@@ -61652,6 +62591,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           },
@@ -61803,6 +62745,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           }
@@ -61890,6 +62835,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           }
@@ -61993,6 +62941,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           }
@@ -62188,6 +63139,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"FUSION_RADIO_SOURCE",
             "PartOfPrimaryKey":true
@@ -62589,6 +63543,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"YES_NO"
           }
@@ -62945,6 +63902,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":4294967292,
+            "UnknownValue":4294967295,
+            "OutOfRangeValue":4294967294,
+            "ReservedValue":4294967293,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"FUSION_REPEAT_STATUS"
           }
@@ -63032,6 +63992,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":4294967292,
+            "UnknownValue":4294967295,
+            "OutOfRangeValue":4294967294,
+            "ReservedValue":4294967293,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"FUSION_SETTING"
           },
@@ -63154,6 +64117,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":4294967292,
+            "UnknownValue":4294967295,
+            "OutOfRangeValue":4294967294,
+            "ReservedValue":4294967293,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"FUSION_SETTING"
           },
@@ -63257,6 +64223,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"FUSION_MUTE_COMMAND"
           }
@@ -64364,6 +65333,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"FUSION_POWER_STATE"
           }
@@ -64512,6 +65484,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"FUSION_SIRIUS_TUNING_MODE"
           }
@@ -65381,6 +66356,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_TYPE"
           },
@@ -65395,6 +66372,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_CATEGORY"
           },
@@ -65972,6 +66951,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_TYPE"
           },
@@ -65986,6 +66967,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_CATEGORY"
           },
@@ -66109,6 +67092,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_LANGUAGE_ID"
           },
@@ -67460,6 +68446,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":65532,
+            "UnknownValue":65535,
+            "OutOfRangeValue":65534,
+            "ReservedValue":65533,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"NAVICO_DATA_TYPE"
           },
@@ -67699,6 +68688,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_TYPE"
           },
@@ -67713,6 +68704,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_CATEGORY"
           },
@@ -68158,6 +69151,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"TEMPERATURE_SOURCE",
             "PartOfPrimaryKey":true
@@ -68270,6 +69266,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":4092,
+            "UnknownValue":4095,
+            "OutOfRangeValue":4094,
+            "ReservedValue":4093,
             "FieldType":"DYNAMIC_FIELD_KEY",
             "LookupFieldTypeEnumeration":"BANDG_KEY_VALUE",
             "PartOfPrimaryKey":true
@@ -68506,6 +69505,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":4092,
+            "UnknownValue":4095,
+            "OutOfRangeValue":4094,
+            "ReservedValue":4093,
             "FieldType":"DYNAMIC_FIELD_KEY",
             "LookupFieldTypeEnumeration":"MERCURY_KEY_VALUE",
             "PartOfPrimaryKey":true
@@ -68787,6 +69789,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":65532,
+            "UnknownValue":65535,
+            "OutOfRangeValue":65534,
+            "ReservedValue":65533,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_ALARM_ID"
           },
@@ -68801,6 +69806,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":6,
+            "UnknownValue":7,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_STATE"
           },
@@ -68828,6 +69834,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"ALERT_TYPE"
           },
@@ -69140,6 +70148,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"MERCURY_COMMAND_OPCODE"
           },
@@ -70715,6 +71726,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":4092,
+            "UnknownValue":4095,
+            "OutOfRangeValue":4094,
+            "ReservedValue":4093,
             "FieldType":"DYNAMIC_FIELD_KEY",
             "LookupFieldTypeEnumeration":"BANDG_KEY_VALUE",
             "PartOfPrimaryKey":true
@@ -70756,6 +71770,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":254,
+            "UnknownValue":255,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"BANDG_DECIMALS"
           },
@@ -71541,6 +72556,8 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":13,
+            "UnknownValue":15,
+            "OutOfRangeValue":14,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"TANK_TYPE"
           },
@@ -71793,6 +72810,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -72105,6 +73123,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -72559,6 +73578,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DATA_SOURCE"
           },
@@ -72802,6 +73824,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -72816,6 +73839,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -72830,6 +73854,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -72844,6 +73869,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -72858,6 +73884,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -72872,6 +73899,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -72886,6 +73914,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -72900,6 +73929,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           },
@@ -72914,6 +73944,7 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":2,
+            "UnknownValue":3,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"OFF_ON"
           }
@@ -73398,6 +74429,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SHIP_TYPE"
           },
@@ -74256,6 +75290,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DISPLAY_GROUP"
           },
@@ -74288,6 +75325,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":16777212,
+            "UnknownValue":16777215,
+            "OutOfRangeValue":16777214,
+            "ReservedValue":16777213,
             "FieldType":"DYNAMIC_FIELD_KEY",
             "LookupFieldTypeEnumeration":"SIMNET_KEY_VALUE",
             "PartOfPrimaryKey":true
@@ -74303,6 +75343,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_KEY_OPERATION"
           },
@@ -74419,6 +75462,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DISPLAY_GROUP"
           },
@@ -74451,6 +75497,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":16777212,
+            "UnknownValue":16777215,
+            "OutOfRangeValue":16777214,
+            "ReservedValue":16777213,
             "FieldType":"DYNAMIC_FIELD_KEY",
             "LookupFieldTypeEnumeration":"SIMNET_KEY_VALUE",
             "PartOfPrimaryKey":true
@@ -74466,6 +75515,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_KEY_OPERATION"
           },
@@ -75140,6 +76192,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DISPLAY_GROUP"
           },
@@ -75291,6 +76346,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DISPLAY_GROUP"
           },
@@ -75442,6 +76500,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DISPLAY_GROUP"
           },
@@ -75593,6 +76654,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DISPLAY_GROUP"
           },
@@ -75744,6 +76808,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DISPLAY_GROUP"
           },
@@ -75895,6 +76962,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DISPLAY_GROUP"
           },
@@ -76068,6 +77138,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DISPLAY_GROUP"
           },
@@ -76219,6 +77292,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DISPLAY_GROUP"
           },
@@ -76276,6 +77352,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DIRECTION"
           },
@@ -76404,6 +77483,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DISPLAY_GROUP"
           },
@@ -76435,6 +77517,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":65532,
+            "UnknownValue":65535,
+            "OutOfRangeValue":65534,
+            "ReservedValue":65533,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_TIMER_EVENT"
           },
@@ -76586,6 +77671,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DISPLAY_GROUP"
           },
@@ -76617,6 +77705,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_ALARM_COMMAND"
           },
@@ -76641,6 +77732,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":65532,
+            "UnknownValue":65535,
+            "OutOfRangeValue":65534,
+            "ReservedValue":65533,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_ALARM_ID"
           },
@@ -76773,6 +77867,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DISPLAY_GROUP"
           },
@@ -76804,6 +77901,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_AP_EVENTS"
           },
@@ -76974,6 +78074,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DISPLAY_GROUP"
           },
@@ -77143,6 +78246,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DISPLAY_GROUP"
           },
@@ -77200,6 +78306,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DIRECTION"
           },
@@ -77328,6 +78437,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_DISPLAY_GROUP"
           },
@@ -77359,6 +78471,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_AP_EVENTS"
           },
@@ -77538,6 +78653,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":65532,
+            "UnknownValue":65535,
+            "OutOfRangeValue":65534,
+            "ReservedValue":65533,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"SIMNET_ALARM_ID"
           },
@@ -79789,6 +80907,9 @@
             "Signed":false,
             "RangeMin":0,
             "RangeMax":252,
+            "UnknownValue":255,
+            "OutOfRangeValue":254,
+            "ReservedValue":253,
             "FieldType":"LOOKUP",
             "LookupEnumeration":"AIRMAR_POST_ID"
           },

--- a/docs/canboat.xml
+++ b/docs/canboat.xml
@@ -23,7 +23,7 @@ limitations under the License.
 -->
 <?xml-stylesheet type="text/xsl" href="canboat.xsl"?>
 <PGNDefinitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <SchemaVersion>2.4.0</SchemaVersion>
+  <SchemaVersion>2.5.0</SchemaVersion>
   <Comment>See https://github.com/canboat/canboat for the full source code</Comment>
   <CreatorCode>Canboat NMEA2000 Analyzer</CreatorCode>
   <License>Apache License Version 2.0</License>
@@ -254,57 +254,68 @@ limitations under the License.
       <Description>Number</Description>
       <EncodingDescription>Binary numbers are little endian. Number fields that are at least two bits in length use the highest positive value to represent unknown. Number fields with at least 7 as maximum (3 bits unsigned, 4 bits signed) use the highest value minus one as an error indicator. This is likely also true for numbers where 3 is the maximum value, but there are few fields that have this length -- certainly as a number, there are a lot of lookup fields of two bits length.  For signed numbers the maximum values are the maximum positive value and that minus 1, not the all-ones bit encoding which is the maximum negative value.</EncodingDescription>
       <URL>https://en.wikipedia.org/wiki/Binary_number</URL>
+      <Sentinels>TopOfRange</Sentinels>
     </FieldType>
     <FieldType Name="FLOAT">
       <Description>32 bit IEEE-754 floating point number</Description>
       <URL>https://en.wikipedia.org/wiki/IEEE_754</URL>
       <Bits>32</Bits>
       <Signed>true</Signed>
+      <Sentinels>NaN</Sentinels>
     </FieldType>
     <FieldType Name="DECIMAL">
       <Description>An unsigned numeric value where each byte holds the binary value of two decimal digits (0..99)</Description>
       <EncodingDescription>Each byte contains the binary value of two decimal digits, so 1234 is represented by 2 bytes containing 0x0c (=12) and 0x22 (=34). This is NOT BCD. A value with an odd number of digits is padded with a trailing zero, e.g. the 9-digit MMSI 512000953 is encoded as 5120009530 (5 bytes).</EncodingDescription>
       <Signed>false</Signed>
+      <Sentinels>None</Sentinels>
     </FieldType>
     <FieldType Name="LOOKUP">
       <Description>Number value where each value encodes for a distinct meaning</Description>
       <EncodingDescription>Each lookup has a LookupEnumeration defining what the possible values mean</EncodingDescription>
       <Comment>For almost all lookups the list of values is known with some precision, but it is quite possible that a value occurs that has no corresponding textual explanation. Generally the same special values for Error (max value - 1) and Unknown (max value) that are used for plain numbers are also valid for lookups, but some lookups define a lookup key/value pair for the maximum possible value in that field. In fact, recent additions to PGNs such as alerts have two bit lookup fields that specify four actual valid values. This makes it impossible to send an unknown value for these fields. </Comment>
       <Signed>false</Signed>
+      <Sentinels>TopOfRange</Sentinels>
     </FieldType>
     <FieldType Name="INDIRECT_LOOKUP">
       <Description>Number value where each value encodes for a distinct meaning but the meaning also depends on the value in another field</Description>
       <EncodingDescription>Each lookup has a LookupIndirectEnumeration defining what the possible values mean</EncodingDescription>
       <Comment>For almost all lookups the list of values is known with some precision, but it is quite possible that a value occurs that has no corresponding textual explanation.</Comment>
       <Signed>false</Signed>
+      <Sentinels>TopOfRange</Sentinels>
     </FieldType>
     <FieldType Name="BITLOOKUP">
       <Description>Number value where each bit value encodes for a distinct meaning</Description>
       <EncodingDescription>Each LookupBit has a LookupBitEnumeration defining what the possible values mean. A bitfield can have any combination of bits set.</EncodingDescription>
       <Comment>For almost all lookups the list of values is known with some precision, but it is quite possible that a value occurs that has no corresponding textual explanation.</Comment>
+      <Sentinels>None</Sentinels>
     </FieldType>
     <FieldType Name="DYNAMIC_FIELD_KEY">
       <Description>Number value where each value encodes for a distinct meaning including a fieldtype of the next variable field; generally followed by an optional DYNAMIC_FIELD_LENGTH and a DYNAMIC_FIELD_VALUE field; when there is no DYNAMIC_FIELD_LENGTH field the length is contained in the lookup table</Description>
       <EncodingDescription>Each lookup has a LookupFieldTypeEnumeration defining what the possible values mean</EncodingDescription>
       <Comment>These values have been determined by reverse engineering, given the known values it is anticipated that there are unkown enumeration values and some known values have incorrect datatypes</Comment>
       <Signed>false</Signed>
+      <Sentinels>TopOfRange</Sentinels>
     </FieldType>
     <FieldType Name="DYNAMIC_FIELD_LENGTH">
       <Description>Number value that indicates the length of the following DYNAMIC_FIELD_VALUE field</Description>
       <Signed>false</Signed>
+      <Sentinels>TopOfRange</Sentinels>
     </FieldType>
     <FieldType Name="DYNAMIC_FIELD_VALUE">
       <Description>Variable field whose type and length is dynamic</Description>
       <EncodingDescription>The type definition of the field is defined by an earlier LookupFieldTypeEnumeration field. The length is defined by the preceding length field or the length determined by the lookup value.</EncodingDescription>
+      <Sentinels>Variable</Sentinels>
     </FieldType>
     <FieldType Name="TIME">
       <Description>Time</Description>
       <URL>https://en.wikipedia.org/wiki/Time</URL>
       <Unit>s</Unit>
+      <Sentinels>TopOfRange</Sentinels>
     </FieldType>
     <FieldType Name="DURATION">
       <Description>Duration</Description>
       <Unit>s</Unit>
+      <Sentinels>TopOfRange</Sentinels>
     </FieldType>
     <FieldType Name="DATE">
       <Description>Date</Description>
@@ -313,45 +324,54 @@ limitations under the License.
       <Bits>16</Bits>
       <Unit>d</Unit>
       <Signed>false</Signed>
+      <Sentinels>TopOfRange</Sentinels>
     </FieldType>
     <FieldType Name="PGN">
       <Description>Parameter Group Number</Description>
       <EncodingDescription>A 24 bit number referring to a PGN</EncodingDescription>
+      <Sentinels>None</Sentinels>
     </FieldType>
     <FieldType Name="ISO_NAME">
       <Description>ISO NAME field</Description>
       <EncodingDescription>A 64 bit field containing the ISO name, e.g. all fields produced by PGN 60928. Use the definition of PGN 60928 to explain the subfields.</EncodingDescription>
       <Bits>64</Bits>
+      <Sentinels>None</Sentinels>
     </FieldType>
     <FieldType Name="STRING_FIX">
       <Description>A fixed length string containing single byte codepoints.</Description>
-      <EncodingDescription>The length of the string is determined by the PGN field definition. Trailing bytes have been observed as '@', ' ', 0x0 or 0xff.</EncodingDescription>
+      <EncodingDescription>This always takes up as many bytes as defined in the field definition. Three end-of-string characters are seen: 0xff (255), the standard NMEA 2000 "Unknown" value. '@', the standard AIS "Unknown" value for strings. 0x00, the standard C end-of-string marker. It is encouraged to stop the string at the first such character (and not make it part of the string). An empty string can be considered to make the entire field "Unknown".</EncodingDescription>
       <Comment>It is unclear what character sets are allowed/supported. Possibly UTF-8 but it could also be that only ASCII values are supported.</Comment>
+      <Sentinels>EmptyString</Sentinels>
     </FieldType>
     <FieldType Name="STRING_LZ">
       <Description>A varying length string containing single byte codepoints encoded with a length byte and terminating zero.</Description>
       <EncodingDescription>The length of the string is determined by a starting length byte. It also contains a terminating zero byte. The length byte includes neither the zero byte or itself. The character encoding is UTF-8.</EncodingDescription>
       <Comment>This type of string is found only in SonicHub and Fusion brand specific PGNs. SonicHub is no longer produced. The use of the Fusion specific PGNs is no longer very prevalent now that there are generic PGNs for audio/media devices.</Comment>
       <VariableSize>true</VariableSize>
+      <Sentinels>EmptyString</Sentinels>
     </FieldType>
     <FieldType Name="STRING_LAU">
       <Description>A varying length string containing double or single byte codepoints encoded with a length byte and terminating zero.</Description>
       <EncodingDescription>The length of the string is determined by a starting length byte. This count includes the length and type bytes, so any empty string contains count 2. The 2nd byte contains 0 for UNICODE or 1 for ASCII.</EncodingDescription>
       <VariableSize>true</VariableSize>
+      <Sentinels>EmptyString</Sentinels>
     </FieldType>
     <FieldType Name="BINARY">
       <Description>Binary field</Description>
       <EncodingDescription>Unspecified content consisting of any number of bits.</EncodingDescription>
+      <Sentinels>None</Sentinels>
     </FieldType>
     <FieldType Name="RESERVED">
       <Description>Reserved field</Description>
       <EncodingDescription>All reserved bits shall be 1</EncodingDescription>
       <Comment>NMEA reserved for future expansion and/or to align next data on byte boundary</Comment>
+      <Sentinels>None</Sentinels>
     </FieldType>
     <FieldType Name="SPARE">
       <Description>Spare field</Description>
       <EncodingDescription>All spare bits shall be 0</EncodingDescription>
       <Comment>This is like a reserved field but originates from other sources where unused fields shall be 0, like the AIS ITU-1371 standard.</Comment>
+      <Sentinels>None</Sentinels>
     </FieldType>
     <FieldType Name="MMSI">
       <Description>MMSI</Description>
@@ -359,17 +379,20 @@ limitations under the License.
       <URL>https://navcen.uscg.gov/maritime-mobile-service-identity</URL>
       <Bits>32</Bits>
       <Signed>false</Signed>
+      <Sentinels>None</Sentinels>
     </FieldType>
     <FieldType Name="VARIABLE">
       <Description>Variable</Description>
       <EncodingDescription>The definition of the field is that of the reference PGN and reference field, this is totally variable.</EncodingDescription>
       <VariableSize>true</VariableSize>
+      <Sentinels>None</Sentinels>
     </FieldType>
     <FieldType Name="FIELD_INDEX">
       <Description>Field Index</Description>
       <EncodingDescription>Index of the specified field in the PGN referenced.</EncodingDescription>
       <Bits>8</Bits>
       <Signed>false</Signed>
+      <Sentinels>TopOfRange</Sentinels>
     </FieldType>
   </FieldTypes>
   <MissingEnumerations>
@@ -5023,6 +5046,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ISO_CONTROL</LookupEnumeration>
         </Field>
@@ -5594,6 +5620,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2044</RangeMax>
+          <UnknownValue>2047</UnknownValue>
+          <OutOfRangeValue>2046</OutOfRangeValue>
+          <ReservedValue>2045</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MANUFACTURER_CODE</LookupEnumeration>
         </Field>
@@ -5637,6 +5666,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>INDIRECT_LOOKUP</FieldType>
           <LookupIndirectEnumeration>DEVICE_FUNCTION</LookupIndirectEnumeration>
           <LookupIndirectEnumerationFieldOrder>7</LookupIndirectEnumerationFieldOrder>
@@ -5662,6 +5694,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>125</RangeMax>
+          <UnknownValue>127</UnknownValue>
+          <OutOfRangeValue>126</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DEVICE_CLASS</LookupEnumeration>
         </Field>
@@ -5692,6 +5726,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>INDUSTRY_CODE</LookupEnumeration>
         </Field>
@@ -5740,6 +5775,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2044</RangeMax>
+          <UnknownValue>2047</UnknownValue>
+          <OutOfRangeValue>2046</OutOfRangeValue>
+          <ReservedValue>2045</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MANUFACTURER_CODE</LookupEnumeration>
         </Field>
@@ -5764,6 +5802,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>INDUSTRY_CODE</LookupEnumeration>
         </Field>
@@ -6101,6 +6140,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>65532</RangeMax>
+          <UnknownValue>65535</UnknownValue>
+          <OutOfRangeValue>65534</OutOfRangeValue>
+          <ReservedValue>65533</ReservedValue>
           <FieldType>DYNAMIC_FIELD_KEY</FieldType>
           <LookupFieldTypeEnumeration>VICTRON_VREG</LookupFieldTypeEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -6307,6 +6349,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2044</RangeMax>
+          <UnknownValue>2047</UnknownValue>
+          <OutOfRangeValue>2046</OutOfRangeValue>
+          <ReservedValue>2045</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MANUFACTURER_CODE</LookupEnumeration>
         </Field>
@@ -6331,6 +6376,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>INDUSTRY_CODE</LookupEnumeration>
         </Field>
@@ -6778,6 +6824,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>POWER_FACTOR</LookupEnumeration>
         </Field>
@@ -6992,6 +7039,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>POWER_FACTOR</LookupEnumeration>
         </Field>
@@ -7207,6 +7255,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>POWER_FACTOR</LookupEnumeration>
         </Field>
@@ -7422,6 +7471,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>POWER_FACTOR</LookupEnumeration>
         </Field>
@@ -7691,6 +7741,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>POWER_FACTOR</LookupEnumeration>
         </Field>
@@ -7906,6 +7957,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>POWER_FACTOR</LookupEnumeration>
         </Field>
@@ -8121,6 +8173,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>POWER_FACTOR</LookupEnumeration>
         </Field>
@@ -8336,6 +8389,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>POWER_FACTOR</LookupEnumeration>
         </Field>
@@ -8527,6 +8581,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2044</RangeMax>
+          <UnknownValue>2047</UnknownValue>
+          <OutOfRangeValue>2046</OutOfRangeValue>
+          <ReservedValue>2045</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MANUFACTURER_CODE</LookupEnumeration>
         </Field>
@@ -8570,6 +8627,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>INDIRECT_LOOKUP</FieldType>
           <LookupIndirectEnumeration>DEVICE_FUNCTION</LookupIndirectEnumeration>
           <LookupIndirectEnumerationFieldOrder>7</LookupIndirectEnumerationFieldOrder>
@@ -8595,6 +8655,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>125</RangeMax>
+          <UnknownValue>127</UnknownValue>
+          <OutOfRangeValue>126</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DEVICE_CLASS</LookupEnumeration>
         </Field>
@@ -8625,6 +8687,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>INDUSTRY_CODE</LookupEnumeration>
         </Field>
@@ -8684,6 +8747,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2044</RangeMax>
+          <UnknownValue>2047</UnknownValue>
+          <OutOfRangeValue>2046</OutOfRangeValue>
+          <ReservedValue>2045</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MANUFACTURER_CODE</LookupEnumeration>
         </Field>
@@ -8708,6 +8774,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>INDUSTRY_CODE</LookupEnumeration>
         </Field>
@@ -10285,6 +10352,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>BOOT_STATE</LookupEnumeration>
         </Field>
@@ -10365,6 +10433,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>TEMPERATURE_SOURCE</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -10794,6 +10865,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>TANK_TYPE</LookupEnumeration>
         </Field>
@@ -10907,6 +10980,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ACCESS_LEVEL</LookupEnumeration>
         </Field>
@@ -11110,6 +11184,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>TANK_TYPE</LookupEnumeration>
         </Field>
@@ -11226,6 +11302,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SEATALK_ALARM_STATUS</LookupEnumeration>
         </Field>
@@ -11240,6 +11319,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SEATALK_ALARM_ID</LookupEnumeration>
         </Field>
@@ -11254,6 +11336,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SEATALK_ALARM_GROUP</LookupEnumeration>
         </Field>
@@ -12490,6 +12575,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>65532</RangeMax>
+          <UnknownValue>65535</UnknownValue>
+          <OutOfRangeValue>65534</OutOfRangeValue>
+          <ReservedValue>65533</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>CZONE_ALARM_TYPE</LookupEnumeration>
         </Field>
@@ -13668,6 +13756,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DEVICE_MODEL</LookupEnumeration>
         </Field>
@@ -13698,6 +13789,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_AP_STATUS</LookupEnumeration>
         </Field>
@@ -13777,6 +13871,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DEVICE_MODEL</LookupEnumeration>
         </Field>
@@ -13875,6 +13972,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DEVICE_MODEL</LookupEnumeration>
         </Field>
@@ -13983,6 +14083,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DEVICE_MODEL</LookupEnumeration>
         </Field>
@@ -14083,6 +14186,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DEVICE_MODEL</LookupEnumeration>
         </Field>
@@ -15681,6 +15787,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_AUTOPILOT_MODE_CLASS</LookupEnumeration>
         </Field>
@@ -15695,6 +15804,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_AUTOPILOT_MODE</LookupEnumeration>
         </Field>
@@ -15837,6 +15949,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_AP_MODE</LookupEnumeration>
         </Field>
@@ -16661,6 +16776,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SEATALK_ALARM_ID</LookupEnumeration>
         </Field>
@@ -16675,6 +16793,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SEATALK_ALARM_GROUP</LookupEnumeration>
         </Field>
@@ -17049,6 +17170,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>65532</RangeMax>
+          <UnknownValue>65535</UnknownValue>
+          <OutOfRangeValue>65534</OutOfRangeValue>
+          <ReservedValue>65533</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SEATALK_PILOT_MODE_16</LookupEnumeration>
         </Field>
@@ -17327,6 +17451,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIRMAR_DEPTH_QUALITY_FACTOR</LookupEnumeration>
         </Field>
@@ -18219,6 +18345,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>FIELD_INDEX</FieldType>
         </Field>
         <Field>
@@ -18289,6 +18418,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>PRIORITY</LookupEnumeration>
         </Field>
@@ -18331,6 +18462,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>FIELD_INDEX</FieldType>
         </Field>
         <Field>
@@ -18401,6 +18535,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>PGN_ERROR_CODE</LookupEnumeration>
         </Field>
@@ -18415,6 +18551,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>TRANSMISSION_INTERVAL</LookupEnumeration>
         </Field>
@@ -18445,6 +18583,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>PARAMETER_FIELD</LookupEnumeration>
         </Field>
@@ -18516,6 +18656,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2044</RangeMax>
+          <UnknownValue>2047</UnknownValue>
+          <OutOfRangeValue>2046</OutOfRangeValue>
+          <ReservedValue>2045</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MANUFACTURER_CODE</LookupEnumeration>
         </Field>
@@ -18540,6 +18683,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>INDUSTRY_CODE</LookupEnumeration>
         </Field>
@@ -18595,6 +18739,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>FIELD_INDEX</FieldType>
         </Field>
         <Field>
@@ -18614,6 +18761,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>FIELD_INDEX</FieldType>
         </Field>
       </Fields>
@@ -18679,6 +18829,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2044</RangeMax>
+          <UnknownValue>2047</UnknownValue>
+          <OutOfRangeValue>2046</OutOfRangeValue>
+          <ReservedValue>2045</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MANUFACTURER_CODE</LookupEnumeration>
         </Field>
@@ -18703,6 +18856,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>INDUSTRY_CODE</LookupEnumeration>
         </Field>
@@ -18758,6 +18912,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>FIELD_INDEX</FieldType>
         </Field>
         <Field>
@@ -18777,6 +18934,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>FIELD_INDEX</FieldType>
         </Field>
         <Field>
@@ -18849,6 +19009,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2044</RangeMax>
+          <UnknownValue>2047</UnknownValue>
+          <OutOfRangeValue>2046</OutOfRangeValue>
+          <ReservedValue>2045</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MANUFACTURER_CODE</LookupEnumeration>
         </Field>
@@ -18873,6 +19036,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>INDUSTRY_CODE</LookupEnumeration>
         </Field>
@@ -18928,6 +19092,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>FIELD_INDEX</FieldType>
         </Field>
         <Field>
@@ -18947,6 +19114,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>FIELD_INDEX</FieldType>
         </Field>
         <Field>
@@ -19019,6 +19189,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2044</RangeMax>
+          <UnknownValue>2047</UnknownValue>
+          <OutOfRangeValue>2046</OutOfRangeValue>
+          <ReservedValue>2045</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MANUFACTURER_CODE</LookupEnumeration>
         </Field>
@@ -19043,6 +19216,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>INDUSTRY_CODE</LookupEnumeration>
         </Field>
@@ -19098,6 +19272,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>FIELD_INDEX</FieldType>
         </Field>
         <Field>
@@ -19117,6 +19294,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>FIELD_INDEX</FieldType>
         </Field>
         <Field>
@@ -19152,6 +19332,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>PGN_LIST_FUNCTION</LookupEnumeration>
         </Field>
@@ -19745,6 +19928,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2044</RangeMax>
+          <UnknownValue>2047</UnknownValue>
+          <OutOfRangeValue>2046</OutOfRangeValue>
+          <ReservedValue>2045</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MANUFACTURER_CODE</LookupEnumeration>
         </Field>
@@ -19769,6 +19955,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>INDUSTRY_CODE</LookupEnumeration>
         </Field>
@@ -19913,6 +20100,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SEATALK_PILOT_MODE</LookupEnumeration>
         </Field>
@@ -20066,6 +20256,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SEATALK_PILOT_HULL_TYPE</LookupEnumeration>
         </Field>
@@ -20193,6 +20386,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -20207,6 +20403,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -20351,6 +20550,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SEATALK_DEVICE_ID</LookupEnumeration>
         </Field>
@@ -20458,6 +20660,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SEATALK_NETWORK_GROUP</LookupEnumeration>
         </Field>
@@ -20472,6 +20677,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SEATALK_SHARED</LookupEnumeration>
         </Field>
@@ -20622,6 +20830,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SEATALK_NETWORK_GROUP</LookupEnumeration>
         </Field>
@@ -20661,6 +20872,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SEATALK_DISPLAY_COLOR</LookupEnumeration>
         </Field>
@@ -20811,6 +21025,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SEATALK_KEYSTROKE</LookupEnumeration>
         </Field>
@@ -20941,6 +21158,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>FUSION_COMMAND</LookupEnumeration>
         </Field>
@@ -21044,6 +21264,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>FUSION_SIRIUS_COMMAND</LookupEnumeration>
         </Field>
@@ -21309,6 +21532,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>FUSION_MUTE_COMMAND</LookupEnumeration>
         </Field>
@@ -21641,6 +21867,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>FUSION_POWER_STATE</LookupEnumeration>
         </Field>
@@ -21859,6 +22088,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIRMAR_CALIBRATE_FUNCTION</LookupEnumeration>
         </Field>
@@ -21873,6 +22105,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIRMAR_CALIBRATE_STATUS</LookupEnumeration>
         </Field>
@@ -22143,6 +22378,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -22239,6 +22475,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -22564,6 +22801,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIRMAR_TEMPERATURE_INSTANCE</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -23180,6 +23418,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIRMAR_TRANSMISSION_INTERVAL</LookupEnumeration>
         </Field>
@@ -23337,6 +23576,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>65532</RangeMax>
+          <UnknownValue>65535</UnknownValue>
+          <OutOfRangeValue>65534</OutOfRangeValue>
+          <ReservedValue>65533</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MARETRON_PRODUCT_CODE</LookupEnumeration>
         </Field>
@@ -23383,6 +23625,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MARETRON_STATUS_DEVIATION</LookupEnumeration>
         </Field>
@@ -23577,6 +23822,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>65532</RangeMax>
+          <UnknownValue>65535</UnknownValue>
+          <OutOfRangeValue>65534</OutOfRangeValue>
+          <ReservedValue>65533</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MARETRON_PRODUCT_CODE</LookupEnumeration>
         </Field>
@@ -23607,6 +23855,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MARETRON_OPCODE</LookupEnumeration>
         </Field>
@@ -24140,6 +24391,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>GARMIN_BACKLIGHT_LEVEL</LookupEnumeration>
         </Field>
@@ -24309,6 +24563,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>GARMIN_BACKLIGHT_LEVEL</LookupEnumeration>
         </Field>
@@ -24478,6 +24735,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>GARMIN_COLOR</LookupEnumeration>
         </Field>
@@ -24535,6 +24795,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_TYPE</LookupEnumeration>
         </Field>
@@ -24549,6 +24811,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_CATEGORY</LookupEnumeration>
         </Field>
@@ -24778,6 +25042,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_TRIGGER_CONDITION</LookupEnumeration>
         </Field>
@@ -24792,6 +25058,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_THRESHOLD_STATUS</LookupEnumeration>
         </Field>
@@ -24822,6 +25090,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_STATE</LookupEnumeration>
         </Field>
@@ -24850,6 +25121,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_TYPE</LookupEnumeration>
         </Field>
@@ -24864,6 +25137,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_CATEGORY</LookupEnumeration>
         </Field>
@@ -25037,6 +25312,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_TYPE</LookupEnumeration>
         </Field>
@@ -25051,6 +25328,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_CATEGORY</LookupEnumeration>
         </Field>
@@ -25174,6 +25453,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_LANGUAGE_ID</LookupEnumeration>
         </Field>
@@ -25221,6 +25503,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_TYPE</LookupEnumeration>
         </Field>
@@ -25235,6 +25519,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_CATEGORY</LookupEnumeration>
         </Field>
@@ -25464,6 +25750,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_TYPE</LookupEnumeration>
         </Field>
@@ -25478,6 +25766,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_CATEGORY</LookupEnumeration>
         </Field>
@@ -25699,6 +25989,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_TYPE</LookupEnumeration>
         </Field>
@@ -25713,6 +26005,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_CATEGORY</LookupEnumeration>
         </Field>
@@ -25929,6 +26223,8 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SYSTEM_TIME</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -26040,6 +26336,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>CONTROLLER_STATE</LookupEnumeration>
         </Field>
@@ -26054,6 +26351,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>CONTROLLER_STATE</LookupEnumeration>
         </Field>
@@ -26068,6 +26366,7 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>EQUIPMENT_STATUS</LookupEnumeration>
         </Field>
@@ -26175,6 +26474,9 @@ limitations under the License.
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>CERTIFICATION_LEVEL</LookupEnumeration>
         </Field>
@@ -26300,6 +26602,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MOB_STATUS</LookupEnumeration>
         </Field>
@@ -26342,6 +26645,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MOB_POSITION_SOURCE</LookupEnumeration>
         </Field>
@@ -26438,6 +26742,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DIRECTION_REFERENCE</LookupEnumeration>
         </Field>
@@ -26512,6 +26817,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>LOW_BATTERY</LookupEnumeration>
         </Field>
@@ -26549,6 +26855,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -26563,6 +26870,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -26577,6 +26885,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -26591,6 +26900,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -26605,6 +26915,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>STEERING_MODE</LookupEnumeration>
         </Field>
@@ -26619,6 +26930,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>TURN_MODE</LookupEnumeration>
         </Field>
@@ -26633,6 +26945,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DIRECTION_REFERENCE</LookupEnumeration>
         </Field>
@@ -26657,6 +26970,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DIRECTION_RUDDER</LookupEnumeration>
         </Field>
@@ -26863,6 +27177,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DIRECTION_RUDDER</LookupEnumeration>
         </Field>
@@ -27016,6 +27331,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DIRECTION_REFERENCE</LookupEnumeration>
         </Field>
@@ -27281,6 +27597,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MAGNETIC_VARIATION</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -27365,6 +27683,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENGINE_INSTANCE</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -27457,6 +27778,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENGINE_INSTANCE</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -28041,6 +28365,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENGINE_INSTANCE</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -28056,6 +28383,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>GEAR_STATUS</LookupEnumeration>
         </Field>
@@ -28743,6 +29071,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENGINE_INSTANCE</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -28843,6 +29174,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENGINE_INSTANCE</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -29067,6 +29401,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29081,6 +29416,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29095,6 +29431,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29109,6 +29446,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29123,6 +29461,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29137,6 +29476,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29151,6 +29491,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29165,6 +29506,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29179,6 +29521,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29193,6 +29536,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29207,6 +29551,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29221,6 +29566,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29235,6 +29581,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29249,6 +29596,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29263,6 +29611,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29277,6 +29626,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29291,6 +29641,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29305,6 +29656,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29319,6 +29671,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29333,6 +29686,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29347,6 +29701,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29361,6 +29716,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29375,6 +29731,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29389,6 +29746,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29403,6 +29761,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29417,6 +29776,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29431,6 +29791,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29445,6 +29806,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -29933,6 +30295,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AC_LINE</LookupEnumeration>
         </Field>
@@ -30146,6 +30509,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>LINE</LookupEnumeration>
         </Field>
@@ -30160,6 +30524,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>WAVEFORM</LookupEnumeration>
         </Field>
@@ -30339,6 +30704,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>TANK_TYPE</LookupEnumeration>
         </Field>
@@ -30445,6 +30812,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DC_SOURCE</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -30598,6 +30968,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>CHARGER_STATE</LookupEnumeration>
         </Field>
@@ -30612,6 +30984,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>CHARGER_MODE</LookupEnumeration>
         </Field>
@@ -30626,6 +31000,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -30640,6 +31015,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -30848,6 +31224,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>INVERTER_STATE</LookupEnumeration>
         </Field>
@@ -30862,6 +31240,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -30933,6 +31312,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -30975,6 +31355,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>CHARGING_ALGORITHM</LookupEnumeration>
         </Field>
@@ -30989,6 +31371,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>CHARGER_MODE</LookupEnumeration>
         </Field>
@@ -31004,6 +31388,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DEVICE_TEMP_STATE</LookupEnumeration>
         </Field>
@@ -31018,6 +31404,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -31032,6 +31419,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -31128,6 +31516,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -31142,6 +31531,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>INVERTER_MODE</LookupEnumeration>
         </Field>
@@ -31156,6 +31547,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -31256,6 +31648,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AGS_MODE</LookupEnumeration>
         </Field>
@@ -31310,6 +31704,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>BATTERY_TYPE</LookupEnumeration>
         </Field>
@@ -31324,6 +31720,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -31348,6 +31745,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>BATTERY_VOLTAGE</LookupEnumeration>
         </Field>
@@ -31362,6 +31761,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>BATTERY_CHEMISTRY</LookupEnumeration>
         </Field>
@@ -31494,6 +31895,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AGS_OPERATING_STATE</LookupEnumeration>
         </Field>
@@ -31508,6 +31911,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AGS_GENERATING_STATE</LookupEnumeration>
         </Field>
@@ -31522,6 +31927,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AGS_ON_REASON</LookupEnumeration>
         </Field>
@@ -31536,6 +31944,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AGS_OFF_REASON</LookupEnumeration>
         </Field>
@@ -32142,6 +32553,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>CONVERTER_STATE</LookupEnumeration>
         </Field>
@@ -32156,6 +32570,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>GOOD_WARNING_ERROR</LookupEnumeration>
         </Field>
@@ -32170,6 +32585,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>GOOD_WARNING_ERROR</LookupEnumeration>
         </Field>
@@ -32184,6 +32600,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>GOOD_WARNING_ERROR</LookupEnumeration>
         </Field>
@@ -32198,6 +32615,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>GOOD_WARNING_ERROR</LookupEnumeration>
         </Field>
@@ -32764,6 +33182,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>THRUSTER_DIRECTION_CONTROL</LookupEnumeration>
         </Field>
@@ -32778,6 +33198,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -32792,6 +33213,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>THRUSTER_RETRACT_CONTROL</LookupEnumeration>
         </Field>
@@ -32903,6 +33325,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>THRUSTER_MOTOR_TYPE</LookupEnumeration>
         </Field>
@@ -33159,6 +33583,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>WATER_REFERENCE</LookupEnumeration>
         </Field>
@@ -33462,6 +33889,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DIRECTION_REFERENCE</LookupEnumeration>
         </Field>
@@ -33620,6 +34048,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -34383,6 +34812,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>WINDLASS_DIRECTION</LookupEnumeration>
         </Field>
@@ -34397,6 +34827,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -34411,6 +34842,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SPEED_TYPE</LookupEnumeration>
         </Field>
@@ -34446,6 +34878,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -34460,6 +34893,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -34474,6 +34908,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -34488,6 +34923,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -34591,6 +35027,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>WINDLASS_DIRECTION</LookupEnumeration>
         </Field>
@@ -34605,6 +35042,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>WINDLASS_MOTION</LookupEnumeration>
         </Field>
@@ -34619,6 +35057,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>RODE_TYPE</LookupEnumeration>
         </Field>
@@ -34679,6 +35118,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DOCKING_STATUS</LookupEnumeration>
         </Field>
@@ -35017,6 +35457,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DIRECTION_REFERENCE</LookupEnumeration>
         </Field>
@@ -35221,6 +35662,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>GNS_METHOD</LookupEnumeration>
         </Field>
@@ -35235,6 +35678,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DIRECTION_REFERENCE</LookupEnumeration>
         </Field>
@@ -35409,6 +35853,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>GNS</LookupEnumeration>
         </Field>
@@ -35423,6 +35869,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>GNS_METHOD</LookupEnumeration>
         </Field>
@@ -35548,6 +35996,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>GNS</LookupEnumeration>
         </Field>
@@ -35677,6 +36127,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -35845,6 +36297,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -35896,6 +36350,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>14</RangeMax>
+          <UnknownValue>15</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>NAV_STATUS</LookupEnumeration>
         </Field>
@@ -35984,6 +36439,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -36151,6 +36608,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -36330,6 +36789,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -36516,6 +36977,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SHIP_TYPE</LookupEnumeration>
         </Field>
@@ -36558,6 +37022,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>POSITION_FIX_DEVICE</LookupEnumeration>
         </Field>
@@ -36691,6 +37157,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -36729,6 +37197,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -36987,6 +37457,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>POSITION_FIX_DEVICE</LookupEnumeration>
         </Field>
@@ -37022,6 +37494,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -37347,6 +37821,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>RESIDUAL_MODE</LookupEnumeration>
         </Field>
@@ -37371,6 +37847,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -37460,6 +37937,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DIRECTION_REFERENCE</LookupEnumeration>
         </Field>
@@ -37474,6 +37952,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -37488,6 +37967,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -37502,6 +37982,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>BEARING_MODE</LookupEnumeration>
         </Field>
@@ -37754,6 +38235,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DIRECTION</LookupEnumeration>
         </Field>
@@ -37768,6 +38250,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -37891,6 +38374,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DIRECTION_REFERENCE</LookupEnumeration>
         </Field>
@@ -38009,6 +38493,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MARK_TYPE</LookupEnumeration>
         </Field>
@@ -38081,6 +38567,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DIRECTION_REFERENCE</LookupEnumeration>
         </Field>
@@ -38095,6 +38582,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>BEARING_MODE</LookupEnumeration>
         </Field>
@@ -38155,6 +38643,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MARK_TYPE</LookupEnumeration>
         </Field>
@@ -38169,6 +38659,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MARK_TYPE</LookupEnumeration>
         </Field>
@@ -38300,6 +38792,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>GNSS_MODE</LookupEnumeration>
         </Field>
@@ -38314,6 +38807,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DGNSS_MODE</LookupEnumeration>
         </Field>
@@ -38328,6 +38822,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -38378,6 +38873,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -38431,6 +38927,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>GNSS_MODE</LookupEnumeration>
         </Field>
@@ -38445,6 +38942,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>GNSS_MODE</LookupEnumeration>
         </Field>
@@ -38552,6 +39050,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>RANGE_RESIDUAL_MODE</LookupEnumeration>
         </Field>
@@ -38680,6 +39179,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SATELLITE_STATUS</LookupEnumeration>
         </Field>
@@ -39596,6 +40097,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>GNS</LookupEnumeration>
         </Field>
@@ -39628,6 +40131,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>STATION_HEALTH</LookupEnumeration>
         </Field>
@@ -39785,6 +40290,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SERIAL_BIT_RATE</LookupEnumeration>
         </Field>
@@ -39799,6 +40306,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SERIAL_DETECTION_MODE</LookupEnumeration>
         </Field>
@@ -39813,6 +40321,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DIFFERENTIAL_SOURCE</LookupEnumeration>
         </Field>
@@ -39827,6 +40337,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DIFFERENTIAL_MODE</LookupEnumeration>
         </Field>
@@ -39951,6 +40463,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>GNS</LookupEnumeration>
         </Field>
@@ -39981,6 +40495,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SERIAL_BIT_RATE</LookupEnumeration>
         </Field>
@@ -39995,6 +40511,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SERIAL_DETECTION_MODE</LookupEnumeration>
         </Field>
@@ -40009,6 +40526,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -40033,6 +40551,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DIFFERENTIAL_SOURCE</LookupEnumeration>
         </Field>
@@ -40341,6 +40861,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -40393,6 +40915,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -40514,6 +41038,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -40659,6 +41185,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -40701,6 +41229,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>POSITION_FIX_DEVICE</LookupEnumeration>
         </Field>
@@ -40729,6 +41259,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -40805,6 +41337,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SHIP_TYPE</LookupEnumeration>
         </Field>
@@ -40968,6 +41503,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>POSITION_FIX_DEVICE</LookupEnumeration>
         </Field>
@@ -41006,6 +41543,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -41044,6 +41583,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -41096,6 +41637,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -41214,6 +41757,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -41266,6 +41811,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -41341,6 +41888,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -41393,6 +41942,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -41461,6 +42012,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -41629,6 +42182,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -41783,6 +42338,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>TELEPHONE_MODE</LookupEnumeration>
         </Field>
@@ -41832,6 +42390,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -41884,6 +42444,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -41939,6 +42501,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -41991,6 +42555,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -42092,6 +42658,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -42144,6 +42712,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -42197,6 +42767,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -42249,6 +42821,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -42297,6 +42871,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -42337,6 +42913,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -42411,6 +42989,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -42494,6 +43074,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -42546,6 +43128,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -42705,6 +43289,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -42757,6 +43343,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -42866,6 +43454,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -42918,6 +43508,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -42998,6 +43590,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>TX_RX_MODE</LookupEnumeration>
         </Field>
@@ -43146,6 +43740,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ZONE_SIZE</LookupEnumeration>
         </Field>
@@ -43197,6 +43792,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -43249,6 +43846,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>TX_RX_MODE</LookupEnumeration>
         </Field>
@@ -43345,6 +43944,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>STATION_TYPE</LookupEnumeration>
         </Field>
@@ -43369,6 +43970,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SHIP_TYPE</LookupEnumeration>
         </Field>
@@ -43403,6 +44007,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>REPORTING_INTERVAL</LookupEnumeration>
         </Field>
@@ -43477,6 +44083,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DSC_FORMAT</LookupEnumeration>
         </Field>
@@ -43521,6 +44130,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DSC_NATURE</LookupEnumeration>
         </Field>
@@ -43535,6 +44147,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DSC_SECOND_TELECOMMAND</LookupEnumeration>
         </Field>
@@ -43647,6 +44262,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -43727,6 +44343,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DSC_EXPANSION_DATA</LookupEnumeration>
         </Field>
@@ -43770,6 +44389,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DSC_FORMAT</LookupEnumeration>
         </Field>
@@ -43784,6 +44406,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DSC_CATEGORY</LookupEnumeration>
         </Field>
@@ -43812,6 +44437,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DSC_FIRST_TELECOMMAND</LookupEnumeration>
         </Field>
@@ -43826,6 +44454,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DSC_SECOND_TELECOMMAND</LookupEnumeration>
         </Field>
@@ -43938,6 +44569,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -44018,6 +44650,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DSC_EXPANSION_DATA</LookupEnumeration>
         </Field>
@@ -44053,6 +44688,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -44104,6 +44741,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -44158,6 +44797,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -44200,6 +44841,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SHIP_TYPE</LookupEnumeration>
         </Field>
@@ -44338,6 +44982,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>POSITION_FIX_DEVICE</LookupEnumeration>
         </Field>
@@ -44352,6 +44998,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -44427,6 +45075,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -44506,6 +45156,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -44598,6 +45250,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -44677,6 +45331,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -44820,6 +45476,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -44926,6 +45584,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>14</RangeMax>
+          <UnknownValue>15</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>NAV_STATUS</LookupEnumeration>
         </Field>
@@ -44999,6 +45658,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -45058,6 +45719,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -45147,6 +45810,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -45237,6 +45902,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -45373,6 +46040,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -45462,6 +46131,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_MESSAGE_ID</LookupEnumeration>
         </Field>
@@ -45514,6 +46185,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>29</RangeMax>
+          <UnknownValue>31</UnknownValue>
+          <OutOfRangeValue>30</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIS_TRANSCEIVER</LookupEnumeration>
         </Field>
@@ -45811,6 +46484,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>RESIDUAL_MODE</LookupEnumeration>
         </Field>
@@ -46055,6 +46730,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>RESIDUAL_MODE</LookupEnumeration>
         </Field>
@@ -46599,6 +47276,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>WP_POSITION_RESOLUTION</LookupEnumeration>
         </Field>
@@ -46774,6 +47453,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>WP_IDENTIFICATION_METHOD</LookupEnumeration>
         </Field>
@@ -46786,6 +47466,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>WP_ROUTE_STATUS</LookupEnumeration>
         </Field>
@@ -46920,6 +47602,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>WP_NAVIGATION_METHOD</LookupEnumeration>
         </Field>
@@ -46932,6 +47615,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>WP_IDENTIFICATION_METHOD</LookupEnumeration>
         </Field>
@@ -46944,6 +47628,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>WP_ROUTE_STATUS</LookupEnumeration>
         </Field>
@@ -47378,6 +48064,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>WP_NAVIGATION_METHOD</LookupEnumeration>
         </Field>
@@ -48060,6 +48747,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>WIND_REFERENCE</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -48209,6 +48897,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>TEMPERATURE_SOURCE</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -48224,6 +48914,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>HUMIDITY_SOURCE</LookupEnumeration>
         </Field>
@@ -48338,6 +49029,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>TEMPERATURE_SOURCE</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -48445,6 +49139,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>HUMIDITY_SOURCE</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -48552,6 +49249,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>PRESSURE_SOURCE</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -48641,6 +49341,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>PRESSURE_SOURCE</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -48731,6 +49434,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>TEMPERATURE_SOURCE</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -48795,6 +49501,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>RESIDUAL_MODE</LookupEnumeration>
         </Field>
@@ -48809,6 +49517,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>TIDE</LookupEnumeration>
         </Field>
@@ -48975,6 +49684,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>RESIDUAL_MODE</LookupEnumeration>
         </Field>
@@ -49136,6 +49847,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>RESIDUAL_MODE</LookupEnumeration>
         </Field>
@@ -49150,6 +49863,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>FLOOD_STATE</LookupEnumeration>
         </Field>
@@ -49352,6 +50066,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>RESIDUAL_MODE</LookupEnumeration>
         </Field>
@@ -49484,6 +50200,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>WIND_REFERENCE</LookupEnumeration>
         </Field>
@@ -49595,6 +50312,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>RESIDUAL_MODE</LookupEnumeration>
         </Field>
@@ -49727,6 +50446,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>WIND_REFERENCE</LookupEnumeration>
         </Field>
@@ -49968,6 +50688,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -50354,6 +51075,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>LIGHTING_COMMAND</LookupEnumeration>
         </Field>
@@ -50778,6 +51500,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -51229,6 +51952,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -51587,6 +52311,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>61</RangeMax>
+          <UnknownValue>63</UnknownValue>
+          <OutOfRangeValue>62</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>WATERMAKER_STATE</LookupEnumeration>
         </Field>
@@ -51601,6 +52327,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -51615,6 +52342,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -51629,6 +52357,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -51643,6 +52372,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -51657,6 +52387,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -51671,6 +52402,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OK_WARNING</LookupEnumeration>
         </Field>
@@ -51685,6 +52417,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -51699,6 +52432,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OK_WARNING</LookupEnumeration>
         </Field>
@@ -51713,6 +52447,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OK_WARNING</LookupEnumeration>
         </Field>
@@ -51727,6 +52462,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OK_WARNING</LookupEnumeration>
         </Field>
@@ -51741,6 +52477,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OK_WARNING</LookupEnumeration>
         </Field>
@@ -51755,6 +52492,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OK_WARNING</LookupEnumeration>
         </Field>
@@ -51960,6 +52698,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_SOURCE</LookupEnumeration>
         </Field>
@@ -52045,6 +52786,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_ZONE</LookupEnumeration>
         </Field>
@@ -52059,6 +52803,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_SOURCE</LookupEnumeration>
         </Field>
@@ -52107,6 +52854,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_PLAY_STATUS</LookupEnumeration>
         </Field>
@@ -52157,6 +52907,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_REPEAT_STATUS</LookupEnumeration>
         </Field>
@@ -52171,6 +52923,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_SHUFFLE_STATUS</LookupEnumeration>
         </Field>
@@ -52219,6 +52973,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_LIKE_STATUS</LookupEnumeration>
         </Field>
@@ -52338,6 +53095,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_SOURCE</LookupEnumeration>
         </Field>
@@ -52386,6 +53146,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_TYPE</LookupEnumeration>
         </Field>
@@ -52479,6 +53242,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_ZONE</LookupEnumeration>
         </Field>
@@ -52491,6 +53257,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -52503,6 +53270,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -52568,6 +53336,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_SOURCE</LookupEnumeration>
         </Field>
@@ -52599,6 +53370,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_TYPE</LookupEnumeration>
         </Field>
@@ -52613,6 +53387,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_ZONE</LookupEnumeration>
         </Field>
@@ -52695,6 +53472,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_ID_TYPE</LookupEnumeration>
         </Field>
@@ -52760,6 +53540,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_SOURCE</LookupEnumeration>
         </Field>
@@ -52808,6 +53591,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_GROUP</LookupEnumeration>
         </Field>
@@ -52829,6 +53615,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_GROUP</LookupEnumeration>
         </Field>
@@ -52848,6 +53637,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_GROUP</LookupEnumeration>
         </Field>
@@ -52959,6 +53751,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_SOURCE</LookupEnumeration>
         </Field>
@@ -53019,6 +53814,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -53031,6 +53827,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -53141,6 +53938,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_ZONE</LookupEnumeration>
         </Field>
@@ -53183,6 +53983,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_SOURCE</LookupEnumeration>
         </Field>
@@ -53358,6 +54161,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>RESIDUAL_MODE</LookupEnumeration>
         </Field>
@@ -53372,6 +54177,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>DIRECTION_REFERENCE</LookupEnumeration>
         </Field>
@@ -53657,6 +54463,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -53671,6 +54478,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_DEFAULT_SETTINGS</LookupEnumeration>
         </Field>
@@ -53685,6 +54493,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_REGIONS</LookupEnumeration>
         </Field>
@@ -53715,6 +54525,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>VIDEO_PROTOCOLS</LookupEnumeration>
         </Field>
@@ -53755,6 +54567,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -53769,6 +54582,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_DEFAULT_SETTINGS</LookupEnumeration>
         </Field>
@@ -53783,6 +54597,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_REGIONS</LookupEnumeration>
         </Field>
@@ -53883,6 +54699,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_ZONE</LookupEnumeration>
         </Field>
@@ -53922,6 +54741,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_ZONE</LookupEnumeration>
         </Field>
@@ -53955,6 +54777,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_VOLUME_CONTROL</LookupEnumeration>
         </Field>
@@ -53969,6 +54792,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -53993,6 +54817,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_CHANNEL</LookupEnumeration>
         </Field>
@@ -54085,6 +54912,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_EQ</LookupEnumeration>
         </Field>
@@ -54185,6 +55015,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>BLUETOOTH_STATUS</LookupEnumeration>
         </Field>
@@ -54256,6 +55089,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>BLUETOOTH_SOURCE_STATUS</LookupEnumeration>
         </Field>
@@ -54270,6 +55105,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -54284,6 +55120,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -54324,6 +55161,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_ZONE</LookupEnumeration>
         </Field>
@@ -54464,6 +55304,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_EQ</LookupEnumeration>
         </Field>
@@ -54478,6 +55321,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_FILTER</LookupEnumeration>
         </Field>
@@ -54528,6 +55374,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ENTERTAINMENT_CHANNEL</LookupEnumeration>
         </Field>
@@ -54561,6 +55410,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2044</RangeMax>
+          <UnknownValue>2047</UnknownValue>
+          <OutOfRangeValue>2046</OutOfRangeValue>
+          <ReservedValue>2045</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MANUFACTURER_CODE</LookupEnumeration>
         </Field>
@@ -54585,6 +55437,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>INDUSTRY_CODE</LookupEnumeration>
         </Field>
@@ -54697,6 +55550,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_CONTROL</LookupEnumeration>
         </Field>
@@ -54831,6 +55687,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_CONTROL</LookupEnumeration>
         </Field>
@@ -54845,6 +55704,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_TUNING</LookupEnumeration>
         </Field>
@@ -55012,6 +55874,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_CONTROL</LookupEnumeration>
         </Field>
@@ -55129,6 +55994,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_CONTROL</LookupEnumeration>
         </Field>
@@ -55143,6 +56011,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_SOURCE</LookupEnumeration>
         </Field>
@@ -55244,6 +56115,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_CONTROL</LookupEnumeration>
         </Field>
@@ -55386,6 +56260,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_CONTROL</LookupEnumeration>
         </Field>
@@ -55400,6 +56277,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>FUSION_MUTE_COMMAND</LookupEnumeration>
         </Field>
@@ -55501,6 +56381,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_CONTROL</LookupEnumeration>
         </Field>
@@ -55515,6 +56398,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_TUNING</LookupEnumeration>
         </Field>
@@ -55682,6 +56568,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_CONTROL</LookupEnumeration>
         </Field>
@@ -55696,6 +56585,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_PLAYLIST</LookupEnumeration>
         </Field>
@@ -55881,6 +56773,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_CONTROL</LookupEnumeration>
         </Field>
@@ -56007,6 +56902,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_CONTROL</LookupEnumeration>
         </Field>
@@ -56133,6 +57031,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_CONTROL</LookupEnumeration>
         </Field>
@@ -56259,6 +57160,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_CONTROL</LookupEnumeration>
         </Field>
@@ -56433,6 +57337,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_CONTROL</LookupEnumeration>
         </Field>
@@ -56550,6 +57457,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_CONTROL</LookupEnumeration>
         </Field>
@@ -56680,6 +57590,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_CONTROL</LookupEnumeration>
         </Field>
@@ -56813,6 +57726,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_CONTROL</LookupEnumeration>
         </Field>
@@ -56914,6 +57830,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_CONTROL</LookupEnumeration>
         </Field>
@@ -57034,6 +57953,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SONICHUB_CONTROL</LookupEnumeration>
         </Field>
@@ -58176,6 +59098,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AUTOMATIC_MANUAL</LookupEnumeration>
         </Field>
@@ -58190,6 +59115,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SBAS_SV</LookupEnumeration>
         </Field>
@@ -59326,6 +60254,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_TYPE</LookupEnumeration>
         </Field>
@@ -59340,6 +60270,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_CATEGORY</LookupEnumeration>
         </Field>
@@ -59566,6 +60498,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -60651,6 +61584,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>FUSION_SOURCE_TYPE</LookupEnumeration>
         </Field>
@@ -60870,6 +61806,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>65532</RangeMax>
+          <UnknownValue>65535</UnknownValue>
+          <OutOfRangeValue>65534</OutOfRangeValue>
+          <ReservedValue>65533</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>FUSION_PLAY_STATUS</LookupEnumeration>
         </Field>
@@ -62008,6 +62947,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -62160,6 +63102,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -62248,6 +63193,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -62352,6 +63300,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -62549,6 +63500,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>FUSION_RADIO_SOURCE</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -62953,6 +63907,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>YES_NO</LookupEnumeration>
         </Field>
@@ -63312,6 +64269,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>4294967292</RangeMax>
+          <UnknownValue>4294967295</UnknownValue>
+          <OutOfRangeValue>4294967294</OutOfRangeValue>
+          <ReservedValue>4294967293</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>FUSION_REPEAT_STATUS</LookupEnumeration>
         </Field>
@@ -63400,6 +64360,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>4294967292</RangeMax>
+          <UnknownValue>4294967295</UnknownValue>
+          <OutOfRangeValue>4294967294</OutOfRangeValue>
+          <ReservedValue>4294967293</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>FUSION_SETTING</LookupEnumeration>
         </Field>
@@ -63523,6 +64486,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>4294967292</RangeMax>
+          <UnknownValue>4294967295</UnknownValue>
+          <OutOfRangeValue>4294967294</OutOfRangeValue>
+          <ReservedValue>4294967293</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>FUSION_SETTING</LookupEnumeration>
         </Field>
@@ -63627,6 +64593,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>FUSION_MUTE_COMMAND</LookupEnumeration>
         </Field>
@@ -64743,6 +65712,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>FUSION_POWER_STATE</LookupEnumeration>
         </Field>
@@ -64892,6 +65864,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>FUSION_SIRIUS_TUNING_MODE</LookupEnumeration>
         </Field>
@@ -65772,6 +66747,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_TYPE</LookupEnumeration>
         </Field>
@@ -65786,6 +66763,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_CATEGORY</LookupEnumeration>
         </Field>
@@ -66379,6 +67358,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_TYPE</LookupEnumeration>
         </Field>
@@ -66393,6 +67374,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_CATEGORY</LookupEnumeration>
         </Field>
@@ -66516,6 +67499,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_LANGUAGE_ID</LookupEnumeration>
         </Field>
@@ -67903,6 +68889,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>65532</RangeMax>
+          <UnknownValue>65535</UnknownValue>
+          <OutOfRangeValue>65534</OutOfRangeValue>
+          <ReservedValue>65533</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>NAVICO_DATA_TYPE</LookupEnumeration>
         </Field>
@@ -68151,6 +69140,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_TYPE</LookupEnumeration>
         </Field>
@@ -68165,6 +69156,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_CATEGORY</LookupEnumeration>
         </Field>
@@ -68620,6 +69613,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>TEMPERATURE_SOURCE</LookupEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -68733,6 +69729,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>4092</RangeMax>
+          <UnknownValue>4095</UnknownValue>
+          <OutOfRangeValue>4094</OutOfRangeValue>
+          <ReservedValue>4093</ReservedValue>
           <FieldType>DYNAMIC_FIELD_KEY</FieldType>
           <LookupFieldTypeEnumeration>BANDG_KEY_VALUE</LookupFieldTypeEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -68975,6 +69974,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>4092</RangeMax>
+          <UnknownValue>4095</UnknownValue>
+          <OutOfRangeValue>4094</OutOfRangeValue>
+          <ReservedValue>4093</ReservedValue>
           <FieldType>DYNAMIC_FIELD_KEY</FieldType>
           <LookupFieldTypeEnumeration>MERCURY_KEY_VALUE</LookupFieldTypeEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -69261,6 +70263,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>65532</RangeMax>
+          <UnknownValue>65535</UnknownValue>
+          <OutOfRangeValue>65534</OutOfRangeValue>
+          <ReservedValue>65533</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_ALARM_ID</LookupEnumeration>
         </Field>
@@ -69275,6 +70280,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>6</RangeMax>
+          <UnknownValue>7</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_STATE</LookupEnumeration>
         </Field>
@@ -69302,6 +70308,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>ALERT_TYPE</LookupEnumeration>
         </Field>
@@ -69626,6 +70634,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>MERCURY_COMMAND_OPCODE</LookupEnumeration>
         </Field>
@@ -71263,6 +72274,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>4092</RangeMax>
+          <UnknownValue>4095</UnknownValue>
+          <OutOfRangeValue>4094</OutOfRangeValue>
+          <ReservedValue>4093</ReservedValue>
           <FieldType>DYNAMIC_FIELD_KEY</FieldType>
           <LookupFieldTypeEnumeration>BANDG_KEY_VALUE</LookupFieldTypeEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -71304,6 +72318,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>254</RangeMax>
+          <UnknownValue>255</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>BANDG_DECIMALS</LookupEnumeration>
         </Field>
@@ -72119,6 +73134,8 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>13</RangeMax>
+          <UnknownValue>15</UnknownValue>
+          <OutOfRangeValue>14</OutOfRangeValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>TANK_TYPE</LookupEnumeration>
         </Field>
@@ -72371,6 +73388,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -72693,6 +73711,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -73173,6 +74192,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DATA_SOURCE</LookupEnumeration>
         </Field>
@@ -73424,6 +74446,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -73438,6 +74461,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -73452,6 +74476,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -73466,6 +74491,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -73480,6 +74506,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -73494,6 +74521,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -73508,6 +74536,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -73522,6 +74551,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -73536,6 +74566,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>2</RangeMax>
+          <UnknownValue>3</UnknownValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>OFF_ON</LookupEnumeration>
         </Field>
@@ -74033,6 +75064,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SHIP_TYPE</LookupEnumeration>
         </Field>
@@ -74918,6 +75952,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DISPLAY_GROUP</LookupEnumeration>
         </Field>
@@ -74950,6 +75987,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>16777212</RangeMax>
+          <UnknownValue>16777215</UnknownValue>
+          <OutOfRangeValue>16777214</OutOfRangeValue>
+          <ReservedValue>16777213</ReservedValue>
           <FieldType>DYNAMIC_FIELD_KEY</FieldType>
           <LookupFieldTypeEnumeration>SIMNET_KEY_VALUE</LookupFieldTypeEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -74965,6 +76005,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_KEY_OPERATION</LookupEnumeration>
         </Field>
@@ -75084,6 +76127,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DISPLAY_GROUP</LookupEnumeration>
         </Field>
@@ -75116,6 +76162,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>16777212</RangeMax>
+          <UnknownValue>16777215</UnknownValue>
+          <OutOfRangeValue>16777214</OutOfRangeValue>
+          <ReservedValue>16777213</ReservedValue>
           <FieldType>DYNAMIC_FIELD_KEY</FieldType>
           <LookupFieldTypeEnumeration>SIMNET_KEY_VALUE</LookupFieldTypeEnumeration>
           <PartOfPrimaryKey>true</PartOfPrimaryKey>
@@ -75131,6 +76180,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_KEY_OPERATION</LookupEnumeration>
         </Field>
@@ -75835,6 +76887,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DISPLAY_GROUP</LookupEnumeration>
         </Field>
@@ -75990,6 +77045,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DISPLAY_GROUP</LookupEnumeration>
         </Field>
@@ -76145,6 +77203,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DISPLAY_GROUP</LookupEnumeration>
         </Field>
@@ -76300,6 +77361,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DISPLAY_GROUP</LookupEnumeration>
         </Field>
@@ -76455,6 +77519,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DISPLAY_GROUP</LookupEnumeration>
         </Field>
@@ -76610,6 +77677,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DISPLAY_GROUP</LookupEnumeration>
         </Field>
@@ -76787,6 +77857,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DISPLAY_GROUP</LookupEnumeration>
         </Field>
@@ -76942,6 +78015,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DISPLAY_GROUP</LookupEnumeration>
         </Field>
@@ -76999,6 +78075,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DIRECTION</LookupEnumeration>
         </Field>
@@ -77131,6 +78210,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DISPLAY_GROUP</LookupEnumeration>
         </Field>
@@ -77162,6 +78244,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>65532</RangeMax>
+          <UnknownValue>65535</UnknownValue>
+          <OutOfRangeValue>65534</OutOfRangeValue>
+          <ReservedValue>65533</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_TIMER_EVENT</LookupEnumeration>
         </Field>
@@ -77316,6 +78401,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DISPLAY_GROUP</LookupEnumeration>
         </Field>
@@ -77347,6 +78435,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_ALARM_COMMAND</LookupEnumeration>
         </Field>
@@ -77371,6 +78462,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>65532</RangeMax>
+          <UnknownValue>65535</UnknownValue>
+          <OutOfRangeValue>65534</OutOfRangeValue>
+          <ReservedValue>65533</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_ALARM_ID</LookupEnumeration>
         </Field>
@@ -77506,6 +78600,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DISPLAY_GROUP</LookupEnumeration>
         </Field>
@@ -77537,6 +78634,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_AP_EVENTS</LookupEnumeration>
         </Field>
@@ -77710,6 +78810,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DISPLAY_GROUP</LookupEnumeration>
         </Field>
@@ -77883,6 +78986,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DISPLAY_GROUP</LookupEnumeration>
         </Field>
@@ -77940,6 +79046,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DIRECTION</LookupEnumeration>
         </Field>
@@ -78072,6 +79181,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_DISPLAY_GROUP</LookupEnumeration>
         </Field>
@@ -78103,6 +79215,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_AP_EVENTS</LookupEnumeration>
         </Field>
@@ -78290,6 +79405,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>65532</RangeMax>
+          <UnknownValue>65535</UnknownValue>
+          <OutOfRangeValue>65534</OutOfRangeValue>
+          <ReservedValue>65533</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>SIMNET_ALARM_ID</LookupEnumeration>
         </Field>
@@ -80602,6 +81720,9 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
           <Signed>false</Signed>
           <RangeMin>0</RangeMin>
           <RangeMax>252</RangeMax>
+          <UnknownValue>255</UnknownValue>
+          <OutOfRangeValue>254</OutOfRangeValue>
+          <ReservedValue>253</ReservedValue>
           <FieldType>LOOKUP</FieldType>
           <LookupEnumeration>AIRMAR_POST_ID</LookupEnumeration>
         </Field>

--- a/docs/canboat.xsd
+++ b/docs/canboat.xsd
@@ -1,4 +1,4 @@
-<xs:schema version="2.4.0"
+<xs:schema version="2.5.0"
            attributeFormDefault="unqualified"
            elementFormDefault="qualified"
            xmlns:xs="http://www.w3.org/2001/XMLSchema">
@@ -333,6 +333,37 @@ limitations under the License.
             True if the fields of this FieldType all have a variable length in bits.
           </xs:documentation>
         </xs:annotation>
+      </xs:element>
+      <xs:element name="Sentinels">
+        <xs:annotation>
+          <xs:documentation>
+            How a field of this type signals "data not available" (and, for integers,
+            out-of-range and reserved). One of:
+            TopOfRange  - the top 1 to 3 raw integer values are reserved as
+                          Unknown (most positive), OutOfRange (max-1) and Reserved
+                          (max-2); the count depends on the bit width, so the actual
+                          reserved values are given per field as UnknownValue,
+                          OutOfRangeValue and ReservedValue. For LOOKUP fields a value
+                          that the enumeration names explicitly is a real value and is
+                          not reserved, lowering the count.
+            EmptyString - an empty string (after trimming end-of-string bytes such as
+                          0xff, 0x00 and '@') marks the field as unavailable.
+            NaN         - the IEEE-754 Not-a-Number value.
+            Variable    - the convention depends on the data type that is resolved at
+                          run time through the companion DYNAMIC_FIELD_KEY field.
+            None        - the field has no unavailable encoding (an identifier such as
+                          PGN or MMSI, filler such as RESERVED, or a structured field).
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="TopOfRange"/>
+            <xs:enumeration value="EmptyString"/>
+            <xs:enumeration value="NaN"/>
+            <xs:enumeration value="Variable"/>
+            <xs:enumeration value="None"/>
+          </xs:restriction>
+        </xs:simpleType>
       </xs:element>
     </xs:sequence>
     <xs:attribute type="xs:string" name="Name"/>

--- a/docs/canboat.xsl
+++ b/docs/canboat.xsl
@@ -624,6 +624,35 @@
           </p>
         </xsl:when>
       </xsl:choose>
+      <xsl:if test="Sentinels">
+        <p>
+          Unavailable value:
+          <xsl:choose>
+            <xsl:when test="Sentinels = 'TopOfRange'">
+              the top of the integer range is reserved. The most positive value means
+              "data not available"; depending on the bit width the next one or two values
+              below it mean "out of range" and "reserved". Each individual field lists its
+              actual reserved values as Unknown, OutOfRange and Reserved. For a lookup, a
+              value that the enumeration names explicitly is a real value and is not reserved.
+            </xsl:when>
+            <xsl:when test="Sentinels = 'EmptyString'">
+              an empty string (after trimming end-of-string bytes such as 0xff, 0x00 and '@')
+              means the whole field is unavailable.
+            </xsl:when>
+            <xsl:when test="Sentinels = 'NaN'">
+              the IEEE-754 Not-a-Number value means the field is unavailable.
+            </xsl:when>
+            <xsl:when test="Sentinels = 'Variable'">
+              depends on the data type that is resolved at run time through the companion
+              DYNAMIC_FIELD_KEY field.
+            </xsl:when>
+            <xsl:otherwise>
+              none. This field type has no unavailable encoding (it is an identifier, filler
+              or structured field).
+            </xsl:otherwise>
+          </xsl:choose>
+        </p>
+      </xsl:if>
       <xsl:if test="URL">
         <p>
           For more information see:


### PR DESCRIPTION
## What

Makes every field type's "data not available" convention explicit in the schema, and extends the top-of-range sentinel markers to lookups.

### `Sentinels` per field type
Adds a `Sentinels` enum (`fieldtype.h`) emitted as `<Sentinels>` on every FieldType (XML/JSON) and rendered as an "Unavailable value:" line in the HTML Field Types section:

| Token | Field types |
|-------|-------------|
| `TopOfRange` | NUMBER, DATE, TIME, DURATION, FIELD_INDEX, DYNAMIC_FIELD_LENGTH, LOOKUP, INDIRECT_LOOKUP, DYNAMIC_FIELD_KEY |
| `EmptyString` | STRING_FIX, STRING_LZ, STRING_LAU |
| `NaN` | FLOAT |
| `Variable` | DYNAMIC_FIELD_VALUE (datatype resolved via DYNAMIC_FIELD_KEY) |
| `None` | PGN, MMSI, ISO_NAME, DECIMAL, BINARY, RESERVED, SPARE, VARIABLE, BITLOOKUP |

This is now the single source of truth for which fields emit markers — the per-field emission keys off `.sentinels == TopOfRange`, replacing the previous hand-maintained exclusion list.

### Lookup markers
LOOKUP/INDIRECT_LOOKUP fields now emit `UnknownValue`/`OutOfRangeValue`/`ReservedValue`. **An enumeration name always wins**: a value the lookup names explicitly is a real value, so a sentinel position it names is not emitted (verified: the 139 fields whose enum names the top raw value emit no marker there).

### Also
- `FIELD_INDEX` now carries markers (corrected to range 0..252; it reserves the top 3 of an 8-bit field).
- `STRING_FIX` encoding description rewritten to explain end-of-string bytes (`0xff`/`@`/`0x00`) and that an empty string ⇒ Unknown.
- `MMSI`/`PGN` stay `None` — confirmed against the sample corpus (~11.8k MMSI + ~15.8k PGN field instances): no device uses an all-ones sentinel; MMSI "unavailable" is `0` (bottom-of-range), PGN fields always carry a real PGN.

## Schema
`SCHEMA_VERSION` 2.4.0 → 2.5.0 (additive: new optional `<Sentinels>` element + new optional markers on lookup fields).

## Validation
Decoder behavior is unchanged (lookup decode uses `extractNumber`, not the sentinel-stripping path; number-field `reservedCount` is identical to before). Full `make generated` passes: tests, schema validation, and JSON range-validation. `pgns.dbc` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)