### PR TITLE
feat(socketcan): manage the CAN link lifecycle via netlink

### DIFF
--- a/rust/crates/canboat-bridge/src/server/mod.rs
+++ b/rust/crates/canboat-bridge/src/server/mod.rs
@@ -348,6 +348,10 @@ pub struct BridgeConfig {
     pub maretron: Option<String>,
     pub socketcan: Option<String>,
     pub socketcan_address: u8,
+    /// When `true`, the SocketCAN driver brings the interface up itself (at
+    /// the fixed NMEA 2000 250 kbit/s) via netlink, instead of relying on an
+    /// external `ip link set … up` unit being ordered first.
+    pub socketcan_configure_link: bool,
     pub canboat_csv: Option<String>,
     pub canboat_csv_write: Option<String>,
     pub baud: Option<u32>,
@@ -391,6 +395,7 @@ impl Default for BridgeConfig {
             maretron: None,
             socketcan: None,
             socketcan_address: 0,
+            socketcan_configure_link: false,
             canboat_csv: None,
             canboat_csv_write: None,
             baud: None,
@@ -431,6 +436,9 @@ impl From<Args> for BridgeConfig {
             maretron: a.maretron,
             socketcan: a.socketcan,
             socketcan_address: a.socketcan_address,
+            // The standalone `canboat` CLI keeps assuming an externally
+            // configured interface; only library embedders (merrimac) opt in.
+            socketcan_configure_link: false,
             canboat_csv: a.canboat_csv,
             canboat_csv_write: a.canboat_csv_write,
             baud: a.baud,
@@ -600,6 +608,7 @@ fn open_source(config: &BridgeConfig) -> Result<OpenedSource> {
         let config = device::socketcan::Config {
             address: config.socketcan_address,
             model_version: Some("canboat-pipeline-rs"),
+            configure_link: config.socketcan_configure_link,
             ..device::socketcan::Config::default()
         };
         // Shared across factory reconnects so the live claim address

--- a/rust/crates/canboat-io/src/device/socketcan.rs
+++ b/rust/crates/canboat-io/src/device/socketcan.rs
@@ -63,6 +63,14 @@ mod config {
         /// `"canboat-pipeline-rs"` so a downstream display can tell which
         /// canboat-rs binary is driving the bus.
         pub model_version: Option<&'static str>,
+        /// When `true`, the driver owns the interface's link lifecycle: before
+        /// opening the socket it brings the link down, sets the NMEA 2000
+        /// bitrate (always 250 kbit/s) with bus-off auto-recovery, and brings
+        /// it up — retrying to ride out controllers that intermittently fail
+        /// to configure at boot (notably the MCP2515's "didn't enter config
+        /// mode"). `false` leaves the interface untouched, assuming it was
+        /// configured externally (e.g. a systemd `ip link set … up` unit).
+        pub configure_link: bool,
     }
 
     impl Default for Config {
@@ -76,6 +84,7 @@ mod config {
                 no_claim: false,
                 timeout_secs: 0,
                 model_version: None,
+                configure_link: false,
             }
         }
     }
@@ -106,7 +115,7 @@ mod imp {
     use canboat_core::format::{days_to_ymd, iso11783_compose, iso11783_decompose};
     use canboat_core::frame::RawFrame;
     use canboat_core::{ADDR_GLOBAL, ADDR_NULL, FramePacketType, Reassembled, Reassembler};
-    use socketcan::{CanSocket, EmbeddedFrame, ExtendedId, Socket};
+    use socketcan::{CanInterface, CanSocket, EmbeddedFrame, ExtendedId, Socket};
 
     use super::config::Config;
     use crate::address_claim::{AddressClaim, ClaimState};
@@ -1071,11 +1080,73 @@ mod imp {
     /// injector, so the in-process loopback shows the same `src` the
     /// rewritten frame will reach the bus with) read it from this
     /// atom. The supervisor reuses the same atom across reconnects.
+    /// NMEA 2000 runs at a fixed 250 kbit/s — the standard never varies, so
+    /// the managed bring-up hard-codes it rather than exposing a knob.
+    const NMEA2000_BITRATE: u32 = 250_000;
+    /// Bus-off auto-recovery delay for the managed bring-up (matches the
+    /// historical `ip link … restart-ms 100`).
+    const NMEA2000_RESTART_MS: u32 = 100;
+
+    /// Configure and bring up a SocketCAN link via netlink (RTM_NEWLINK),
+    /// replacing an external `ip link set … up type can bitrate 250000 …`
+    /// unit. A CAN controller must be *down* to set its bit timing, so we
+    /// always cycle down → set bitrate + restart-ms → up. Retried a few times
+    /// because some controllers (notably the MCP2515) intermittently fail to
+    /// enter config mode on the first bring-up after boot, and a fresh down→up
+    /// often clears it. Best-effort: on give-up it logs and returns rather
+    /// than aborting the device session, so a later supervisor reconnect can
+    /// try again. PRIVILEGED — requires the process to run as root.
+    fn configure_can_link(iface: &str) {
+        let ci = match CanInterface::open(iface) {
+            Ok(ci) => ci,
+            Err(e) => {
+                log::error!("CAN {iface}: cannot open netlink handle to configure link: {e}");
+                return;
+            }
+        };
+        const ATTEMPTS: u32 = 5;
+        for attempt in 1..=ATTEMPTS {
+            // Down first: bit timing can only be set while down, and it also
+            // resets a controller left half-configured by a prior failed
+            // bring-up. An already-down interface makes this a no-op.
+            let _ = ci.bring_down();
+            let result = ci
+                .set_bitrate(NMEA2000_BITRATE, None::<u32>)
+                .and_then(|()| ci.set_restart_ms(NMEA2000_RESTART_MS))
+                .and_then(|()| ci.bring_up());
+            match result {
+                Ok(()) => {
+                    log::info!(
+                        "CAN {iface}: configured {NMEA2000_BITRATE} bit/s, \
+                         restart-ms {NMEA2000_RESTART_MS}, link up (attempt {attempt})"
+                    );
+                    return;
+                }
+                Err(e) => {
+                    log::warn!("CAN {iface}: bring-up attempt {attempt}/{ATTEMPTS} failed: {e}");
+                    thread::sleep(std::time::Duration::from_millis(500));
+                }
+            }
+        }
+        log::error!(
+            "CAN {iface}: could not bring link up after {ATTEMPTS} attempts; opening socket \
+             anyway (TX will fail with ENETDOWN until the controller recovers)"
+        );
+    }
+
     pub fn run(
         iface: &str,
         config: Config,
         claim_addr: Arc<AtomicU8>,
     ) -> std::io::Result<DeviceHandle> {
+        // Own the link's lifecycle here instead of relying on an external
+        // bring-up (systemd/ip) that may not be ordered before us — the
+        // historical failure mode where the N2K interface was left DOWN
+        // because its bring-up unit no longer ran first. Best-effort: `run()`
+        // proceeds even if it can't come up, so the supervisor keeps retrying.
+        if config.configure_link {
+            configure_can_link(iface);
+        }
         let sock = CanSocket::open(iface).map_err(std::io::Error::other)?;
         sock.set_nonblocking(true)?;
         let fd = sock.as_raw_fd();

--- a/rust/crates/canboat-io/src/device/supervisor.rs
+++ b/rust/crates/canboat-io/src/device/supervisor.rs
@@ -396,8 +396,17 @@ mod tests {
 
         // Collect frames until we've seen all the expected payloads
         // or we time out.
+        //
+        // The happy path spends ~2s in real sleeps — 500ms after each of
+        // the two mid-stream EOFs plus one INITIAL_BACKOFF for the
+        // simulated open failure — and the loop breaks the moment all 7
+        // frames land, so a generous ceiling costs nothing when the test
+        // passes. It only bounds a genuine hang. Keep it far above the
+        // expected time: a loaded CI runner that stretches those sleeps
+        // must not be mistaken for a dropped frame (a 5s deadline flaked
+        // on macOS, timing out one frame short of the last session).
         let mut got: Vec<u32> = Vec::new();
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let deadline = std::time::Instant::now() + Duration::from_secs(60);
         while got.len() < 7 && std::time::Instant::now() < deadline {
             match sup.frames_rx.recv_timeout(Duration::from_millis(500)) {
                 Ok(f) => got.push(f.pgn),


### PR DESCRIPTION
Ports canboat-rs's orphaned **`feat/socketcan-configure-link`** branch into `rust/`. That branch was never merged to canboat-rs `main`, so #768 (which copied `main`) left it behind — and **merrimac-rs has been building against it**, so merrimac-rs currently does not compile against canboat master:

```
error[E0560]: struct `BridgeConfig` has no field named `socketcan_configure_link`
```

**Stacked on #770** (its commit is the first of three here; targeting master so there's no dead-end base). #770 edits `server/mod.rs` too, which is why this is based on it.

Applied with `git am` so **authorship and both original commit messages are preserved** — this is a port, not a rewrite. It applied cleanly, with offsets where the wire removal shifted lines.

## `feat(socketcan): manage the CAN link lifecycle via netlink`

An opt-in `configure_link` (surfaced as `socketcan_configure_link` on `BridgeConfig`) makes the SocketCAN driver own the interface's link lifecycle, instead of depending on an external `ip link set … up type can bitrate 250000 …` unit being ordered first.

When enabled, before opening the socket the driver cycles the link **down → sets the fixed NMEA 2000 250 kbit/s bitrate with bus-off auto-recovery (`restart-ms 100`) → brings it up**, over netlink (`RTM_NEWLINK`). Bit timing can only be set while the controller is down, and the down step also resets a controller left half-configured by a prior failed bring-up. The bring-up retries a few times to ride out controllers that intermittently fail to enter config mode at boot — notably the MCP2515's *"didn't enter config mode"*.

Properly `cfg(target_os = "linux")`-gated with a non-Linux fallback, so the macOS and Windows CI legs are unaffected.

## `test(supervisor): widen the reconnect test's frame-collection deadline`

Worth having independently of the feature: `supervisor_reconnects_across_eof` gave the supervisor 5 s to deliver 7 frames, but the happy path already spends ~2 s of that in real sleeps, leaving ~2.5× headroom. A loaded **macOS** runner stretched past the deadline and failed one frame short, reported as a confusing ordering mismatch rather than a timeout. Raised to 60 s — the loop still breaks as soon as all 7 frames land (~2.4 s locally), so the deadline now only ever bounds a genuine hang. Our matrix includes `macos-latest`, so this is a flake we would otherwise have inherited.

## Verified

**merrimac-rs builds clean** against this tree (`cargo check` exit 0) — it was the reason for the port, and it's now unblocked. Its working tree was left exactly as found.

canboat: `cargo build` / `test` / `clippy -D warnings` / `fmt --check` all green; C side untouched.

## Remaining orphan

canboat-rs's `chore/canboat-sync-v7.1.0` is also unmerged, but moot — #768 deleted the vendored schema, so there is nothing left to sync. Nothing else on that repo is unmerged, so this closes the migration gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)