### PR TITLE
fix(rust): detect the unavailable sentinel on 64-bit fields

### DIFF
--- a/crates/canboat-core/build.rs
+++ b/crates/canboat-core/build.rs
@@ -845,19 +845,31 @@ fn sentinels(
 ) -> (Option<u64>, Option<u64>, Option<u64>) {
     let ft = ft_of(db, f);
     if f.reserved_count == 0
-        || f.res_bits >= 64
         || f.res_range_min.is_nan()
         || f.match_.is_some()
         || ft.root_sentinels != "TopOfRange"
     {
         return (None, None, None);
     }
+    // NB: emit_xml additionally suppresses these for 64-bit fields, and the
+    // XML/JSON therefore carry no UnknownValue for e.g. 129029's latitude
+    // (QUIRKS Q18). That is right for the *document* but wrong for a runtime
+    // schema: the decoder has nothing left to compare against, so an
+    // unavailable 64-bit lat/lon decoded as the number 922.3372037 instead of
+    // being reported unavailable. The C never had the problem because it
+    // recomputes the bound from the bit width at decode time. So: no width
+    // guard here.
     let highbit = if ft.has_sign == Some(true) && f.res_offset == 0 {
         f.res_bits - 1
     } else {
         f.res_bits
     };
-    let raw = (1u64 << highbit) - 1;
+    // highbit == 64 for an unsigned 64-bit field, where 1u64 << 64 is UB.
+    let raw = if highbit >= 64 {
+        u64::MAX
+    } else {
+        (1u64 << highbit) - 1
+    };
     (
         Some(raw),
         (f.reserved_count >= 2).then(|| raw - 1),


### PR DESCRIPTION
An unavailable 64-bit latitude decoded as the number **922.3372037** instead of being reported unavailable. That's `INT64_MAX * 1e-16` — the raw wire value is the all-ones "not available" sentinel, scaled by the field's resolution as though it were real data.

Across `samples/` that produced **9514** such lines.

## Cause

The decoder decides availability purely from the schema's `unknown_value` / `out_of_range_value` / `reserved_value`, and for a 64-bit field the schema carried **none** — so there was nothing to compare against and every sentinel read as data:

```
$ analyzer -json -nv          # C:    field omitted entirely
"fields":{"GNSS type":{"value":3,...
$ canboat convert --to json --nv   # Rust: sentinel scaled into a position
"fields":{"Latitude":922.3372037,"Longitude":922.3372037,...
```

The C never had the bug because it recomputes the bound from the bit width at decode time rather than reading it from a table.

**The gap traces to a rule I copied a little too faithfully in #774.** `emit_xml` suppresses sentinel elements for fields ≥64 bits (QUIRKS **Q18**), and I carried the `f.res_bits >= 64` guard straight into the Rust schema. It's the right rule for the *document* — `canboat.xml` and `canboat.json` genuinely carry no `UnknownValue` for 129029's latitude — and the wrong rule for a runtime schema, whose whole job is to give the decoder something to compare against.

To be clear about blame: **the bug predates the port.** The old `build.rs` read those same absent values out of `canboat.json`, so canboat-rs has always mis-decoded these.

## Fix

The width guard is dropped in `build.rs` **only** — `emit_xml` keeps it and `canboat.xml` is byte-identical. Two details:

- the shift is made safe: `highbit` reaches 64 for an unsigned 64-bit field, where `1u64 << 64` is UB
- an unsigned 64-bit field whose range already spans the full width derives `reserved_count == 0` and is excluded earlier, so it keeps every bit pattern valid (QUIRKS **Q7**)

## Measured, with a control build

| | before | after |
|---|---|---|
| sentinel leaked as a number | **9514 lines** | **0** |
| files decoding identically to the C | 42 | **43** |
| regressions | — | **none** |

Only one file flips all the way to identical because most of the rest differ for unrelated reasons too — the unnamed-lookup-value class (`Indicator11` emitted as `{"value":2}` where the C omits it) and the byte-order class (`"Helm":"F0"` vs `"0F"`) are still open.

## Gates

450 workspace tests pass with `CANBOAT_GOLDEN=required` · clippy `-D warnings` and fmt clean · `keel check` 0/0 · 6 artifacts current · `contract.py` **No contract changes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)