### PR TITLE
chore: add sponsorship link, bump copyright to 2009-2026

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ relay/server daemon (`n2kd`), and format converters (`candump2analyzer`,
 `socketcan-writer`, `replay`, `ip`, `pcap2candump`, `analyzer2csv`,
 `group-function`).
 
-License is **Apache-2.0**; every file carries the `(C) 2009-2025 Kees Verruijt`
+License is **Apache-2.0**; every file carries the `(C) 2009-2026 Kees Verruijt`
 header. The current `VERSION` and `SCHEMA_VERSION` are defined in
 `common/version.h` — the single source of truth; don't hard-code them elsewhere.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile for all UNIX style platforms including Cygwin
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands
 #
 # $Id:$
 #

--- a/README.md
+++ b/README.md
@@ -98,9 +98,14 @@ just want to use your NMEA 2000 network, these projects build on them and provid
 - [OpenPlotter](https://openplotter.org/)
 - [Signal K](https://signalk.org/)
 
+## Sponsorship
+
+If you find CANboat useful, please consider supporting its development via
+[GitHub Sponsors](https://github.com/sponsors/keesverruijt).
+
 ---
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/actisense-serial/Makefile
+++ b/actisense-serial/Makefile
@@ -1,6 +1,6 @@
 #
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #  
 # This file is part of CANboat.
 # 

--- a/actisense-serial/actisense-serial.c
+++ b/actisense-serial/actisense-serial.c
@@ -3,7 +3,7 @@ Read and write to an Actisense NGT-1 over its serial device.
 This can be a serial version connected to an actual serial port
 or an USB version connected to the virtual serial port.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/actisense-serial/actisense.h
+++ b/actisense-serial/actisense.h
@@ -2,7 +2,7 @@
 
 Defines to interface with an Actisense NGT-1
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/actisense-serial/tests/Makefile
+++ b/actisense-serial/tests/Makefile
@@ -1,5 +1,5 @@
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #
 # This file is part of CANboat.
 #

--- a/analyzer/Makefile
+++ b/analyzer/Makefile
@@ -1,5 +1,5 @@
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #  
 # This file is part of CANboat.
 # 

--- a/analyzer/analyzer-explain.c
+++ b/analyzer/analyzer-explain.c
@@ -2,7 +2,7 @@
 
 Analyzes NMEA 2000 PGNs.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/analyzer/analyzer.c
+++ b/analyzer/analyzer.c
@@ -2,7 +2,7 @@
 
 Analyzes NMEA 2000 PGNs.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/analyzer/analyzer.h
+++ b/analyzer/analyzer.h
@@ -2,7 +2,7 @@
 
 Analyzes NMEA 2000 PGNs.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/analyzer/fieldtype.c
+++ b/analyzer/fieldtype.c
@@ -2,7 +2,7 @@
 
 Analyzes NMEA 2000 PGNs.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/analyzer/fieldtype.h
+++ b/analyzer/fieldtype.h
@@ -2,7 +2,7 @@
 
 Analyzes NMEA 2000 PGNs.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/analyzer/fixup-version.py
+++ b/analyzer/fixup-version.py
@@ -1,7 +1,7 @@
 
 
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #  
 # This file is part of CANboat.
 # 

--- a/analyzer/lookup.c
+++ b/analyzer/lookup.c
@@ -2,7 +2,7 @@
 
 Analyzes NMEA 2000 PGNs.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/analyzer/nonstdbool.h
+++ b/analyzer/nonstdbool.h
@@ -1,6 +1,6 @@
 /*
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/analyzer/pgn-j1939.h
+++ b/analyzer/pgn-j1939.h
@@ -2,7 +2,7 @@
 
 Analyzes NMEA 2000 PGNs.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/analyzer/pgn.c
+++ b/analyzer/pgn.c
@@ -2,7 +2,7 @@
 
 Analyzes NMEA 2000 PGNs.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/analyzer/pgn.h
+++ b/analyzer/pgn.h
@@ -2,7 +2,7 @@
 
 Analyzes NMEA 2000 PGNs.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/analyzer/print.c
+++ b/analyzer/print.c
@@ -2,7 +2,7 @@
 
 Analyzes NMEA 2000 PGNs.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/analyzer/tests/Makefile
+++ b/analyzer/tests/Makefile
@@ -1,5 +1,5 @@
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #  
 # This file is part of CANboat.
 # 

--- a/analyzer/validate-json.py
+++ b/analyzer/validate-json.py
@@ -1,5 +1,5 @@
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #  
 # This file is part of CANboat.
 # 

--- a/candump2analyzer/Makefile
+++ b/candump2analyzer/Makefile
@@ -1,5 +1,5 @@
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #  
 # This file is part of CANboat.
 # 

--- a/candump2analyzer/candump2analyzer.c
+++ b/candump2analyzer/candump2analyzer.c
@@ -9,7 +9,7 @@ Further info re: SocketCAN and the can-utils can be viewed here...
 
 http://en.wikipedia.org/wiki/SocketCAN
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/candump2analyzer/tests/Makefile
+++ b/candump2analyzer/tests/Makefile
@@ -1,5 +1,5 @@
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #
 # This file is part of CANboat.
 #

--- a/common/b64.c
+++ b/common/b64.c
@@ -1,6 +1,6 @@
 /*
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/common/common.c
+++ b/common/common.c
@@ -1,6 +1,6 @@
 /*
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/common/common.h
+++ b/common/common.h
@@ -1,6 +1,6 @@
 /*
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/common/dup.h
+++ b/common/dup.h
@@ -2,7 +2,7 @@
 
 Analyzes NMEA 2000 PGNs.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/common/license.h
+++ b/common/license.h
@@ -1,6 +1,6 @@
 /*
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 
@@ -37,6 +37,6 @@ limitations under the License.
 
 #define COPYRIGHT                                                 \
   "CANboat version v" VERSION "\n\n"                              \
-  "(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.\n"   \
+  "(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.\n"   \
   "For more information see https://github.com/canboat/canboat\n" \
   "\n" LICENSE "\n"

--- a/common/parse.c
+++ b/common/parse.c
@@ -2,7 +2,7 @@
 
 Analyzes NMEA 2000 PGNs.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/common/parse.h
+++ b/common/parse.h
@@ -2,7 +2,7 @@
 
 Analyzes NMEA 2000 PGNs.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/common/pow.h
+++ b/common/pow.h
@@ -2,7 +2,7 @@
 
 Analyzes NMEA 2000 PGNs.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/common/utf.c
+++ b/common/utf.c
@@ -1,6 +1,6 @@
 /*
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 (C) 2019, Davidp
 
 This file is part of CANboat.

--- a/common/utf.h
+++ b/common/utf.h
@@ -1,6 +1,6 @@
 /*
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 (C) 2019, Davidp
 
 This file is part of CANboat.

--- a/common/version.h
+++ b/common/version.h
@@ -1,6 +1,6 @@
 /*
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/config/n2kd
+++ b/config/n2kd
@@ -1,5 +1,5 @@
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #  
 # This file is part of CANboat.
 # 

--- a/docs/canboat.html
+++ b/docs/canboat.html
@@ -4,7 +4,7 @@
             7.1.0.
           </p><h3>Copyright</h3><p class="xs">CANboat version v7.1.0
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 For more information see https://github.com/canboat/canboat
 
 This file is part of CANboat.

--- a/docs/canboat.json
+++ b/docs/canboat.json
@@ -5,7 +5,7 @@
     "CreatorCode":"Canboat NMEA2000 Analyzer",
     "License":"Apache License Version 2.0",
     "Version":"7.1.0",
-    "Copyright":"CANboat version v7.1.0\n\n(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.\nFor more information see https://github.com/canboat/canboat\n\nThis file is part of CANboat.\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n    http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n\n\n",
+    "Copyright":"CANboat version v7.1.0\n\n(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.\nFor more information see https://github.com/canboat/canboat\n\nThis file is part of CANboat.\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n    http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n\n\n",
     "PhysicalQuantities":[
     {
         "Name":"ELECTRICAL_CURRENT",

--- a/docs/canboat.xml
+++ b/docs/canboat.xml
@@ -2,7 +2,7 @@
 <!--
 CANboat version v7.1.0
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 For more information see https://github.com/canboat/canboat
 
 This file is part of CANboat.
@@ -30,7 +30,7 @@ limitations under the License.
   <Version>7.1.0</Version>
   <Copyright>CANboat version v7.1.0
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 For more information see https://github.com/canboat/canboat
 
 This file is part of CANboat.

--- a/docs/canboat.xsd
+++ b/docs/canboat.xsd
@@ -5,7 +5,7 @@
   <xs:element name="PGNDefinitions" type="PGNDefinitions">
     <xs:annotation>
       <xs:documentation>
-CANboat version v7.1.0 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+CANboat version v7.1.0 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 For more information see https://github.com/canboat/canboat
 
 This file is part of CANboat.

--- a/group-function/Makefile
+++ b/group-function/Makefile
@@ -1,5 +1,5 @@
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #  
 # This file is part of CANboat.
 # 

--- a/group-function/command.c
+++ b/group-function/command.c
@@ -1,6 +1,6 @@
 /*
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/group-function/request.c
+++ b/group-function/request.c
@@ -1,6 +1,6 @@
 /*
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/ikonvert-serial/Makefile
+++ b/ikonvert-serial/Makefile
@@ -1,5 +1,5 @@
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #  
 # This file is part of CANboat.
 # 

--- a/ikonvert-serial/ikonvert-serial.c
+++ b/ikonvert-serial/ikonvert-serial.c
@@ -3,7 +3,7 @@ Read and write to a Digital Yacht iKonvert over its serial device.
 This can be a serial version connected to an actual serial port
 or an USB version connected to the virtual serial port.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/ikonvert-serial/ikonvert.h
+++ b/ikonvert-serial/ikonvert.h
@@ -1,7 +1,7 @@
 /*
  Defines to interface with a Digital Yacht iKonvert
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/ip/Makefile
+++ b/ip/Makefile
@@ -1,5 +1,5 @@
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #  
 # This file is part of CANboat.
 # 

--- a/ip/iptee.c
+++ b/ip/iptee.c
@@ -1,6 +1,6 @@
 /*
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/maretron-ipg/Makefile
+++ b/maretron-ipg/Makefile
@@ -1,5 +1,5 @@
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #
 # This file is part of CANboat.
 #

--- a/maretron-ipg/maretron-ipg.c
+++ b/maretron-ipg/maretron-ipg.c
@@ -1,7 +1,7 @@
 /*
 Read and write to a Maretron IPG100 over TCP.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/maretron-ipg/maretron-ipg.h
+++ b/maretron-ipg/maretron-ipg.h
@@ -1,6 +1,6 @@
 /*
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/n2kd/Makefile
+++ b/n2kd/Makefile
@@ -1,5 +1,5 @@
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #
 # This file is part of CANboat.
 #

--- a/n2kd/gps_ais.c
+++ b/n2kd/gps_ais.c
@@ -1,6 +1,6 @@
 /*
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/n2kd/gps_ais.h
+++ b/n2kd/gps_ais.h
@@ -1,6 +1,6 @@
 /*
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/n2kd/main.c
+++ b/n2kd/main.c
@@ -14,7 +14,7 @@ from stdin, collects this data and sends this out on three types of TCP clients:
 - Write-only port to write to serial device (NGT-1, iKonvert, YDWG, etc.)
 
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/n2kd/n2kd.h
+++ b/n2kd/n2kd.h
@@ -1,6 +1,6 @@
 /*
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/n2kd/n2kd_monitor
+++ b/n2kd/n2kd_monitor
@@ -23,7 +23,7 @@
 # Leave out ACTISENSE_SECONDARY if you have only one Actisense gateway.
 # Leave MONITOR set to false for now; its contents have not been open sourced yet.
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #  
 # This file is part of CANboat.
 # 

--- a/n2kd/n2kd_nmea_monitor
+++ b/n2kd/n2kd_nmea_monitor
@@ -15,7 +15,7 @@
 #
 # Leave MONITOR set to false for now; its contents have not been open sourced yet.
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #  
 # This file is part of CANboat.
 # 

--- a/n2kd/nmea0183.c
+++ b/n2kd/nmea0183.c
@@ -5,7 +5,7 @@ Convert JSON encoded NMEA2000 PGNs to NMEA0183.
 At this moment it only supports what one of the authors needed: sensor data
 other than GPS and AIS: depth, heading, wind.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/n2kd/nmea0183.h
+++ b/n2kd/nmea0183.h
@@ -5,7 +5,7 @@ Convert JSON encoded NMEA2000 PGNs to NMEA0183.
 At this moment it only supports what one of the authors needed: sensor data
 other than GPS and AIS: depth, heading, wind.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/n2kd/tests/Makefile
+++ b/n2kd/tests/Makefile
@@ -1,5 +1,5 @@
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #  
 # This file is part of CANboat.
 # 

--- a/nmea0183/Makefile
+++ b/nmea0183/Makefile
@@ -1,5 +1,5 @@
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #  
 # This file is part of CANboat.
 # 

--- a/nmea0183/nmeareader.c
+++ b/nmea0183/nmeareader.c
@@ -1,6 +1,6 @@
 /*
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/replay/Makefile
+++ b/replay/Makefile
@@ -1,6 +1,6 @@
 #
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #  
 # This file is part of CANboat.
 # 

--- a/replay/replay.c
+++ b/replay/replay.c
@@ -5,7 +5,7 @@ in the first field and delaying by the time difference between this
 and the previous message, unless it is not in the range 0..10s;
 in that case the message is sent immediately.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/socketcan-serial/Makefile
+++ b/socketcan-serial/Makefile
@@ -1,5 +1,5 @@
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #
 # This file is part of CANboat.
 #

--- a/socketcan-serial/gen-fastpacket-table.py
+++ b/socketcan-serial/gen-fastpacket-table.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #
 # This file is part of CANboat.
 #

--- a/socketcan-serial/socketcan-serial.c
+++ b/socketcan-serial/socketcan-serial.c
@@ -22,7 +22,7 @@ is decided by range (see common.h) except for the mixed 0x1F000..0x1FFFF
 range, for which fastpacket-table.h holds a per-PGN lookup generated from
 canboat.json at build time.
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/socketcan-writer/Makefile
+++ b/socketcan-writer/Makefile
@@ -1,5 +1,5 @@
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #  
 # This file is part of CANboat.
 # 

--- a/socketcan-writer/socketcan-writer.c
+++ b/socketcan-writer/socketcan-writer.c
@@ -2,7 +2,7 @@
 
 Reads raw n2k ASCII data from stdin and writes it to a Linux SocketCAN device (e.g. can0).
 
-(C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+(C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
 This file is part of CANboat.
 

--- a/tools/contract-pr.sh
+++ b/tools/contract-pr.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# Copyright (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #
 # Upward-compatibility check for the canboat public contract.
 #

--- a/tools/contract.py
+++ b/tools/contract.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# Copyright (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #
 # Canboat "public contract" tooling.
 #

--- a/tools/nmea-pdf/apply_backfill.py
+++ b/tools/nmea-pdf/apply_backfill.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #
 # This file is part of CANboat.
 #

--- a/tools/nmea-pdf/extract.py
+++ b/tools/nmea-pdf/extract.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #
 # This file is part of CANboat.
 #

--- a/tools/nmea-pdf/reconcile.py
+++ b/tools/nmea-pdf/reconcile.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #
 # This file is part of CANboat.
 #

--- a/util/canboat-default.inc
+++ b/util/canboat-default.inc
@@ -1,6 +1,6 @@
 <?php
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #
 # This file is part of CANboat.
 #

--- a/util/format-message
+++ b/util/format-message
@@ -7,7 +7,7 @@
 # 1970-01-01-00:00:00.000,6,59904,0,255,3,14,f0,01
 #
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #
 # This file is part of CANboat.
 #

--- a/util/format-message.inc
+++ b/util/format-message.inc
@@ -7,7 +7,7 @@
 # 1970-01-01-00:00:00.000,6,59904,0,255,3,14,f0,01
 #
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #
 # This file is part of CANboat.
 #

--- a/util/list-product-information
+++ b/util/list-product-information
@@ -3,7 +3,7 @@
 #
 # A very limited script engine that sends and receives CAN messages.
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #
 # This file is part of CANboat.
 #

--- a/util/replay
+++ b/util/replay
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 #
-# (C) 2009-2025, Kees Verruijt, Harlingen, The Netherlands.
+# (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 #  
 # This file is part of CANboat.
 # 


### PR DESCRIPTION
## Summary
- Add a Sponsorship section to README.md linking to https://github.com/sponsors/keesverruijt
- Bump all "(C) 2009-2025" copyright headers to 2009-2026 across the codebase (source files + regenerated docs)

## Test plan
- [x] `make generated` — regenerated docs pick up the new year
- [x] `make tests` — full suite green
- [x] `make pr` — no contract changes