### PR TITLE
feat(navico): drop PGN 130861 "Simrad: Engine Data" — no producer exists

### DIFF
--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -9955,13 +9955,6 @@ Pgn pgnList[] = {
                     "meaning of the individual fields not yet identified."}
 
     ,
-    {"Simrad: Engine Data",
-     130861,
-     PACKET_INCOMPLETE | PACKET_NOT_SEEN,
-     PACKET_FAST,
-     {COMPANY(1857), END_OF_FIELDS}}
-
-    ,
     {"Airmar: Additional Weather Data",
      130880,
      PACKET_INCOMPLETE | PACKET_NOT_SEEN,

--- a/docs/canboat.dbc
+++ b/docs/canboat.dbc
@@ -1984,10 +1984,6 @@ BO_ 2583637246 PGN_130860_simnetApUnknown4: 8 Vector__XXX
  SG_ fastPacketData : 8|56@1+ (1,0) [0|0] "" Vector__XXX
  SG_ fastPacketSequenceCounter : 0|8@1+ (1,0) [0|0] "" Vector__XXX
 
-BO_ 2583637502 PGN_130861_simradEngineData: 8 Vector__XXX
- SG_ fastPacketData : 8|56@1+ (1,0) [0|0] "" Vector__XXX
- SG_ fastPacketSequenceCounter : 0|8@1+ (1,0) [0|0] "" Vector__XXX
-
 BO_ 2583642366 PGN_130880_airmarAdditionalWeath: 8 Vector__XXX
  SG_ fastPacketData : 8|56@1+ (1,0) [0|0] "" Vector__XXX
  SG_ fastPacketSequenceCounter : 0|8@1+ (1,0) [0|0] "" Vector__XXX
@@ -2567,7 +2563,6 @@ CM_ BO_ 2583634942 "Fast packet (multiple variants)";
 CM_ BO_ 2583635198 "Navico: Proprietary 2 FP";
 CM_ BO_ 2583636222 "Simnet: Alarm Message";
 CM_ BO_ 2583637246 "Simnet: AP Unknown 4";
-CM_ BO_ 2583637502 "Simrad: Engine Data";
 CM_ BO_ 2583642366 "Airmar: Additional Weather Data";
 CM_ BO_ 2583642622 "Airmar: Heater Control";
 CM_ BO_ 2583647486 "Xantrex: AC Status";

--- a/docs/canboat.html
+++ b/docs/canboat.html
@@ -20611,29 +20611,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
                       <a href="#ft-NUMBER">NUMBER</a></td><td/></tr><tr><td>9</td><td>F</td><td/><td><div class="xs">0 .. 4294967292</div></td><td>32 bits
                   
                         unsigned
-                      <a href="#ft-NUMBER">NUMBER</a></td><td/></tr></table><h3 id="pgn-130861">0x1FF2D:
-            PGN 130861
-            - Simrad: Engine Data</h3><p>
-              This PGN description applies when the following field(s) match:
-              <table><tr><td>Manufacturer Code</td><td>1857</td></tr><tr><td>Industry Code</td><td>4</td></tr></table></p><p/><p>
-                This PGN is not fully reverse engineered. Some aspects that are known to be missing/incorrect:
-                <ul><li>The list of fields is incomplete; some fields maybe be missing or their attributes may be incorrect</li><li>The length of one or more fields is likely incorrect</li><li>The resolution of one or more fields is likely incorrect</li><li>The PGN has not been seen in any logfiles yet</li><li>The default transmission interval is not known</li></ul></p><p>
-            This
-             fast-packet 
-            PGN is
-            2
-            bytes long and contains 3 fields.
-
-            </p><table><tr><th> Field # </th><th> Field Name </th><th> Description </th><th> Unit </th><th> Type </th><th> PartOfPrimaryKey </th></tr><tr><td>1</td><td>Manufacturer Code</td><td>1857:
-                  Simrad</td><td><div class="xs">0 .. 2044</div></td><td>11 bits
-                  
-                      lookup
-                      <a href="#lookup-MANUFACTURER_CODE">MANUFACTURER_CODE</a></td><td/></tr><tr><td>2</td><td>Reserved</td><td/><td/><td>2 bits
-                  <a href="#ft-RESERVED">RESERVED</a></td><td/></tr><tr><td>3</td><td>Industry Code</td><td>4:
-                  Marine Industry</td><td><div class="xs">0 .. 6</div></td><td>3 bits
-                  
-                      lookup
-                      <a href="#lookup-INDUSTRY_CODE">INDUSTRY_CODE</a></td><td/></tr></table><h3 id="pgn-130880">0x1FF40:
+                      <a href="#ft-NUMBER">NUMBER</a></td><td/></tr></table><h3 id="pgn-130880">0x1FF40:
             PGN 130880
             - Airmar: Additional Weather Data</h3><p>
               This PGN description applies when the following field(s) match:

--- a/docs/canboat.json
+++ b/docs/canboat.json
@@ -78879,61 +78879,6 @@
         ]
       },
       {
-        "PGN":130861,
-        "Id":"simradEngineData",
-        "Description":"Simrad: Engine Data",
-        "Type":"Fast",
-        "Complete":false,
-        "Missing":["Fields","FieldLengths","Resolution","SampleData","Interval"
-        ],
-        "FieldCount":3,
-        "Length":2,
-        "Fields":[
-          {
-            "Order":1,
-            "Id":"manufacturerCode",
-            "Name":"Manufacturer Code",
-            "Description":"Simrad",
-            "BitLength":11,
-            "BitOffset":0,
-            "BitStart":0,
-            "Match":1857,
-            "Resolution":1,
-            "Signed":false,
-            "RangeMin":0,
-            "RangeMax":2044,
-            "FieldType":"LOOKUP",
-            "LookupEnumeration":"MANUFACTURER_CODE"
-          },
-          {
-            "Order":2,
-            "Id":"reserved",
-            "Name":"Reserved",
-            "BitLength":2,
-            "BitOffset":11,
-            "BitStart":3,
-            "Resolution":1,
-            "FieldType":"RESERVED"
-          },
-          {
-            "Order":3,
-            "Id":"industryCode",
-            "Name":"Industry Code",
-            "Description":"Marine Industry",
-            "BitLength":3,
-            "BitOffset":13,
-            "BitStart":5,
-            "Match":4,
-            "Resolution":1,
-            "Signed":false,
-            "RangeMin":0,
-            "RangeMax":6,
-            "FieldType":"LOOKUP",
-            "LookupEnumeration":"INDUSTRY_CODE"
-          }
-        ]
-      },
-      {
         "PGN":130880,
         "Id":"airmarAdditionalWeatherData",
         "Description":"Airmar: Additional Weather Data",

--- a/docs/canboat.xml
+++ b/docs/canboat.xml
@@ -79639,66 +79639,6 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
       </Fields>
     </PGNInfo>
     <PGNInfo>
-      <PGN>130861</PGN>
-      <Id>simradEngineData</Id>
-      <Description>Simrad: Engine Data</Description>
-      <Type>Fast</Type>
-      <Complete>false</Complete>
-      <Missing>
-        <MissingAttribute>Fields</MissingAttribute>
-        <MissingAttribute>FieldLengths</MissingAttribute>
-        <MissingAttribute>Resolution</MissingAttribute>
-        <MissingAttribute>SampleData</MissingAttribute>
-        <MissingAttribute>Interval</MissingAttribute>
-      </Missing>
-      <FieldCount>3</FieldCount>
-      <Length>2</Length>
-      <Fields>
-        <Field>
-          <Order>1</Order>
-          <Id>manufacturerCode</Id>
-          <Name>Manufacturer Code</Name>
-          <Description>Simrad</Description>
-          <BitLength>11</BitLength>
-          <BitOffset>0</BitOffset>
-          <BitStart>0</BitStart>
-          <Match>1857</Match>
-          <Resolution>1</Resolution>
-          <Signed>false</Signed>
-          <RangeMin>0</RangeMin>
-          <RangeMax>2044</RangeMax>
-          <FieldType>LOOKUP</FieldType>
-          <LookupEnumeration>MANUFACTURER_CODE</LookupEnumeration>
-        </Field>
-        <Field>
-          <Order>2</Order>
-          <Id>reserved</Id>
-          <Name>Reserved</Name>
-          <BitLength>2</BitLength>
-          <BitOffset>11</BitOffset>
-          <BitStart>3</BitStart>
-          <Resolution>1</Resolution>
-          <FieldType>RESERVED</FieldType>
-        </Field>
-        <Field>
-          <Order>3</Order>
-          <Id>industryCode</Id>
-          <Name>Industry Code</Name>
-          <Description>Marine Industry</Description>
-          <BitLength>3</BitLength>
-          <BitOffset>13</BitOffset>
-          <BitStart>5</BitStart>
-          <Match>4</Match>
-          <Resolution>1</Resolution>
-          <Signed>false</Signed>
-          <RangeMin>0</RangeMin>
-          <RangeMax>6</RangeMax>
-          <FieldType>LOOKUP</FieldType>
-          <LookupEnumeration>INDUSTRY_CODE</LookupEnumeration>
-        </Field>
-      </Fields>
-    </PGNInfo>
-    <PGNInfo>
       <PGN>130880</PGN>
       <Id>airmarAdditionalWeatherData</Id>
       <Description>Airmar: Additional Weather Data</Description>


### PR DESCRIPTION
## Summary

Drops the fieldless `PACKET_NOT_SEEN` definition of PGN **130861** ("Simrad: Engine Data").

Per the reverse-engineering follow-up in #712: **no Simrad or B&G autopilot actually produces this PGN** — MFDs can receive it, but nothing on the bus sends it. It also occurs **0 times** across the entire capture corpus (canboat `samples/` + the Navico RE captures). Rather than flesh out a speculative field set for a message that never appears on the wire, the definition is removed.

## Contract impact

Minor — a PGN definition is removed (`pgn-removed`). Downstream regenerates types / updates fixtures; no source that decoded 130861 could ever have matched real traffic.

Closes #712

🤖 Generated with [Claude Code](https://claude.com/claude-code)