### PR TITLE
feat(navico): decode SIMNET_ALARM_COMMAND 88 as Tack/Gybe Confirm

### DIFF
--- a/analyzer/lookup.h
+++ b/analyzer/lookup.h
@@ -3201,6 +3201,7 @@ LOOKUP(SIMNET_ALARM_COMMAND, 56, "Deactivate")
 LOOKUP(SIMNET_ALARM_COMMAND, 57, "Activate")
 LOOKUP(SIMNET_ALARM_COMMAND, 58, "Acknowledge")
 LOOKUP(SIMNET_ALARM_COMMAND, 68, "Silence")
+LOOKUP(SIMNET_ALARM_COMMAND, 88, "Tack/Gybe Confirm")  // no Alarm ID; the AP48 head brackets each 130850 Command AP Tack with this (confirm prompt shown/cleared)
 LOOKUP(SIMNET_ALARM_COMMAND, 104, "Alarm History")
 LOOKUP(SIMNET_ALARM_COMMAND, 107, "MOB Activated")  // broadcast to all groups, no Alarm ID; the MOB position rides the standard PGN 127233
 LOOKUP(SIMNET_ALARM_COMMAND, 108, "MOB Cancelled")

--- a/docs/canboat.html
+++ b/docs/canboat.html
@@ -22694,7 +22694,7 @@ The Default update rate of this PGN is autonomous, as it is dependant upon notif
         (0 - 255)
       </h3><table><tr><th>Value</th><th>Description</th></tr><tr><td>2</td><td>Port</td></tr><tr><td>3</td><td>Starboard</td></tr><tr><td>4</td><td>Left rudder (port)</td></tr><tr><td>5</td><td>Right rudder (starboard)</td></tr></table><h3 id="lookup-SIMNET_ALARM_COMMAND">SIMNET_ALARM_COMMAND
         (0 - 255)
-      </h3><table><tr><th>Value</th><th>Description</th></tr><tr><td>56</td><td>Deactivate</td></tr><tr><td>57</td><td>Activate</td></tr><tr><td>58</td><td>Acknowledge</td></tr><tr><td>68</td><td>Silence</td></tr><tr><td>104</td><td>Alarm History</td></tr><tr><td>107</td><td>MOB Activated</td></tr><tr><td>108</td><td>MOB Cancelled</td></tr></table><h3 id="lookup-SIMNET_EVENT_TYPE">SIMNET_EVENT_TYPE
+      </h3><table><tr><th>Value</th><th>Description</th></tr><tr><td>56</td><td>Deactivate</td></tr><tr><td>57</td><td>Activate</td></tr><tr><td>58</td><td>Acknowledge</td></tr><tr><td>68</td><td>Silence</td></tr><tr><td>88</td><td>Tack/Gybe Confirm</td></tr><tr><td>104</td><td>Alarm History</td></tr><tr><td>107</td><td>MOB Activated</td></tr><tr><td>108</td><td>MOB Cancelled</td></tr></table><h3 id="lookup-SIMNET_EVENT_TYPE">SIMNET_EVENT_TYPE
         (0 - 255)
       </h3><table><tr><th>Value</th><th>Description</th></tr><tr><td>2</td><td>Follow Up</td></tr><tr><td>10</td><td>AP Command</td></tr><tr><td>23</td><td>Timer</td></tr><tr><td>31</td><td>Siren</td></tr><tr><td>36</td><td>AIS vessel selected</td></tr><tr><td>255</td><td>Alarm</td></tr></table><h3 id="lookup-SIMNET_TIMER_EVENT">SIMNET_TIMER_EVENT
         (0 - 65535)

--- a/docs/canboat.json
+++ b/docs/canboat.json
@@ -3731,6 +3731,7 @@
           {"Name":"Activate", "Value":57},
           {"Name":"Acknowledge", "Value":58},
           {"Name":"Silence", "Value":68},
+          {"Name":"Tack/Gybe Confirm", "Value":88},
           {"Name":"Alarm History", "Value":104},
           {"Name":"MOB Activated", "Value":107},
           {"Name":"MOB Cancelled", "Value":108}

--- a/docs/canboat.xml
+++ b/docs/canboat.xml
@@ -3013,6 +3013,7 @@ limitations under the License.
       <EnumPair Value='57' Name='Activate' />
       <EnumPair Value='58' Name='Acknowledge' />
       <EnumPair Value='68' Name='Silence' />
+      <EnumPair Value='88' Name='Tack/Gybe Confirm' />
       <EnumPair Value='104' Name='Alarm History' />
       <EnumPair Value='107' Name='MOB Activated' />
       <EnumPair Value='108' Name='MOB Cancelled' />


### PR DESCRIPTION
## What

Adds one value to the `SIMNET_ALARM_COMMAND` lookup (PGN 130850 byte 6):

```c
LOOKUP(SIMNET_ALARM_COMMAND, 88, "Tack/Gybe Confirm")
```

## Wire evidence

```
2026-07-05T00:05:05.031Z ... 130850,21,255,12,41,9f,ff,ff,01,ff,58,00,ff,ff,ff,ff   <- before tack
2026-07-05T00:05:05.033Z ... 130850,21,255 Command AP Tack                          <- the tack
2026-07-05T00:05:05.074Z ... 130851,19,255 AP command Reply (Tack)                  <- AP echoes
2026-07-05T00:05:05.081Z ... 130850,21,255,12,41,9f,ff,ff,01,ff,58,00,ff,ff,ff,ff   <- after tack
```

