### PR TITLE
fix(ci): drop --offline from the release Cargo.lock re-stamp

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -51,11 +51,17 @@ jobs:
           make generated
 
       # Sync rust/Cargo.lock to the workspace version release-please just wrote
-      # into rust/Cargo.toml. --workspace touches only the member packages, and
-      # --offline keeps third-party resolution exactly as committed, so this
-      # moves the eight member version lines and nothing else.
+      # into rust/Cargo.toml. --workspace updates only the member packages;
+      # third-party pins are left exactly as locked (cargo reports them as
+      # "unchanged dependencies behind latest"), so this moves the member
+      # version lines and nothing else.
+      #
+      # Deliberately NOT --offline: a fresh runner has no registry cache, so
+      # cargo cannot resolve even already-locked third-party crates from the
+      # index and fails with "no matching package named `indexmap` found".
+      # It only appeared in CI because a warm local cache hides it.
       - name: re-stamp rust/Cargo.lock
-        run: cargo update --workspace --offline --manifest-path rust/Cargo.toml
+        run: cargo update --workspace --manifest-path rust/Cargo.toml
 
       - name: commit regenerated files
         run: |


### PR DESCRIPTION
The re-stamp step I added in #769 **fails on every release-please run**:

```
error: no matching package named `indexmap` found
location searched: crates.io index
note: offline mode (via `--offline`) can sometimes cause surprising resolution failures
```

`--offline` was meant to prove third-party resolution couldn't drift, and it worked when I tested locally because my registry cache was warm. A fresh runner has no cache, so cargo can't resolve even *already-locked* crates from the index. Classic works-on-my-machine.

**Dropping it is safe.** `cargo update --workspace` updates only the member packages regardless of `--offline`. Verified by simulating the bump on the current tree:

- lock diff is **14 lines, all member versions** (7 members × 2)
- **zero** non-version lines changed
- cargo explicitly reports the 52 third-party dependencies as left `behind latest`

**Why it matters now:** the `regenerate` job has failed on the last two master pushes, so it never re-stamped the lock — meaning release PR **#710 is still red** on every `cargo --locked` job. This unblocks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)