### PR TITLE
feat(convert): expose the analyzer's output flags on `canboat convert`

### DIFF
--- a/crates/canboat/src/convert.rs
+++ b/crates/canboat/src/convert.rs
@@ -20,7 +20,9 @@ use anyhow::{Context, Result};
 
 use canboat_core::RawFrame;
 use canboat_core::format::InputFormat;
-use canboat_core::output::{GeoFormat, JsonOptions, TextOptions, write_json, write_text};
+use canboat_core::output::{
+    CamelCase, GeoFormat, JsonOptions, TextOptions, write_json, write_text,
+};
 use canboat_io::{
     EblReader, EblWriter, FrameReader, FrameWriter, LineFrameReader, PlainWriter, TextLineWriter,
     analyze, container, copy,
@@ -177,6 +179,63 @@ pub struct Args {
     /// captures.
     #[arg(long)]
     filtered_only: bool,
+
+    // ----- decoded-output shape: the same knobs the `analyzer` alias
+    // exposes, so `convert --to json` can be diffed against canboat C.
+    /// Emit lookup values as `{"value":N,"name":"..."}` instead of the
+    /// bare name string. Matches canboat's `-nv`. JSON only.
+    #[arg(long)]
+    nv: bool,
+
+    /// Include unavailable fields — `null` in JSON, `Unknown` in text —
+    /// instead of omitting them. Matches canboat's `-empty`.
+    #[arg(long)]
+    empty: bool,
+
+    /// Annotate every field with its raw bytes and bits. Matches
+    /// canboat's `-debug`.
+    #[arg(long)]
+    debug: bool,
+
+    /// Emit field keys and PGN descriptions as camelCase identifiers.
+    /// Matches canboat's `-camel`.
+    #[arg(long)]
+    camel: bool,
+
+    /// As `--camel`, but UpperCamelCase. Matches canboat's
+    /// `-upper-camel`.
+    #[arg(long, conflicts_with = "camel")]
+    upper_camel: bool,
+
+    /// Strict SI units — radians, kelvin, pascals — rather than the
+    /// practical defaults (deg, °C, bar). Matches canboat's `-si`.
+    #[arg(long)]
+    si: bool,
+
+    /// Lat/lon display format. Matches canboat's `-geo`.
+    #[arg(long, value_name = "FMT", default_value = "dd")]
+    geo: GeoArg,
+}
+
+/// `--geo` values, mirroring canboat's `-geo {dd|dm|dms}`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+enum GeoArg {
+    /// Decimal degrees, `dd.dddddd`.
+    Dd,
+    /// Degrees and decimal minutes, `dd.mm.mmm`.
+    Dm,
+    /// Degrees, minutes, seconds, `dd.mm.sss`.
+    Dms,
+}
+
+impl From<GeoArg> for GeoFormat {
+    fn from(g: GeoArg) -> Self {
+        match g {
+            GeoArg::Dd => GeoFormat::Dd,
+            GeoArg::Dm => GeoFormat::Dm,
+            GeoArg::Dms => GeoFormat::Dms,
+        }
+    }
 }
 
 impl Args {
@@ -272,11 +331,23 @@ fn convert_decoded<W: Write>(
     ebl: bool,
     out: &mut W,
 ) -> Result<()> {
-    let json_opts = JsonOptions::default();
+    let camel_case = if args.upper_camel {
+        CamelCase::Upper
+    } else if args.camel {
+        CamelCase::Lower
+    } else {
+        CamelCase::Off
+    };
+    let json_opts = JsonOptions {
+        include_empty: args.empty,
+        name_value: args.nv,
+        debug: args.debug,
+        camel_case,
+    };
     let text_opts = TextOptions {
-        show_unavailable: false,
-        debug: false,
-        geo: GeoFormat::Dd,
+        show_unavailable: args.empty,
+        debug: args.debug,
+        geo: args.geo.into(),
     };
     let as_json = args.to == OutFormat::Json;
     let cfg = analyze::Config {
@@ -285,7 +356,11 @@ fn convert_decoded<W: Write>(
         src_filter: args.src,
         dst_filter: args.dst,
         suppress_startup_record: false,
-        units: canboat_core::Units::Metric,
+        units: if args.si {
+            canboat_core::Units::Si
+        } else {
+            canboat_core::Units::Metric
+        },
     };
 
     let mut line = String::with_capacity(512);


### PR DESCRIPTION
## First: I owe you a correction

I told you we needed "`convert -json -nv` equivalency and the header". **Both already existed** — I was comparing the wrong entry point.

`canboat` has an argv[0] alias: invoked as **`analyzer`** it already accepts `--json --empty --nv --si --debug --geo --camel --upper-camel --fixtime --src --dst --format`, and it **does** emit the version record. The golden tests have been exercising it that way all along (`pgn_test_json_nv` and friends). My corpus comparison used `canboat convert`, which is the format-conversion tool, not the compatibility alias — so what I reported as "missing parity" was me holding it wrong.

```
$ analyzer -json -nv                 # C
{"version":"7.1.0","units":"std","showLookupValues":true}
$ canboat(as analyzer) --json --nv   # Rust
{"version":"7.1.0","commit":"eb78613","units":"std","showLookupValues":true}
```
Byte-identical data lines; the only header difference is the Rust side's extra `"commit"` field.

## What this PR actually does

`convert` was still hardcoding one arbitrary point in the C's option space — `JsonOptions::default()`, `debug: false`, `GeoFormat::Dd`, `Units::Metric`. It now exposes the same set:

| flag | C equivalent |
|---|---|
| `--nv` | `-nv` |
| `--empty` | `-empty` |
| `--debug` | `-debug` |
| `--camel` / `--upper-camel` | `-camel` / `-upper-camel` |
| `--si` | `-si` |
| `--geo dd\|dm\|dms` | `-geo` |

**No new capability** — `canboat-core` already implements all of it. This is CLI plumbing.

Verified: `canboat convert --to json --nv` is now byte-identical to `analyzer -json -nv` (modulo the leading version record) on `samples/130311.raw`; `--si` gives radians where the default gives degrees; `--geo dms` renders `14d 04' 26.610"N`; `--camel` switches to `vesselHeading`. The `analyzer` alias is unchanged.

## The real gap is decoding, not flags

With the *correct* invocation across the samples corpus (`-json -nv`, version record dropped): **35 identical, 59 differing.** Those 59 are not about flags:

| | |
|---|---|
| 1 | `ikonvert.log` — the **C** decodes nothing, Rust produces 8922 lines |
| 1 | `device_functions.csv` — **Rust** decodes nothing, C produces 2 lines |
| 57 | both decode, content differs |

Sampling the 57 turns up several distinct classes, all real:

- **unnamed lookup entries** — C emits `{"value":2,"name":null}` in a bit array, Rust omits the entry
- **unavailable 64-bit lat/lon** — Rust renders `922.3372037` where C omits the field (sentinel handling)
- **float precision** — `"Heading to Steer":2.7274` vs `2.7273988723754883`
- **key/value pairs** — C decodes `Value` after `Length`, Rust stops
- **byte order** — `"Helm":"F0"` vs `"0F"`
- plus fields each side emits that the other doesn't (`Address`, `Spare`, `Message`)

That's a multi-PR project with genuine bugs on both sides, and worth its own scoping conversation rather than me picking. Happy to start wherever you'd like — the sentinel/lat-lon and byte-order ones look most like outright defects.

## Gates

450 workspace tests pass with `CANBOAT_GOLDEN=required` · clippy `-D warnings` and fmt clean · `keel check` 0/0 · C side untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)