### PR TITLE
fix(rust): match canboat on sub-byte BINARY and unnamed lookup values

### DIFF
--- a/crates/canboat-core/build.rs
+++ b/crates/canboat-core/build.rs
@@ -845,19 +845,31 @@ fn sentinels(
 ) -> (Option<u64>, Option<u64>, Option<u64>) {
     let ft = ft_of(db, f);
     if f.reserved_count == 0
-        || f.res_bits >= 64
         || f.res_range_min.is_nan()
         || f.match_.is_some()
         || ft.root_sentinels != "TopOfRange"
     {
         return (None, None, None);
     }
+    // NB: emit_xml additionally suppresses these for 64-bit fields, and the
+    // XML/JSON therefore carry no UnknownValue for e.g. 129029's latitude
+    // (QUIRKS Q18). That is right for the *document* but wrong for a runtime
+    // schema: the decoder has nothing left to compare against, so an
+    // unavailable 64-bit lat/lon decoded as the number 922.3372037 instead of
+    // being reported unavailable. The C never had the problem because it
+    // recomputes the bound from the bit width at decode time. So: no width
+    // guard here.
     let highbit = if ft.has_sign == Some(true) && f.res_offset == 0 {
         f.res_bits - 1
     } else {
         f.res_bits
     };
-    let raw = (1u64 << highbit) - 1;
+    // highbit == 64 for an unsigned 64-bit field, where 1u64 << 64 is UB.
+    let raw = if highbit >= 64 {
+        u64::MAX
+    } else {
+        (1u64 << highbit) - 1
+    };
     (
         Some(raw),
         (f.reserved_count >= 2).then(|| raw - 1),

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -1125,6 +1125,20 @@ fn decode_lookup(
     if let Some(sent) = sentinel_field_value(f, ex) {
         return sent;
     }
+    // Still nothing, and the table does not name this value. canboat does not
+    // fall back to printing the bare number here: fieldPrintLookup treats an
+    // unnamed value in the top reserved band as unavailable, using a bound it
+    // computes from the field width rather than any schema hint --
+    //     *bits > 1 && value >= maxValue - (*bits > 2 ? 2 : 1)
+    // so a 2-bit lookup reserves its top two values and anything wider its top
+    // three. Without this, PGN 127501's `Indicator11` reported {"value":2}
+    // where canboat omits the field entirely.
+    if bit_length > 1 {
+        let band = if bit_length > 2 { 2 } else { 1 };
+        if ex.value >= ex.max - band {
+            return FieldValue::NotAvailable;
+        }
+    }
     FieldValue::Lookup {
         value: raw,
         name: None,
@@ -1291,22 +1305,43 @@ fn decode_binary(data: &[u8], bit_offset: u32, bit_length: u32) -> FieldValue {
         let end = declared_end.min(data.len());
         return FieldValue::Binary(data[start..end].to_vec());
     }
-    // Bit-aligned binary: pack into bytes LSB-first to keep round-trip
-    // semantics with extract_bits.
-    let bytes = bit_length.div_ceil(8);
-    let mut out = vec![0u8; bytes];
-    let mut bo = bit_offset;
-    let mut remaining = bit_length;
-    let mut byte_i = 0usize;
-    while remaining > 0 {
-        let chunk = remaining.min(8);
-        let Some(ex) = extract_bits(data, bo, chunk, false, 0) else {
-            return FieldValue::NotAvailable;
+    // Not byte-aligned. This is NOT a clean bit-extraction, and must not
+    // become one: `fieldPrintBinary` masks the *first* byte to the field's
+    // width but then shifts it back to where it sat in the byte, and takes
+    // every later byte whole. So PGN 130829's two 4-bit nibbles render as
+    // "0F" (low) and "F0" (high) — the high nibble keeps its position rather
+    // than being normalised down. Packing LSB-first instead reported both as
+    // "0F", losing which nibble the bits came from.
+    let start_byte = bit_offset / 8;
+    let start_bit = bit_offset % 8;
+    // canboat clamps the width to what the payload actually holds.
+    let avail = data.len().saturating_mul(8).saturating_sub(bit_offset);
+    let bit_length = bit_length.min(avail);
+    if bit_length == 0 {
+        return FieldValue::NotAvailable;
+    }
+    let nbytes = bit_length.div_ceil(8);
+    let mut out = Vec::with_capacity(nbytes);
+    let mut remaining = bit_length as isize;
+    for i in 0..nbytes {
+        let Some(&raw) = data.get(start_byte + i) else {
+            break;
         };
-        out[byte_i] = ex.value as u8;
-        byte_i += 1;
-        bo += chunk;
-        remaining -= chunk;
+        let mut byte = raw;
+        if i == 0 && start_bit != 0 {
+            byte >>= start_bit;
+            if (remaining as usize) + start_bit < 8 {
+                byte &= (1u8 << remaining) - 1;
+            }
+            byte <<= start_bit;
+            remaining -= (8 - start_bit) as isize;
+        } else {
+            if remaining < 8 {
+                byte &= (1u8 << remaining) - 1;
+            }
+            remaining -= 8;
+        }
+        out.push(byte);
     }
     FieldValue::Binary(out)
 }


### PR DESCRIPTION
Two more decode divergences from the corpus comparison, both traced to the C and fixed to match it. **Stacked on #777** (the sentinel fix is the first of the three commits here; targeting master so there's no dead-end base).

## Sub-byte BINARY lost its bit position

PGN 130829 has two adjacent 4-bit nibbles. canboat prints them `"0F"` (low) and `"F0"` (high); the Rust printed `"0F"` for both.

`fieldPrintBinary` masks the **first** byte to the field's width and then shifts it *back* to where it sat in the byte — and takes every later byte whole. It is deliberately not a clean bit-extraction:

```c
byte >>= startBit;
if (remaining_bits + startBit < 8) byte &= (1 << remaining_bits) - 1;
byte <<= startBit;                  // shift zeros back in
```

The Rust packed LSB-first, which normalised the high nibble down and lost which half of the byte the bits came from. `decode_binary` now mirrors the C loop, including its clamp against a short payload. Byte-aligned fields are untouched — that path already agreed and still takes the fast slice.

## An unnamed lookup value in the reserved band is unavailable, not a number

PGN 127501's `Indicator11` reported `{"value":2}` where canboat omits the field entirely.

When no enumeration name resolves, `fieldPrintLookup` doesn't fall back to printing the raw value. It first tests a bound it computes **from the field width**, not from any schema hint:

```c
*bits > 1 && value >= maxValue - (*bits > 2 ? 2 : 1)
```

So a 2-bit lookup reserves its top two values, anything wider its top three. The Rust consulted only the per-field sentinel hints — which schema 2.5.0 carries for roughly a third of LOOKUP fields — and emitted the bare number for the rest. The computed band is now the fallback *after* those hints, so the existing "an enumeration name always wins" contract still holds.

## Measured

| | before | after |
|---|---|---|
| differing lines across the corpus | 37022 | **36368** |
| files identical to the C | 43 | **44** (`mercury-proprietary.raw`) |

No regressions in either. Files rarely flip outright because most carry several unrelated divergences at once, so the **line count is the honest measure** of these two changes — I checked both fixes directly on the fields in question as well.

## Gates

450 workspace tests pass with `CANBOAT_GOLDEN=required` · clippy `-D warnings` and fmt clean · C side untouched.

## Still open

The next visible class is whole records one side emits and the other doesn't — e.g. a 126208 *NMEA - Command group function* that the Rust decodes and canboat skips. That's a different shape of problem (record acceptance, not field rendering) and wants its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)