### PR TITLE
fix: decode parity between canboat convert and the C analyzer

### DIFF
--- a/analyzer/print.c
+++ b/analyzer/print.c
@@ -602,6 +602,33 @@ extern bool fieldPrintDecimal(const Field   *field,
     *bits = dataLen * 8 - startBit;
   }
 
+  /*
+   * All bits set is "not available", as it is for every other field type.
+   * Without this the loop below prints nothing at all -- each 0xff byte is
+   * 255, which fails its own `value < 100` test -- and printField's
+   * "print routine did not print anything" guard then throws the whole PGN
+   * away. A DSC call whose MMSI of Ship In Distress is simply absent took
+   * every other field of the record with it.
+   */
+  {
+    size_t byteCount = (*bits + 7) / 8;
+    size_t i;
+    bool   allOnes = (byteCount > 0);
+
+    for (i = 0; i < byteCount && allOnes; i++)
+    {
+      if (data[i] != 0xff)
+      {
+        allOnes = false;
+      }
+    }
+    if (allOnes)
+    {
+      printEmpty(fieldName, DATAFIELD_UNKNOWN);
+      return true;
+    }
+  }
+
   for (bit = 0; bit < *bits && bit < sizeof(buf) * 8; bit++)
   {
     /* Act on the current bit */

--- a/analyzer/print.c
+++ b/analyzer/print.c
@@ -1168,7 +1168,35 @@ extern bool fieldPrintTime(const Field   *field,
   hours    = minutes / 60;
   minutes  = minutes % 60;
 
-  digits = log10(unitspersecond);
+  /*
+   * How many decimals to show, and `fraction` expressed in them.
+   *
+   * `fraction` counts resolution units, not decimal places. Printing it as a
+   * decimal is only correct when there are a power of ten of those per second.
+   * DURATION_UFIX8_5MS has 200/s, so 19 units -- 0.095 s -- came out as
+   * "00:00:00.19", and 150 units (0.750 s) as "00:00:00.150", three digits in
+   * a two-digit field. Take the width from the units-per-second instead (the
+   * smallest power of ten that covers it) and scale the fraction into it.
+   *
+   * Done in integer arithmetic on purpose: deriving the width by multiplying
+   * the resolution by ten until it reaches 1.0 would be at the mercy of
+   * binary rounding, and 0.0001 -- 23 fields -- is exactly the sort of value
+   * that lands a hair under and gains a digit.
+   */
+  {
+    uint64_t scale = 1;
+
+    digits = 0;
+    while (scale < unitspersecond && digits < 9)
+    {
+      scale *= 10;
+      digits++;
+    }
+    if (digits > 0 && unitspersecond > 0)
+    {
+      fraction = (uint32_t) (((uint64_t) fraction * scale) / unitspersecond);
+    }
+  }
 
   if (showJson)
   {

--- a/crates/canboat-core/build.rs
+++ b/crates/canboat-core/build.rs
@@ -92,6 +92,10 @@ struct RawField {
     match_value: Option<i64>,
     part_of_primary_key: Option<bool>,
     condition: Option<String>,
+    /// Bytes of per-record header that sit between a
+    /// DYNAMIC_FIELD_LENGTH field and the value it sizes, and that the
+    /// reported length counts. Subtracted to get the value's own width.
+    dynamic_field_length_overhead: u32,
 }
 
 struct RawLookup {
@@ -452,7 +456,8 @@ fn emit_field(out: &mut String, f: &RawField, v: &FieldView) {
          lookup_enumeration:{le},lookup_bit_enumeration:{lbe},lookup_indirect_enumeration:{lie},\
          lookup_indirect_enumeration_field_order:{liefo},lookup_field_type_enumeration:{lfte},\
          match_value:{mv},part_of_primary_key:{popk},condition:{cond},\
-         unit_offset:{unit_offset},precision:{precision},is_dynamic_length_marker:{dlm}}},",
+         unit_offset:{unit_offset},precision:{precision},is_dynamic_length_marker:{dlm},\
+         dynamic_field_length_overhead:{dflo}}},",
         order = f.order,
         id = quote(&f.id),
         name = quote(&f.name),
@@ -485,6 +490,7 @@ fn emit_field(out: &mut String, f: &RawField, v: &FieldView) {
         unit_offset = float(v.unit_offset),
         precision = v.precision,
         dlm = v.is_dynamic_length_marker,
+        dflo = f.dynamic_field_length_overhead,
     )
     .unwrap();
 }
@@ -946,6 +952,7 @@ fn raw_field(
         match_value: db.resolve_match(f).map(|v| v as i64),
         part_of_primary_key: f.primary_key.then_some(true),
         condition: f.proprietary.then(|| "PGNIsProprietary".to_string()),
+        dynamic_field_length_overhead: f.dynamic_field_length_overhead,
     }
 }
 

--- a/crates/canboat-core/build.rs
+++ b/crates/canboat-core/build.rs
@@ -147,6 +147,11 @@ struct RawFieldTypeValue {
     unit: Option<String>,
     lookup_enumeration: Option<String>,
     lookup_bit_enumeration: Option<String>,
+    /// Signedness of the fieldtype this entry resolves to — e.g.
+    /// `CURRENT_FIX32_MA` for VICTRON_VREG's "DC Current". Carried
+    /// explicitly because `field_type` above is the *root* name
+    /// (`NUMBER`), which says nothing about the sign.
+    signed: bool,
 }
 
 // ---------------------------------------------------------------------
@@ -267,7 +272,13 @@ struct ComputedFt {
 }
 
 fn compute_ft(v: &mut RawFieldTypeValue) -> ComputedFt {
-    let mut c = ComputedFt::default();
+    let mut c = ComputedFt {
+        // The fieldtype's own signedness is the answer. The unit test
+        // below only ever *adds* to it, for angle types that canboat
+        // spells FIX under the hood.
+        signed: v.signed,
+        ..ComputedFt::default()
+    };
     let Some(unit) = v.unit.clone() else {
         return c;
     };
@@ -1096,6 +1107,7 @@ fn from_keel(root: &Path) -> CanboatJson {
                                 .map(|b| b.to_string()),
                             resolution: ftv.map(|f| f.resolution).filter(|r| *r != 0.0),
                             unit: ftv.and_then(|f| f.unit.clone()),
+                            signed: ftv.and_then(|f| f.has_sign).unwrap_or(false),
                             lookup_enumeration: e
                                 .lookup
                                 .clone()

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -1632,10 +1632,15 @@ fn decode_string_fix(data: &[u8], bit_offset: u32, bit_length: u32) -> FieldValu
         };
     }
     let start = bo / 8;
-    let end = start + bl / 8;
-    if end > data.len() {
+    if start >= data.len() {
         return FieldValue::NotAvailable;
     }
+    // Cap to what is actually in the message rather than dropping the
+    // field — `len = CB_MIN(len, dataLen)` in `fieldPrintStringFix`
+    // (print.c). Navico's 130821 ASCII Data declares a 230-byte
+    // Message and sends however much text it has, so the declared
+    // width is a maximum, not a promise.
+    let end = (start + bl / 8).min(data.len());
     // Canboat's `printString` first finds an embedded NUL and shortens
     // the string at that point (matches the C-string convention some
     // devices use to terminate inside a fixed-width buffer — e.g. a
@@ -2119,6 +2124,35 @@ mod tests {
             db().decode(&frame),
             Err(DecodeError::UnknownPgn { pgn: 1 })
         ));
+    }
+
+    #[test]
+    fn string_fix_is_capped_to_the_message_not_dropped() {
+        // Navico's 130821 ASCII Data declares a 230-byte `Message` and
+        // sends however much text it has, so the declared width is a
+        // maximum. canboat caps to what arrived
+        // (`len = CB_MIN(len, dataLen)`, fieldPrintStringFix); dropping
+        // the field instead loses the whole payload.
+        let mut data: smallvec::SmallVec<[u8; 8]> = smallvec::smallvec![0x13, 0x99, 0x00];
+        data.extend_from_slice(b"HELLO");
+        let frame = RawFrame {
+            timestamp: None,
+            prio: 7,
+            pgn: 130821,
+            src: 19,
+            dst: 255,
+            data,
+        };
+        let dec = db().decode(&frame).expect("decode");
+        let msg = dec
+            .fields
+            .iter()
+            .find(|f| f.info.name == "Message")
+            .expect("a Message field");
+        match &msg.value {
+            FieldValue::String(s) => assert_eq!(s, "HELLO"),
+            other => panic!("expected the truncated text, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -34,6 +34,32 @@ fn sentinel_field_value(f: &FieldInfo, ex: Extracted) -> Option<FieldValue> {
     }
 }
 
+/// The tail of canboat's `fieldPrintLookup` for a value the
+/// enumeration does not name: one in the top band of the field's width
+/// is unavailable rather than a bare number —
+///
+/// ```text
+///     *bits > 1 && value >= maxValue - (*bits > 2 ? 2 : 1)
+/// ```
+///
+/// so a 2-bit lookup reserves its top value and anything wider its top
+/// two. Shared, because the C reaches a *dynamic* LOOKUP through the
+/// very same `fieldPrintLookup` as a static one; PGN 127501's
+/// `Indicator11` and PGN 130845's `Auto calibration mode` are the same
+/// rule seen from the two paths.
+fn unnamed_lookup_value(ex: Extracted, bits: u32) -> FieldValue {
+    if bits > 1 {
+        let band = if bits > 2 { 2 } else { 1 };
+        if ex.value >= ex.max - band {
+            return FieldValue::NotAvailable;
+        }
+    }
+    FieldValue::Lookup {
+        value: ex.raw,
+        name: None,
+    }
+}
+
 /// The same test, for a field whose FieldType declares
 /// `Sentinels: None` and so carries none of the hints above, but which
 /// still has a `RangeMax` below what its bit width can hold.
@@ -1342,24 +1368,8 @@ fn decode_lookup(
     if let Some(sent) = sentinel_field_value(f, ex) {
         return sent;
     }
-    // Still nothing, and the table does not name this value. canboat does not
-    // fall back to printing the bare number here: fieldPrintLookup treats an
-    // unnamed value in the top reserved band as unavailable, using a bound it
-    // computes from the field width rather than any schema hint --
-    //     *bits > 1 && value >= maxValue - (*bits > 2 ? 2 : 1)
-    // so a 2-bit lookup reserves its top two values and anything wider its top
-    // three. Without this, PGN 127501's `Indicator11` reported {"value":2}
-    // where canboat omits the field entirely.
-    if bit_length > 1 {
-        let band = if bit_length > 2 { 2 } else { 1 };
-        if ex.value >= ex.max - band {
-            return FieldValue::NotAvailable;
-        }
-    }
-    FieldValue::Lookup {
-        value: raw,
-        name: None,
-    }
+    // Still nothing, and the table does not name this value.
+    unnamed_lookup_value(ex, bit_length)
 }
 
 /// INDIRECT_LOOKUP: resolve `(value1, value2)` where `value1` is
@@ -2017,11 +2027,16 @@ fn decode_dynamic_field_value(
                 else {
                     return (FieldValue::NotAvailable, bits);
                 };
-                let raw = ex.value as u64;
-                let nm = db.lookup(name).and_then(|t| t.get(raw)).map(|v| v.name);
-                FieldValue::Lookup {
-                    value: raw,
-                    name: nm,
+                match db.lookup(name).and_then(|t| t.get(ex.raw)).map(|v| v.name) {
+                    Some(nm) => FieldValue::Lookup {
+                        value: ex.raw,
+                        name: Some(nm),
+                    },
+                    // PGN 130845's `Auto calibration mode` reads 0xFF on a
+                    // Read request, which SIMNET_COMPASS_AUTOCAL_MODE does
+                    // not name, and canboat omits the field rather than
+                    // reporting `{"value":255}`.
+                    None => unnamed_lookup_value(ex, bits),
                 }
             }
             None => decode_binary(data, bit_offset, bits),
@@ -2245,6 +2260,18 @@ mod tests {
         assert_eq!(trim_string_padding("abc\t \u{0}@\u{ff}"), "abc");
         // Interior whitespace is untouched.
         assert_eq!(trim_string_padding("a b"), "a b");
+    }
+
+    #[test]
+    fn dynamic_field_signedness_comes_from_the_field_type() {
+        // Victron's VE.Can Register 8220 (DC Current) resolves to
+        // CURRENT_FIX32_MA — signed. The generated table used to derive
+        // signedness from the *unit* alone (angles only), so a negative
+        // current read as 4294964.496 instead of -2.8.
+        let entry = db()
+            .field_type_lookup("VICTRON_VREG", 8220)
+            .expect("VICTRON_VREG 8220");
+        assert!(entry.signed, "DC Current must be signed");
     }
 
     #[test]

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -1409,15 +1409,20 @@ fn decode_reserved(
             bit_length,
         };
     }
-    // Pack just the field's value into bytes (little-endian), one byte
-    // per `ceil(bit_length / 8)`. This avoids leaking neighboring
-    // fields' bits when the reserved span shares a byte with adjacent
-    // payload (which slicing `data[start..end]` would do).
-    let n_bytes = bit_length.div_ceil(8).max(1) as usize;
-    let mut bytes = Vec::with_capacity(n_bytes);
-    for i in 0..n_bytes {
-        bytes.push(((raw >> (i * 8)) & 0xff) as u8);
-    }
+    // A RESERVED or SPARE field that does need printing is handed
+    // straight to `fieldPrintBinary` by the C (`fieldPrintReserved` /
+    // `fieldPrintSpare`, print.c), so every bit stays where it sat:
+    // the first byte is masked to the field's width and shifted back
+    // into position, and later bytes come whole off the message.
+    //
+    // Packing the extracted value LSB-first instead moved the bits down
+    // to bit 0 — PGN 130824's 2-bit Reserved at bit 11 printed `02`
+    // where canboat prints `10`, and the same shift showed up on every
+    // proprietary PGN's Reserved field.
+    let bytes = match decode_binary(data, bit_offset, bit_length) {
+        FieldValue::Binary(b) => b,
+        _ => Vec::new(),
+    };
     if is_reserved {
         FieldValue::Reserved {
             value: raw,
@@ -2152,6 +2157,34 @@ mod tests {
         match &msg.value {
             FieldValue::String(s) => assert_eq!(s, "HELLO"),
             other => panic!("expected the truncated text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reserved_bytes_keep_their_bit_position() {
+        // PGN 130824's field 2 is a 2-bit Reserved at bit 11, i.e. bits
+        // 3..4 of byte 1. canboat prints it through `fieldPrintBinary`,
+        // which masks the first byte and shifts it back where it was,
+        // so a value of 0b10 renders `10` — not `02`.
+        let data: smallvec::SmallVec<[u8; 8]> =
+            smallvec::smallvec![0x7d, 0x91, 0x64, 0x20, 0x2d, 0x00];
+        let frame = RawFrame {
+            timestamp: None,
+            prio: 3,
+            pgn: 130824,
+            src: 26,
+            dst: 255,
+            data,
+        };
+        let dec = db().decode(&frame).expect("decode");
+        let r = dec
+            .fields
+            .iter()
+            .find(|f| f.info.name == "Reserved")
+            .expect("a Reserved field");
+        match &r.value {
+            FieldValue::Reserved { bytes, .. } => assert_eq!(bytes.as_slice(), &[0x10]),
+            other => panic!("expected Reserved bytes, got {other:?}"),
         }
     }
 

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -556,9 +556,16 @@ struct DecodeContext {
     /// after. Stored as cloned data so we don't have to thread a
     /// lifetime through every decoder.
     dynamic_field_type: Option<crate::types::LookupFieldTypeValue>,
-    /// Byte length from a DYNAMIC_FIELD_LENGTH field. Cleared with
-    /// `dynamic_field_type` after the value is decoded.
-    dynamic_length_bytes: Option<u32>,
+    /// Byte length from a DYNAMIC_FIELD_LENGTH field, net of the
+    /// record overhead. Cleared with `dynamic_field_type` after the
+    /// value is decoded. Signed, and legitimately negative when a
+    /// truncated record declares a length below its own header — the
+    /// C's `g_length` is `int64_t` for the same reason.
+    dynamic_length_bytes: Option<i64>,
+    /// Set by a decoder that wants its field omitted from the output
+    /// while the walk carries on past it — canboat's `g_skip`
+    /// (print.c). Read and cleared by the field walker.
+    skip_field: bool,
     /// Which definition of `target_pgn` the parameters address, and
     /// whether it had to be borrowed from the catch-all. Resolved at
     /// the first VARIABLE field and reused for the rest of the record,
@@ -657,6 +664,12 @@ fn decode_fields(
             decode_one_field_at(f, info, data, db, effective_offset, &mut ctx)
         {
             cursor_bits = effective_offset + bits_consumed;
+            // `skip_field` omits the field but keeps the walk going,
+            // and the cursor has already advanced past it.
+            if core::mem::take(&mut ctx.skip_field) {
+                i += 1;
+                continue;
+            }
             out.push(decoded);
         }
         i += 1;
@@ -772,8 +785,13 @@ fn decode_repeating(
                     Some(iter)
                 };
                 first_field_of_iter = false;
-                out.push(d);
                 sub_cursor = off + bits;
+                // The record is still real when a value is omitted for
+                // being explicitly empty, so this iteration counts as
+                // productive and the walk continues to the next record.
+                if !core::mem::take(&mut ctx.skip_field) {
+                    out.push(d);
+                }
                 produced_any = true;
             } else if let Some(bl) = sf.bit_length {
                 // Field couldn't decode but has a known size; advance
@@ -954,12 +972,12 @@ fn decode_one_field_at(
     // `DYNAMIC_FIELD_LENGTH` type (e.g. Simnet Parameter Set 130846).
     if f.is_dynamic_length_marker {
         let raw_len = match &value {
-            FieldValue::Integer(n) if *n >= 0 => Some(*n as u32),
-            FieldValue::Number(n) if *n >= 0.0 => Some(*n as u32),
+            FieldValue::Integer(n) if *n >= 0 => Some(*n),
+            FieldValue::Number(n) if *n >= 0.0 => Some(*n as i64),
             _ => None,
         };
         if let Some(n) = raw_len {
-            ctx.dynamic_length_bytes = Some(n);
+            ctx.dynamic_length_bytes = Some(n - i64::from(f.dynamic_field_length_overhead));
         }
     }
 
@@ -1797,7 +1815,12 @@ fn decode_dynamic_field_length(
     if let Some(sent) = sentinel_field_value(f, ex) {
         return sent;
     }
-    let len = ex.raw as u32;
+    // The reported length may cover a per-record header sitting between
+    // this field and the value — Navico's 130822/130823 dumps count the
+    // class byte and the 16-bit data-type id — so take that off to get
+    // the value's own width (`g_length = value - overhead`,
+    // analyzer.c::fillGlobalsBasedOnFieldName).
+    let len = ex.raw as i64 - i64::from(f.dynamic_field_length_overhead);
     ctx.dynamic_length_bytes = Some(len);
     FieldValue::Integer(ex.value)
 }
@@ -1815,17 +1838,48 @@ fn decode_dynamic_field_value(
     ctx: &mut DecodeContext,
 ) -> (FieldValue, u32) {
     let entry = ctx.dynamic_field_type.take();
-    let length_bits = ctx
-        .dynamic_length_bytes
-        .take()
+    let explicit_len = ctx.dynamic_length_bytes.take();
+    let length_bits: Option<i64> = explicit_len
         .map(|n| n * 8)
-        .or_else(|| entry.as_ref().and_then(|e| e.bit_length()));
+        .or_else(|| entry.as_ref().and_then(|e| e.bit_length()).map(i64::from));
+    // An explicit length of zero means the value is present but empty
+    // — PGN 130823 directory entries that declare only a data type.
+    // canboat omits the field rather than printing `""`
+    // (`g_lengthValid && *bits == 0` → `g_skip`, print.c). Note this
+    // is checked before the resolved-key branch below, so a known
+    // field type with a zero length is dropped too.
+    if explicit_len == Some(0) {
+        ctx.skip_field = true;
+        return (FieldValue::NotAvailable, 0);
+    }
+    let bits_signed = length_bits.unwrap_or(0);
+    let remaining = (data.len() as u32 * 8).saturating_sub(bit_offset);
+    if bits_signed < 0 {
+        // A record declaring a length below its own header width. The
+        // C subtracts the overhead into a signed `g_length` and then
+        // casts to `size_t` for the bounds test below, so the negative
+        // width wraps to something enormous, sails past that test and
+        // reaches `fieldPrintBinary`, which clamps it to what is left
+        // of the packet. Accidental, but the resulting reading — dump
+        // the rest of the frame — is the useful one, so match it
+        // deliberately rather than by arithmetic.
+        return (decode_binary(data, bit_offset, remaining), remaining);
+    }
+    // The declared value runs past the end of the packet: the frame
+    // ended mid-record. That is how a repeating key/value group
+    // normally terminates — the device packs as many records as fit
+    // and the last one is cut off — so canboat drops the partial value
+    // and stops there rather than failing the whole PGN (print.c).
+    if (data.len() as i64) < (bit_offset as i64 + bits_signed) >> 3 {
+        ctx.skip_field = true;
+        return (FieldValue::NotAvailable, remaining);
+    }
     // Mirror canboat's fieldPrintKeyValue: no resolved length and
     // no resolved field type → emit an empty BINARY blob (the
     // `g_length = 0, g_ftf = NULL, fieldPrintBinary(bits=0)` path
     // in print.c). Better than erroring out — this is how PGN
     // 130845 with an unknown SIMNET_KEY_VALUE key renders.
-    let bits = length_bits.unwrap_or(0);
+    let bits = bits_signed as u32;
     let Some(entry) = entry else {
         // Unresolved key — render as a raw BINARY blob over the
         // declared length (zero bytes is fine, comes out as "").
@@ -2044,6 +2098,64 @@ mod tests {
             db().decode(&frame),
             Err(DecodeError::UnknownPgn { pgn: 1 })
         ));
+    }
+
+    #[test]
+    fn dynamic_length_overhead_sizes_130823_records() {
+        // A reassembled PGN 130823 directory report (the first record
+        // of samples/navico-130823.raw). Each entry is
+        // [Length][Type][Data Type:16][Value…] and `Length` counts the
+        // three header bytes as well, so the value is `Length - 3`.
+        // Without the overhead the walk reads three bytes too many per
+        // record and every entry after the first is garbage.
+        let data: smallvec::SmallVec<[u8; 8]> = smallvec::smallvec![
+            0x13, 0x99, 0xff, 0x00, 0x05, 0x01, 0x00, 0x0a, 0x00, 0x55, 0x02, 0xbc, 0x2f, 0x00,
+            0x96, 0x50, 0xc0, 0xff, 0x04, 0x02, 0x26, 0x00, 0x00, 0x04, 0x02, 0x27, 0x00, 0x00,
+            0x04, 0x02, 0x7d, 0x00, 0x00, 0x04, 0x02, 0xa5, 0x00, 0x00, 0x04, 0x02, 0x99, 0x01,
+            0x00, 0x04, 0x02, 0xf9, 0x01, 0x00,
+        ];
+        let frame = RawFrame {
+            timestamp: None,
+            prio: 3,
+            pgn: 130823,
+            src: 19,
+            dst: 255,
+            data,
+        };
+        let dec = db().decode(&frame).expect("decode");
+
+        // Walk the repeating set and check every value against the
+        // length that introduced it.
+        let mut pending: Option<i64> = None;
+        let mut records = 0;
+        for f in &dec.fields {
+            match f.info.name {
+                "Length" => {
+                    if let FieldValue::Integer(n) = f.value {
+                        // A record that got its Value dropped for being
+                        // empty must have declared exactly the header.
+                        if let Some(prev) = pending.take() {
+                            assert_eq!(prev, 3, "record with no Value declared Length {prev}");
+                        }
+                        pending = Some(n);
+                        records += 1;
+                    }
+                }
+                "Value" => {
+                    let len = pending.take().expect("Value without a preceding Length");
+                    let bytes = match &f.value {
+                        FieldValue::Binary(b) => b.len() as i64,
+                        other => panic!("expected binary Value, got {other:?}"),
+                    };
+                    assert_eq!(bytes, len - 3, "Length {len} should give {} bytes", len - 3);
+                }
+                _ => {}
+            }
+        }
+        if let Some(last) = pending {
+            assert_eq!(last, 3, "trailing record with no Value declared Length {last}");
+        }
+        assert!(records >= 6, "expected several records, got {records}");
     }
 
     #[test]

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -2122,6 +2122,31 @@ mod tests {
     }
 
     #[test]
+    fn truncated_trailing_reserved_is_omitted() {
+        // A 26-byte AIS Class B position report (PGN 129039 declares
+        // 27). Its trailing 15-bit `Reserved` starts at bit 201, so
+        // only 7 bits survive — and those read all-ones, which canboat
+        // skips. The all-ones test has to be made against the width
+        // actually read: 0x7F is not 0x7FFF.
+        let data: smallvec::SmallVec<[u8; 8]> = smallvec::smallvec![
+            0x12, 0x10, 0xad, 0x8c, 0x0e, 0xb2, 0x33, 0x2c, 0x03, 0xe6, 0x96, 0x6d, 0x1f, 0x3e,
+            0xb8, 0x65, 0x71, 0x00, 0xc0, 0x00, 0xc1, 0xff, 0x7f, 0x00, 0xe2, 0xff,
+        ];
+        let frame = RawFrame {
+            timestamp: None,
+            prio: 4,
+            pgn: 129039,
+            src: 8,
+            dst: 255,
+            data,
+        };
+        let dec = db().decode(&frame).expect("decode");
+        let mut json = String::new();
+        crate::output::write_json(&mut json, &dec, &crate::output::JsonOptions::default()).unwrap();
+        assert!(!json.contains("Reserved"), "got: {json}");
+    }
+
+    #[test]
     fn unresolved_key_takes_the_rest_of_the_frame_as_its_value() {
         // PGN 130845 Simnet: Key Value, from
         // samples/ac42-commissioning.raw. Key 17671 is not in

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -559,6 +559,11 @@ struct DecodeContext {
     /// Byte length from a DYNAMIC_FIELD_LENGTH field. Cleared with
     /// `dynamic_field_type` after the value is decoded.
     dynamic_length_bytes: Option<u32>,
+    /// Which definition of `target_pgn` the parameters address, and
+    /// whether it had to be borrowed from the catch-all. Resolved at
+    /// the first VARIABLE field and reused for the rest of the record,
+    /// mirroring the C's `g_refPgn` (analyzer.c).
+    resolved_target: Option<(&'static PgnInfo, bool)>,
 }
 
 fn decode_fields(
@@ -979,6 +984,86 @@ fn decode_one_field_at(
 /// Used by PGN 126208 group functions where a `Parameter` /
 /// `FIELD_INDEX` field picks one of the target PGN's fields, and the
 /// next VARIABLE field carries that field's value in its native shape.
+/// True for the four proprietary PGN ranges (`IS_PGN_PROPRIETARY`,
+/// common/common.h).
+fn is_pgn_proprietary(n: u32) -> bool {
+    (0xEF00..=0xEFFF).contains(&n)
+        || (0xFF00..=0xFFFF).contains(&n)
+        || (0x1_EF00..=0x1_EFFF).contains(&n)
+        || (0x1_FF00..=0x1_FFFF).contains(&n)
+}
+
+/// Pick the definition of `pgn_id` that a PGN 126208 parameter list
+/// describes. Port of `getMatchingPgnByParameters` (analyzer/pgn.c).
+///
+/// `params` starts at the parameter-count byte: `[count, index, value…,
+/// index, value…]`, where each `index` is a 1-based field number of the
+/// target PGN and the value's width comes from that field. Walking the
+/// list with a candidate's own field sizes is what makes it a test: a
+/// definition whose `Match` fields all agree with the values present is
+/// the answer, and a definition that disagrees (or that has no such
+/// field at all) steps out.
+///
+/// Returns `None` when nothing matches — for a proprietary PGN with
+/// only Manufacturer and Industry given, that is the normal outcome.
+fn match_pgn_by_parameters(
+    db: &PgnDatabase,
+    pgn_id: u32,
+    params: &[u8],
+) -> Option<&'static PgnInfo> {
+    let first = db.first_pgn(pgn_id)?;
+
+    // A proprietary PGN can only be narrowed by Manufacturer (field 1)
+    // and Industry Code (field 3); without both there is nothing to go
+    // on and the C bails out rather than guessing.
+    if is_pgn_proprietary(pgn_id)
+        && (params.len() < 6 || params[0] < 2 || params[1] != 0x01 || params[4] != 3)
+    {
+        return None;
+    }
+
+    // `hasMatchFields` is set per *definition* (fieldtype.c), and the C
+    // tests it on the first one only -- so a PGN whose leading
+    // definition needs no matching is answered by that definition
+    // outright. This is how 126720 resolves: its catch-all is listed
+    // first and carries no `Match`, so a Raymarine request lands there
+    // without ever considering the 52 manufacturer variants behind it.
+    if !first.fields.iter().any(|fi| fi.match_value.is_some()) {
+        return Some(first);
+    }
+
+    let nparams = *params.first()? as usize;
+    'variant: for cand in db.pgn_variants(pgn_id) {
+        let mut d = 1usize;
+        // Exactly `nparams` pairs — walking to the end of the data
+        // instead would read trailing bytes as a bogus extra parameter.
+        for _ in 0..nparams {
+            if d >= params.len() {
+                break; // truncated list: what was there matched
+            }
+            let index = params[d] as usize;
+            d += 1;
+            if index == 0 || index > cand.fields.len() {
+                continue 'variant;
+            }
+            let field = &cand.fields[index - 1];
+            let bits = field.bit_length.unwrap_or(0) as usize;
+            if let Some(want) = field.match_value {
+                let Some(ex) = extract_bits(params, d * 8, bits, field.signed.unwrap_or(false), 0)
+                else {
+                    continue 'variant;
+                };
+                if ex.value != want {
+                    continue 'variant;
+                }
+            }
+            d += bits.div_ceil(8);
+        }
+        return Some(cand);
+    }
+    None
+}
+
 fn decode_variable(
     f: &'static FieldInfo,
     data: &[u8],
@@ -988,11 +1073,79 @@ fn decode_variable(
 ) -> Option<(DecodedField, u32)> {
     let target_pgn = ctx.target_pgn?;
     let target_idx = ctx.current_param_idx?;
-    let target_info = db.first_pgn(target_pgn)?;
+    // Which definition of the target PGN does this parameter address?
+    //
+    // canboat answers this in `fieldPrintVariable` (analyzer.c): first try to
+    // resolve a *variant* from the parameter list itself -- a request for
+    // 130833 that sets Manufacturer=Furuno picks
+    // furunoShipParametersAndAntennaPosition, and its parameter 4 is a real
+    // typed field. Only when that fails (126720 has 53 variants and a
+    // Manufacturer/Industry pair narrows nothing) borrow the *catch-all*
+    // definition, whose leading fields every variant shares.
+    //
+    // It has to be the catch-all and not merely the first definition: the
+    // first definition of 126720 is somebody's specific variant whose
+    // Manufacturer Code is a `Match` field, so borrowing it would make every
+    // request from another manufacturer decode against the wrong layout.
+    //
+    // Resolved once per record and cached, as the C caches `g_refPgn`.
+    let (target_info, used_catch_all) = match ctx.resolved_target {
+        Some(r) => r,
+        None => {
+            // The C hands `getMatchingPgnByParameters` the message from two
+            // bytes back: [parameter count][field index][value...]. At the
+            // first VARIABLE field the cursor sits on the value, so -1 is this
+            // parameter's index byte and -2 the count.
+            let params = (bit_offset as usize / 8)
+                .checked_sub(2)
+                .and_then(|s| data.get(s..))
+                .unwrap_or(&[]);
+            let r = match match_pgn_by_parameters(db, target_pgn, params) {
+                Some(p) => (p, false),
+                None => (
+                    db.fallback_pgn(target_pgn)
+                        .or_else(|| db.first_pgn(target_pgn))?,
+                    true,
+                ),
+            };
+            ctx.resolved_target = Some(r);
+            r
+        }
+    };
     let target_field = target_info
         .fields
         .iter()
         .find(|tf| (tf.order as u32) == target_idx)?;
+    // The catch-all's trailing `Data` field is variable-length with nothing to
+    // size it, so the value is the rest of the message -- for a request or
+    // command that reads as "the field starts with these bytes". Only when we
+    // fell back: a *resolved* PGN's variable-length fields (126998's
+    // Configuration Information strings) decode properly through the normal
+    // path.
+    if used_catch_all
+        && (target_field.bit_length.unwrap_or(0) == 0
+            || target_field.bit_length_variable == Some(true))
+    {
+        let start = bit_offset as usize;
+        let total = data.len() * 8;
+        if start >= total {
+            return None;
+        }
+        let bits = (total - start) as u32;
+        let value = decode_binary(data, bit_offset, bits);
+        return Some((
+            DecodedField {
+                info: f,
+                value,
+                bit_offset: Some(bit_offset),
+                bit_length: Some(bits),
+                repeat_index: None,
+                repeat_set: 0,
+                overrides: None,
+            },
+            bits,
+        ));
+    }
     // Recurse with the target field's metadata at the current cursor.
     // The outer field's name (e.g. "Value", "Selection Value") wraps
     // the decoded result so the JSON keeps the right field label.
@@ -1891,6 +2044,46 @@ mod tests {
             db().decode(&frame),
             Err(DecodeError::UnknownPgn { pgn: 1 })
         ));
+    }
+
+    #[test]
+    fn parameters_resolve_a_proprietary_variant() {
+        // A 126208 request against PGN 130833 naming Manufacturer =
+        // Furuno (1855) and Industry = Marine (4) picks Furuno's
+        // definition out of the three, so parameter 4 decodes against a
+        // real typed field instead of the catch-all's raw `Data`. This
+        // is the half a "several variants → use the catch-all" shortcut
+        // gets wrong.
+        //   [count][1][mfg lo,hi][3][industry][4]
+        let params = [4u8, 0x01, 0x3f, 0x07, 0x03, 0x04, 0x04];
+        let picked = match_pgn_by_parameters(db(), 130833, &params).expect("a variant");
+        assert_eq!(picked.id, "furunoShipParametersAndAntennaPosition");
+    }
+
+    #[test]
+    fn manufacturer_alone_lands_on_the_126720_catch_all() {
+        // From samples/raymarine-ev1.raw: Manufacturer = Raymarine
+        // (1851), Industry = Marine, then parameter 4's value. 126720's
+        // catch-all is listed first and carries no `Match`, so it
+        // answers immediately — none of the 52 manufacturer variants is
+        // ever reachable this way, which is the point: their layouts
+        // would be a guess.
+        let params = [4u8, 0x01, 0x3b, 0x07, 0x03, 0x04, 0x04, 0x5c, 0x05, 0x0f];
+        let picked = match_pgn_by_parameters(db(), 126720, &params).expect("the catch-all");
+        assert!(
+            picked.fallback.unwrap_or(false),
+            "expected the Fallback definition, got id={}",
+            picked.id
+        );
+    }
+
+    #[test]
+    fn proprietary_target_without_manufacturer_does_not_resolve() {
+        // Without a Manufacturer/Industry pair in the first two
+        // parameters there is nothing to narrow a proprietary PGN with,
+        // so the caller has to fall back rather than pick a layout.
+        let params = [1u8, 0x04, 0x00];
+        assert!(match_pgn_by_parameters(db(), 126720, &params).is_none());
     }
 
     #[test]

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -1714,18 +1714,12 @@ fn decode_string_fix(data: &[u8], bit_offset: u32, bit_length: u32) -> FieldValu
     // the string at that point (matches the C-string convention some
     // devices use to terminate inside a fixed-width buffer — e.g. a
     // Mastervolt Product Information field that has two records
-    // separated by NULs), then trims trailing '@' / NUL / space /
-    // 0xFF. Apply both passes here so STRING_FIX renders the leading
+    // separated by NULs), then trims the trailing padding run. Apply both passes here so STRING_FIX renders the leading
     // C-string portion only.
     let raw = &data[start..end];
     let mut len = raw.iter().position(|&b| b == 0).unwrap_or(raw.len());
-    while len > 0 {
-        let b = raw[len - 1];
-        if b == 0 || b == b'@' || b == b' ' || b == 0xff {
-            len -= 1;
-        } else {
-            break;
-        }
+    while len > 0 && is_string_padding(raw[len - 1]) {
+        len -= 1;
     }
     if len == 0 {
         return FieldValue::NotAvailable;
@@ -1789,7 +1783,7 @@ fn decode_string_lau(data: &[u8], bit_offset: u32) -> (FieldValue, u32) {
             // PGN on "Unhandled string type 255".
             let end = body
                 .iter()
-                .rposition(|&b| !matches!(b, 0xff | 0x00 | b'@' | b' '))
+                .rposition(|&b| !is_string_padding(b))
                 .map_or(0, |i| i + 1);
             String::from_utf8_lossy(&body[..end]).into_owned()
         }
@@ -1809,8 +1803,25 @@ fn decode_string_lau(data: &[u8], bit_offset: u32) -> (FieldValue, u32) {
 /// Strip trailing canboat-padding bytes (`\0`, `'@'`, space, `\xff`)
 /// from a string. Matches the trailing-byte loop in `printString` in
 /// analyzer/print.c.
+/// The trailing bytes canboat's `printString` strips off a decoded
+/// string: `0xff` (the NMEA 2000 filler), any `isspace()` character,
+/// NUL, and `'@'` (badly converted AIS data).
+///
+/// `isspace()` is the whole C set, not just a space — Navico's 130847
+/// ASCII Identifier ends its text with a newline, and trimming only
+/// `' '` left it on the value.
+fn is_string_padding(b: u8) -> bool {
+    matches!(b, 0xff | 0x00 | b'@') || b.is_ascii_whitespace() || b == 0x0b
+}
+
 fn trim_string_padding(s: &str) -> &str {
-    s.trim_end_matches(['\0', '@', ' ', '\u{ff}'])
+    s.trim_end_matches(|c: char| match c {
+        // 0xff survives as U+00FF when the bytes came through a
+        // latin-1-ish path rather than as a UTF-8 replacement char.
+        '\u{ff}' => true,
+        c if c.is_ascii() => is_string_padding(c as u8),
+        _ => false,
+    })
 }
 
 fn decode_string_lz(data: &[u8], bit_offset: u32, bit_length: u32) -> FieldValue {
@@ -2222,6 +2233,18 @@ mod tests {
             FieldValue::String(s) => assert_eq!(s, "HELLO"),
             other => panic!("expected the truncated text, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn string_padding_covers_all_of_isspace() {
+        // canboat's `printString` rtrims with `isspace()`, not just a
+        // space. Navico's 130847 ASCII Identifier ends its text with a
+        // newline, which was being kept.
+        assert_eq!(trim_string_padding("107473373\n"), "107473373");
+        assert_eq!(trim_string_padding("abc\r\n"), "abc");
+        assert_eq!(trim_string_padding("abc\t \u{0}@\u{ff}"), "abc");
+        // Interior whitespace is untouched.
+        assert_eq!(trim_string_padding("a b"), "a b");
     }
 
     #[test]

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -232,7 +232,12 @@ pub enum FieldValue {
     /// (1 << bit) and resolved name for each.
     BitField {
         value: u64,
-        bits: Vec<(u64, &'static str)>,
+        /// One entry per *set bit*, in bit order: its value (`1 << bit`)
+        /// and its name, or `None` when the enumeration does not name
+        /// that bit. canboat emits unnamed set bits too — as
+        /// `{"value":N,"name":null}` under `-nv` and as a bare `N`
+        /// otherwise — so they must not be dropped.
+        bits: Vec<(u64, Option<&'static str>)>,
     },
     /// Decoded text (STRING_FIX, STRING_LZ, STRING_LAU).
     String(String),
@@ -1410,12 +1415,22 @@ fn decode_bitlookup(
     // Keep the BitField even when no bits are set — formatters
     // handle the empty case themselves: JSON drops it, text emits
     // "None" (matches canboat).
+    //
+    // Walk the *bit positions*, not the enumeration's entries: canboat
+    // loops `bit < *bits` and emits every set bit, naming it if the
+    // table has an entry and leaving the name null if not
+    // (`fieldPrintBitLookup`, print.c). Iterating the table instead
+    // made a set bit that nothing names invisible — PGN 65305's `Mode`
+    // sets bit 1, which SIMNET_AP_STATUS does not name, and it went
+    // missing from every autopilot status record.
     let mut bits = Vec::new();
-    if let Some(t) = f.lookup_bit_enumeration.and_then(|n| db.bit_lookup(n)) {
-        for v in t.values {
-            if raw & (1u64 << v.bit) != 0 {
-                bits.push((1u64 << v.bit, v.name));
-            }
+    let table = f.lookup_bit_enumeration.and_then(|n| db.bit_lookup(n));
+    for bit in 0..bit_length.min(64) {
+        if raw & (1u64 << bit) != 0 {
+            bits.push((
+                1u64 << bit,
+                table.and_then(|t| t.get(bit as u8)).map(|v| v.name),
+            ));
         }
     }
     FieldValue::BitField { value: raw, bits }
@@ -2207,6 +2222,57 @@ mod tests {
             FieldValue::String(s) => assert_eq!(s, "HELLO"),
             other => panic!("expected the truncated text, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn bitlookup_keeps_set_bits_the_enumeration_does_not_name() {
+        // PGN 65305 Simnet: Pilot Mode, from
+        // samples/ac42-commissioning.raw. Its `Mode` bitmap reads 0x0a
+        // — bits 1 and 3. SIMNET_AP_STATUS names bit 3 ("Standby") but
+        // has no entry for bit 1, and canboat still emits it as
+        // `{"value":2,"name":null}`.
+        //
+        // Walking the enumeration's entries instead of the bit
+        // positions makes an unnamed set bit invisible, which lost a
+        // real bit from every autopilot status record on the bus.
+        let data: smallvec::SmallVec<[u8; 8]> =
+            smallvec::smallvec![0x41, 0x9f, 0x00, 0x0a, 0x0a, 0x00, 0x80, 0x00];
+        let frame = RawFrame {
+            timestamp: None,
+            prio: 7,
+            pgn: 65305,
+            src: 13,
+            dst: 255,
+            data,
+        };
+        let dec = db().decode(&frame).expect("decode");
+        let mode = dec
+            .fields
+            .iter()
+            .find(|f| f.info.name == "Mode")
+            .expect("a Mode field");
+        match &mode.value {
+            FieldValue::BitField { bits, .. } => {
+                assert_eq!(bits.as_slice(), &[(2, None), (8, Some("Standby"))]);
+            }
+            other => panic!("expected a BitField, got {other:?}"),
+        }
+
+        // …and it reaches JSON as a null-named entry, not as a gap.
+        let mut json = String::new();
+        crate::output::write_json(
+            &mut json,
+            &dec,
+            &crate::output::JsonOptions {
+                name_value: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(
+            json.contains(r#""Mode":[{"value":2,"name":null},{"value":8,"name":"Standby"}]"#),
+            "got: {json}"
+        );
     }
 
     #[test]

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -2153,7 +2153,10 @@ mod tests {
             }
         }
         if let Some(last) = pending {
-            assert_eq!(last, 3, "trailing record with no Value declared Length {last}");
+            assert_eq!(
+                last, 3,
+                "trailing record with no Value declared Length {last}"
+            );
         }
         assert!(records >= 6, "expected several records, got {records}");
     }

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -10,7 +10,7 @@
 //! No I/O. No formatting — the result is a structured event ready for
 //! the output formatter or for direct consumption by merrimac-rs.
 
-use crate::bits::{Extracted, Sentinel, classify_sentinel, extract_bits, is_unavailable};
+use crate::bits::{Extracted, Sentinel, classify_sentinel, extract_bits};
 use crate::db::PgnDatabase;
 use crate::frame::RawFrame;
 use crate::types::{FieldInfo, FieldType, PgnInfo};
@@ -1843,6 +1843,21 @@ fn decode_dynamic_field_length(
 /// when the key wasn't resolved. Returns the value plus how many bits
 /// it consumed so the iteration walker can advance correctly. Always
 /// clears the dynamic-* slots in the context.
+///
+/// **No top-of-range sentinel is stripped here.** The value is decoded
+/// against a pseudo-field synthesised from a fieldtype lookup entry,
+/// and in the C those never get a `reservedCount`: that is resolved in
+/// a pass over `pgnList`'s fields (fieldtype.c), which a lookup entry
+/// is not a member of. It therefore stays 0, `extractNumberNotEmpty`'s
+/// threshold becomes `maxValue`, and nothing is ever above it — so an
+/// all-ones dynamic value prints as a number. B&G's `Trip 2 Time`
+/// reads 0xFFFFFFFF on an unstarted trip and canboat renders it
+/// `1193:02:47.295`, where stripping it as "not available" would drop
+/// the field.
+///
+/// ISO_NAME is the exception, and not via this mechanism:
+/// `fieldPrintName` tests `value > maxValue - 2` itself, so it applies
+/// on this path as much as on any other.
 fn decode_dynamic_field_value(
     data: &[u8],
     bit_offset: u32,
@@ -1931,42 +1946,30 @@ fn decode_dynamic_field_value(
             // canboat's pgn.h.
             let known_signed_duration = matches!(entry.name, "Race Timer" | "Timezone offset");
             let want_signed = signed || known_signed_duration;
-            // Always sentinel-check against the unsigned bit pattern,
-            // even when the display interpretation is signed — canboat's
-            // "all-ones" N/A marker is 0xFF..FF in the raw bytes,
-            // regardless of how the value is shown.
             let Some(ex_unsigned) =
                 extract_bits(data, bit_offset as usize, bits as usize, false, 0)
             else {
                 return (FieldValue::NotAvailable, bits);
             };
-            if is_unavailable(ex_unsigned) {
-                FieldValue::NotAvailable
-            } else {
-                let ex = if want_signed {
-                    match extract_bits(data, bit_offset as usize, bits as usize, true, 0) {
-                        Some(e) => e,
-                        None => return (FieldValue::NotAvailable, bits),
-                    }
-                } else {
-                    ex_unsigned
-                };
-                let res = entry.resolution.unwrap_or(1.0);
-                FieldValue::Time {
-                    raw: ex.value,
-                    seconds: ex.value as f64 * res,
+            let ex = if want_signed {
+                match extract_bits(data, bit_offset as usize, bits as usize, true, 0) {
+                    Some(e) => e,
+                    None => return (FieldValue::NotAvailable, bits),
                 }
+            } else {
+                ex_unsigned
+            };
+            let res = entry.resolution.unwrap_or(1.0);
+            FieldValue::Time {
+                raw: ex.value,
+                seconds: ex.value as f64 * res,
             }
         }
         Some("DATE") => {
             let Some(ex) = extract_bits(data, bit_offset as usize, bits as usize, false, 0) else {
                 return (FieldValue::NotAvailable, bits);
             };
-            if is_unavailable(ex) {
-                FieldValue::NotAvailable
-            } else {
-                FieldValue::Date(ex.value as u16)
-            }
+            FieldValue::Date(ex.value as u16)
         }
         // The 130822 source-setting entries (Depth/Speed Source N,
         // Port/Stbd Boat Speed Source, …) carry a device's 8-byte
@@ -1988,9 +1991,6 @@ fn decode_dynamic_number(
     let Some(ex) = extract_bits(data, bit_offset as usize, bit_length as usize, signed, 0) else {
         return FieldValue::NotAvailable;
     };
-    if is_unavailable(ex) {
-        return FieldValue::NotAvailable;
-    }
     let raw = ex.value as f64;
     let res = entry.resolution.unwrap_or(1.0);
     if res == 1.0 && entry.unit.is_none() {
@@ -2110,6 +2110,70 @@ mod tests {
             db().decode(&frame),
             Err(DecodeError::UnknownPgn { pgn: 1 })
         ));
+    }
+
+    #[test]
+    fn all_ones_dynamic_value_is_a_value_not_a_sentinel() {
+        // A B&G key-value frame (samples/pgn130824.raw line 2) whose
+        // `Trip Time` and `Trip 2 Time` both read 0xFFFFFFFF, the trips
+        // never having been started.
+        //
+        // canboat prints those as `1193:02:47.295`. Its dynamic values
+        // are decoded against a pseudo-field built from a fieldtype
+        // lookup entry, which never gets a `reservedCount` — that pass
+        // walks `pgnList`'s fields — so no top-of-range value is ever
+        // stripped on this path. Treating all-ones as "not available"
+        // here silently drops the field instead.
+        let data: smallvec::SmallVec<[u8; 8]> = smallvec::smallvec![
+            0x7d, 0x99, 0x64, 0x20, 0x2d, 0x00, 0x0d, 0x21, 0x43, 0x00, 0x0e, 0x41, 0xc0, 0xa1,
+            0xb2, 0x1f, 0x0f, 0x41, 0xce, 0x50, 0x3c, 0x03, 0x69, 0x20, 0x43, 0x7d, 0xd3, 0x20,
+            0x2a, 0x74, 0x81, 0x40, 0x70, 0xd3, 0x02, 0x00, 0x9a, 0x20, 0x35, 0xf0, 0x82, 0x20,
+            0x00, 0x00, 0x0a, 0x21, 0x98, 0x02, 0x0c, 0x21, 0xb8, 0x02, 0x75, 0x40, 0x20, 0x6c,
+            0xfb, 0xff, 0x09, 0x41, 0xff, 0xff, 0xff, 0xff, 0x0b, 0x41, 0xff, 0xff, 0xff, 0xff,
+            0xd0, 0x40, 0xe0, 0xaa, 0x8c, 0x0e, 0x7f, 0x20, 0x00, 0x00, 0x9d, 0x20, 0x54, 0xad,
+        ];
+        let frame = RawFrame {
+            timestamp: None,
+            prio: 3,
+            pgn: 130824,
+            src: 26,
+            dst: 255,
+            data,
+        };
+        let dec = db().decode(&frame).expect("decode");
+
+        // Each `Key` of 265 / 267 must be followed by a Value carrying
+        // the raw 0xFFFFFFFF, not by nothing at all.
+        let mut expecting_value_for: Option<u64> = None;
+        let mut seen = 0;
+        for f in &dec.fields {
+            match (f.info.name, &f.value) {
+                ("Key", FieldValue::Lookup { value, .. }) => {
+                    assert!(
+                        expecting_value_for.is_none(),
+                        "key {} got no Value at all",
+                        expecting_value_for.unwrap()
+                    );
+                    if matches!(value, 265 | 267) {
+                        expecting_value_for = Some(*value);
+                    }
+                }
+                ("Value", v) => {
+                    if let Some(key) = expecting_value_for.take() {
+                        match v {
+                            FieldValue::Time { raw, .. } => {
+                                assert_eq!(*raw, 0xFFFF_FFFF, "key {key}");
+                                seen += 1;
+                            }
+                            other => panic!("key {key}: expected a Time, got {other:?}"),
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        assert!(expecting_value_for.is_none(), "trailing key had no Value");
+        assert_eq!(seen, 2, "expected both trip-time records");
     }
 
     #[test]

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -1901,15 +1901,24 @@ fn decode_dynamic_field_value(
         ctx.skip_field = true;
         return (FieldValue::NotAvailable, remaining);
     }
-    // Mirror canboat's fieldPrintKeyValue: no resolved length and
-    // no resolved field type → emit an empty BINARY blob (the
-    // `g_length = 0, g_ftf = NULL, fieldPrintBinary(bits=0)` path
-    // in print.c). Better than erroring out — this is how PGN
-    // 130845 with an unknown SIMNET_KEY_VALUE key renders.
     let bits = bits_signed as u32;
     let Some(entry) = entry else {
-        // Unresolved key — render as a raw BINARY blob over the
-        // declared length (zero bytes is fine, comes out as "").
+        // The key resolved to no field type, so there is no width to
+        // decode against. When there was no explicit length either, the
+        // value is simply the rest of the frame, and canboat dumps it
+        // as raw bytes — `*bits = dataLen * 8 - startBit` before
+        // `fieldPrintBinary` (fieldPrintKeyValue, print.c).
+        //
+        // PGN 130845 is the case that needs it: its `Value` has no
+        // preceding DYNAMIC_FIELD_LENGTH at all, so an unrecognised
+        // SIMNET_KEY_VALUE key leaves nothing to size the field with,
+        // and taking the declared zero would print `""` over bytes that
+        // are plainly on the bus.
+        let bits = if bits == 0 && explicit_len.is_none() {
+            remaining
+        } else {
+            bits
+        };
         return (decode_binary(data, bit_offset, bits), bits);
     };
     let signed = entry.signed || matches!(entry.field_type, Some(ft) if ft.starts_with("FIX"));
@@ -2110,6 +2119,38 @@ mod tests {
             db().decode(&frame),
             Err(DecodeError::UnknownPgn { pgn: 1 })
         ));
+    }
+
+    #[test]
+    fn unresolved_key_takes_the_rest_of_the_frame_as_its_value() {
+        // PGN 130845 Simnet: Key Value, from
+        // samples/ac42-commissioning.raw. Key 17671 is not in
+        // SIMNET_KEY_VALUE, so no field type resolves — and this PGN
+        // has no DYNAMIC_FIELD_LENGTH either, so nothing declares a
+        // width. canboat falls back to the rest of the frame and prints
+        // the bytes; the alternative is `""` over data that is plainly
+        // there.
+        let data: smallvec::SmallVec<[u8; 8]> = smallvec::smallvec![
+            0x41, 0x9f, 0xff, 0xff, 0x01, 0xff, 0x07, 0x45, 0x00, 0x01, 0x2d, 0x7d, 0x10, 0x14,
+        ];
+        let frame = RawFrame {
+            timestamp: None,
+            prio: 2,
+            pgn: 130845,
+            src: 13,
+            dst: 255,
+            data,
+        };
+        let dec = db().decode(&frame).expect("decode");
+        let value = dec
+            .fields
+            .iter()
+            .find(|f| f.info.name == "Value")
+            .expect("a Value field");
+        match &value.value {
+            FieldValue::Binary(b) => assert_eq!(b.as_slice(), &[0x2d, 0x7d, 0x10, 0x14]),
+            other => panic!("expected the trailing bytes, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -1451,6 +1451,18 @@ fn decode_iso_name(data: &[u8], bit_offset: u32, bit_length: u32, db: &PgnDataba
     for i in 0..8 {
         value |= (data[byte_off + i] as u64) << (i * 8);
     }
+    // An ISO NAME reserves its top *two* values rather than going
+    // through the usual per-field sentinel machinery, which is
+    // suppressed at 64 bits anyway (QUIRKS Q18): `fieldPrintName`
+    // (print.c) hands anything above `maxValue - 2` to `printEmpty`.
+    // Expanding one of those into subfields would invent a device —
+    // an all-ones NAME reads as Device Instance 31, "Arbitrary address
+    // capable: Yes" and so on, none of which is on the wire.
+    match value {
+        u64::MAX => return FieldValue::NotAvailable,
+        v if v == u64::MAX - 1 => return FieldValue::OutOfRange { value },
+        _ => {}
+    }
     let sub = &data[byte_off..byte_off + 8];
     let subfields = match db.first_pgn(60928) {
         Some(pgn) => decode_fields(pgn, sub, db).map(|x| x.0).unwrap_or_default(),

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -634,6 +634,11 @@ struct DecodeContext {
     /// truncated record declares a length below its own header — the
     /// C's `g_length` is `int64_t` for the same reason.
     dynamic_length_bytes: Option<i64>,
+    /// Raw value of the last field that went through canboat's
+    /// `extractNumberNotEmpty` — its `g_previousFieldValue`. A BINARY
+    /// field with no declared width takes its *bit* length from this
+    /// (`fieldPrintBinary`, print.c).
+    previous_field_value: u64,
     /// Set by a decoder that wants its field omitted from the output
     /// while the walk carries on past it — canboat's `g_skip`
     /// (print.c). Read and cleared by the field walker.
@@ -968,6 +973,15 @@ fn decode_one_field_at(
         let avail = avail - (avail & 7); // round down to whole bytes
         let value = match f.field_type {
             Some(FieldType::StringLz) => decode_string_lz(data, bit_offset, avail),
+            // A BINARY field with no width of its own takes one, in
+            // *bits*, from the value of the field before it — canboat's
+            // `*bits = g_previousFieldValue` (fieldPrintBinary, print.c),
+            // which its own comment calls heuristic. Fusion's 130820
+            // SiriusXM Presets sizes `Values` by the preceding `Count`,
+            // as do AIS 129792 / 129795 / 129797.
+            _ if ctx.previous_field_value > 0 && (ctx.previous_field_value as u32) <= avail => {
+                decode_binary(data, bit_offset, ctx.previous_field_value as u32)
+            }
             _ => decode_binary(data, bit_offset, avail),
         };
         return Some((
@@ -1035,6 +1049,14 @@ fn decode_one_field_at(
             ctx.current_param_idx = Some(*n as u32);
         }
         _ => {}
+    }
+    // `g_previousFieldValue`, which the C sets inside
+    // `extractNumberNotEmpty` — so it tracks the numeric fields, and a
+    // following zero-width BINARY reads its bit count from it.
+    if let FieldValue::Integer(n) = &value
+        && *n >= 0
+    {
+        ctx.previous_field_value = *n as u64;
     }
     // canboat C also picks up dynamic field lengths by FIELD NAME
     // (`analyzer/analyzer.c::fillGlobalsBasedOnFieldName`): any field
@@ -2272,6 +2294,32 @@ mod tests {
             .field_type_lookup("VICTRON_VREG", 8220)
             .expect("VICTRON_VREG 8220");
         assert!(entry.signed, "DC Current must be signed");
+    }
+
+    #[test]
+    fn zero_width_binary_is_sized_by_the_previous_field() {
+        // Fusion 130820 SiriusXM Presets: `Values` is a BINARY with no
+        // declared width, and canboat takes its *bit* count from the
+        // preceding `Count` (`*bits = g_previousFieldValue`,
+        // fieldPrintBinary). Count = 4 here, so one byte masked to its
+        // low nibble.
+        let data: smallvec::SmallVec<[u8; 8]> =
+            smallvec::smallvec![0xa3, 0x99, 0x1e, 0x80, 0x00, 0x04, 0x64, 0x00, 0x00, 0x00];
+        let frame = RawFrame {
+            timestamp: None,
+            prio: 7,
+            pgn: 130820,
+            src: 10,
+            dst: 255,
+            data,
+        };
+        let dec = db().decode(&frame).expect("decode");
+        if let Some(v) = dec.fields.iter().find(|f| f.info.name == "Values") {
+            match &v.value {
+                FieldValue::Binary(b) => assert_eq!(b.as_slice(), &[0x04]),
+                other => panic!("expected one masked byte, got {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -265,6 +265,12 @@ pub enum FieldValue {
         /// otherwise — so they must not be dropped.
         bits: Vec<(u64, Option<&'static str>)>,
     },
+    /// A DECIMAL field's digits. canboat renders one byte as two
+    /// decimal digits (`%02u`) and simply drops a byte that is not a
+    /// valid pair, so the result is a run of digit pairs rather than a
+    /// number — leading zeros included. Kept as text to preserve them;
+    /// both formatters emit it unquoted, as the C does.
+    Decimal(String),
     /// Decoded text (STRING_FIX, STRING_LZ, STRING_LAU).
     String(String),
     /// 16-bit days since 1970-01-01.
@@ -1001,9 +1007,8 @@ fn decode_one_field_at(
     let bit_length = f.bit_length?;
 
     let value = match f.field_type {
-        Some(FieldType::Number) | Some(FieldType::Decimal) => {
-            decode_number(f, data, bit_offset, bit_length, signed, offset_k)
-        }
+        Some(FieldType::Decimal) => decode_decimal(data, bit_offset, bit_length),
+        Some(FieldType::Number) => decode_number(f, data, bit_offset, bit_length, signed, offset_k),
         Some(FieldType::Float) => decode_float(data, bit_offset, bit_length),
         Some(FieldType::Lookup) => decode_lookup(f, data, bit_offset, bit_length, db),
         Some(FieldType::IndirectLookup) => {
@@ -1562,6 +1567,60 @@ fn decode_iso_name(data: &[u8], bit_offset: u32, bit_length: u32, db: &PgnDataba
         None => Vec::new(),
     };
     FieldValue::IsoName { value, subfields }
+}
+
+/// DECIMAL: each group of 8 bits is one decimal *pair*, printed as two
+/// digits — canboat's `fieldPrintDecimal` (print.c). A DSC address of
+/// `33 14 00 5F 1E` reads 5120009530, not the 40-bit integer those
+/// bytes spell.
+///
+/// A byte that is not a valid pair (>= 100) is dropped, as the C drops
+/// it. All bits set is "not available": that is the universal canboat
+/// convention, and reading it as digits would otherwise emit nothing at
+/// all, which in the C takes the whole record down with it.
+fn decode_decimal(data: &[u8], bit_offset: u32, bit_length: u32) -> FieldValue {
+    let start_byte = (bit_offset / 8) as usize;
+    if start_byte >= data.len() {
+        return FieldValue::NotAvailable;
+    }
+    let avail = (data.len() as u32 * 8).saturating_sub(bit_offset);
+    let bits = bit_length.min(avail);
+    let nbytes = bits.div_ceil(8) as usize;
+    let end = (start_byte + nbytes).min(data.len());
+    if data[start_byte..end].iter().all(|&b| b == 0xff) {
+        return FieldValue::NotAvailable;
+    }
+
+    let mut out = String::with_capacity(nbytes * 2);
+    let mut value: u32 = 0;
+    let mut magnitude: u32 = 1;
+    let mut mask: u8 = 1 << (bit_offset % 8);
+    let mut idx = start_byte;
+    for bit in 0..bits {
+        let Some(&byte) = data.get(idx) else { break };
+        if byte & mask != 0 {
+            value |= magnitude;
+        }
+        if mask == 128 {
+            mask = 1;
+            idx += 1;
+        } else {
+            mask <<= 1;
+        }
+        magnitude <<= 1;
+        if bit % 8 == 7 {
+            if value < 100 {
+                out.push((b'0' + (value / 10) as u8) as char);
+                out.push((b'0' + (value % 10) as u8) as char);
+            }
+            value = 0;
+            magnitude = 1;
+        }
+    }
+    if out.is_empty() {
+        return FieldValue::NotAvailable;
+    }
+    FieldValue::Decimal(out)
 }
 
 fn decode_binary(data: &[u8], bit_offset: u32, bit_length: u32) -> FieldValue {
@@ -2269,6 +2328,51 @@ mod tests {
         match &msg.value {
             FieldValue::String(s) => assert_eq!(s, "HELLO"),
             other => panic!("expected the truncated text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decimal_is_digit_pairs_and_all_ones_is_absent() {
+        // samples/pgn129808.raw. A DSC address is five bytes, each one
+        // a *decimal pair*: 0x33 0x14 0x00 0x5F 0x1E reads 5120009530,
+        // not the 40-bit integer 130442859571 those bytes spell. And
+        // this call's `MMSI of Ship In Distress` is all ones — absent.
+        let data: smallvec::SmallVec<[u8; 8]> = smallvec::smallvec![
+            0x70, 0x70, 0x33, 0x14, 0x00, 0x5f, 0x1e, 0x6e, 0x64, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x12, 0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        ];
+        let frame = RawFrame {
+            timestamp: None,
+            prio: 4,
+            pgn: 129808,
+            src: 3,
+            dst: 255,
+            data,
+        };
+        let dec = db().decode(&frame).expect("decode");
+
+        let addr = dec
+            .fields
+            .iter()
+            .find(|f| f.info.name == "DSC Message Address")
+            .expect("a DSC Message Address");
+        match &addr.value {
+            FieldValue::Decimal(d) => assert_eq!(d, "5120009530"),
+            other => panic!("expected decimal digits, got {other:?}"),
+        }
+
+        // All ones is "not available" — every other field type says so,
+        // and reading it as digits yields nothing at all, which is what
+        // used to take the entire record down in the C.
+        for f in &dec.fields {
+            if f.info.name == "MMSI of Ship In Distress" {
+                assert!(
+                    f.value.is_not_available(),
+                    "an all-ones DECIMAL must be absent, got {:?}",
+                    f.value
+                );
+            }
         }
     }
 

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -34,6 +34,47 @@ fn sentinel_field_value(f: &FieldInfo, ex: Extracted) -> Option<FieldValue> {
     }
 }
 
+/// The same test, for a field whose FieldType declares
+/// `Sentinels: None` and so carries none of the hints above, but which
+/// still has a `RangeMax` below what its bit width can hold.
+///
+/// The C never consults the FieldType's `Sentinels` when it works out
+/// how many top-of-range values a field reserves — `reservedCount` is
+/// derived from `rangeMax` against the raw bit-width maximum, capped by
+/// `reservedCountForSize` (fieldtype.c). So an MMSI, whose range stops
+/// at 999999999 in a 32-bit field, still reserves its top three values,
+/// and `extractNumberNotEmpty` hands anything above the threshold to
+/// `printEmpty`. `Sentinels: None` only stops the hints being written
+/// into the document; it does not make every bit pattern valid.
+fn range_max_sentinel(f: &FieldInfo, ex: Extracted, bits: u32) -> Option<FieldValue> {
+    let range_max = f.range_max?;
+    let resolution = f.resolution.unwrap_or(1.0);
+    if bits == 0 || bits >= 64 || resolution <= 0.0 || !range_max.is_finite() {
+        return None;
+    }
+    let raw_max = (1u64 << bits) - 1;
+    let raw_range_max = (range_max / resolution + 0.5) as u64;
+    if raw_range_max >= raw_max {
+        return None;
+    }
+    // reservedCountForSize(): 3 from 8 bits up, 2 from 4, 1 from 2.
+    let by_size: u64 = match bits {
+        8.. => 3,
+        4..=7 => 2,
+        2..=3 => 1,
+        _ => 0,
+    };
+    let reserved = (raw_max - raw_range_max).min(by_size);
+    if reserved == 0 || ex.raw <= raw_max - reserved {
+        return None;
+    }
+    Some(match raw_max - ex.raw {
+        0 => FieldValue::NotAvailable,
+        1 => FieldValue::OutOfRange { value: ex.raw },
+        _ => FieldValue::ReservedValue { value: ex.raw },
+    })
+}
+
 /// One decoded field.
 ///
 /// Schema metadata (`id`, `name`, `order`, `unit`, `resolution`,
@@ -931,7 +972,7 @@ fn decode_one_field_at(
             decode_reserved(data, bit_offset, bit_length, signed, offset_k, false)
         }
         Some(FieldType::Binary) => decode_binary(data, bit_offset, bit_length),
-        Some(FieldType::Mmsi) => decode_mmsi(data, bit_offset, bit_length),
+        Some(FieldType::Mmsi) => decode_mmsi(f, data, bit_offset, bit_length),
         Some(FieldType::Pgn) => decode_pgn_field(data, bit_offset, bit_length, db),
         Some(FieldType::Date) => decode_date(f, data, bit_offset, bit_length),
         Some(FieldType::Time) | Some(FieldType::Duration) => {
@@ -1534,7 +1575,7 @@ fn decode_binary(data: &[u8], bit_offset: u32, bit_length: u32) -> FieldValue {
     FieldValue::Binary(out)
 }
 
-fn decode_mmsi(data: &[u8], bit_offset: u32, bit_length: u32) -> FieldValue {
+fn decode_mmsi(f: &FieldInfo, data: &[u8], bit_offset: u32, bit_length: u32) -> FieldValue {
     if bit_length != 32 {
         return FieldValue::Unsupported {
             field_type: "MMSI (non-32-bit)",
@@ -1543,9 +1584,17 @@ fn decode_mmsi(data: &[u8], bit_offset: u32, bit_length: u32) -> FieldValue {
     let Some(ex) = extract_bits(data, bit_offset as usize, 32, false, 0) else {
         return FieldValue::NotAvailable;
     };
-    // MMSI is an identifier — schema 2.5.0 declares Sentinels='None'
-    // on the FieldType. All 0..=2^32-1 values are legitimate (broadcast
-    // is 0xFFFFFFFF). No sentinel detection.
+    // The MMSI FieldType declares `Sentinels: None`, so the schema
+    // carries no per-field hints and `sentinel_field_value` finds
+    // nothing. That is not the whole rule: an MMSI field's RangeMax is
+    // 999999999, well inside 32 bits, and the C reserves its top three
+    // values on that basis alone (`fieldPrintMMSI` goes through
+    // `extractNumberNotEmpty`). PGN 130842's `Mothership User ID` reads
+    // 0xFFFFFFFF whenever the Class B unit has no mothership, and
+    // canboat omits it rather than printing 4294967295.
+    if let Some(sent) = range_max_sentinel(f, ex, 32) {
+        return sent;
+    }
     FieldValue::Mmsi(ex.value as u32)
 }
 
@@ -2186,6 +2235,52 @@ mod tests {
             FieldValue::Reserved { bytes, .. } => assert_eq!(bytes.as_slice(), &[0x10]),
             other => panic!("expected Reserved bytes, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn all_ones_mmsi_is_suppressed() {
+        // A real PGN 130842 Part B frame
+        // (samples/merrimac-actisense-serial-2011.raw) whose
+        // `Mothership User ID` is 0xFFFFFFFF — this Class B unit has no
+        // mothership.
+        //
+        // The MMSI FieldType declares `Sentinels: None`, so no
+        // per-field hint catches it. The field's RangeMax is 999999999
+        // though, and the C reserves the top three values on that basis
+        // alone, so canboat omits it rather than printing 4294967295.
+        let data: smallvec::SmallVec<[u8; 8]> = smallvec::smallvec![
+            0x41, 0x9f, 0x81, 0xff, 0x18, 0x88, 0x87, 0x94, 0x0e, 0x24, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x50, 0x49, 0x36, 0x34, 0x34, 0x36, 0x00, 0x6e, 0x00, 0x28, 0x00,
+            0x1e, 0x00, 0x3c, 0x00, 0xff, 0xff, 0xff, 0xff, 0xc0,
+        ];
+        let frame = RawFrame {
+            timestamp: None,
+            prio: 6,
+            pgn: 130842,
+            src: 8,
+            dst: 255,
+            data,
+        };
+        let dec = db().decode(&frame).expect("decode");
+
+        let mothership = dec
+            .fields
+            .iter()
+            .find(|f| f.info.name == "Mothership User ID")
+            .expect("a Mothership User ID field");
+        assert!(
+            mothership.value.is_sentinel(),
+            "an all-ones MMSI must read as a sentinel, got {:?}",
+            mothership.value
+        );
+
+        // The ordinary MMSI in the same frame still decodes.
+        let user_id = dec
+            .fields
+            .iter()
+            .find(|f| f.info.name == "User ID")
+            .expect("a User ID field");
+        assert!(matches!(user_id.value, FieldValue::Mmsi(244_615_048)));
     }
 
     #[test]

--- a/crates/canboat-core/src/format/plain.rs
+++ b/crates/canboat-core/src/format/plain.rs
@@ -64,6 +64,8 @@ pub enum ParseError {
         value: String,
         offset: Option<usize>,
     },
+    #[error("line ends after the length field; no payload section")]
+    MissingPayload,
 }
 
 impl ParseError {
@@ -117,6 +119,18 @@ pub fn parse_line(line: &str) -> Result<RawFrame, ParseError> {
 
     if len > RAWFRAME_MAX_SIZE {
         return Err(ParseError::LengthTooLarge { len });
+    }
+
+    // canboat requires a sixth comma — the one terminating `len` and
+    // opening the payload — whatever `len` itself says
+    // (`findOccurrence(p, ',', 6)` in `parseRawFormatFast`,
+    // common/parse.c). Captures contain lines that stop right after the
+    // length, `2020-08-22T13:52:36.981Z,0,16712965,255,0,0`, and the C
+    // rejects them outright with "cannot find sixth comma". Accepting
+    // them produced a zero-byte frame that reached the decoder and came
+    // out as a fields-less record for a PGN that does not exist.
+    if cursor == 0 || rest_bytes[cursor - 1] != b',' {
+        return Err(ParseError::MissingPayload);
     }
 
     // Payload: exactly `len` hex bytes, comma-separated. Fast path:
@@ -338,16 +352,26 @@ mod tests {
             parse_line(line),
             Err(ParseError::LengthTooLarge { .. })
         ));
-        // 250 declared bytes is in range since ISO-TP support; with no
-        // payload supplied it now fails on the byte count instead.
+        // 250 declared bytes is in range since ISO-TP support. The line
+        // stops after the length, so it is rejected for having no
+        // payload section at all — the C's "cannot find sixth comma" —
+        // before the byte count is ever counted.
         let line = "ts,3,129029,36,255,250";
-        assert!(matches!(
-            parse_line(line),
-            Err(ParseError::BadPayloadCount {
-                expected: 250,
-                found: 0
-            })
-        ));
+        assert!(matches!(parse_line(line), Err(ParseError::MissingPayload)));
+    }
+
+    #[test]
+    fn rejects_a_line_that_stops_after_the_length() {
+        // Real capture lines (samples/susteranna2020.raw and friends)
+        // that carry no data at all. canboat rejects them outright;
+        // accepting them yielded a zero-byte frame that decoded into a
+        // fields-less record for a PGN that does not exist.
+        let line = "2020-08-22T13:52:36.981Z,0,16712965,255,0,0";
+        assert!(matches!(parse_line(line), Err(ParseError::MissingPayload)));
+        // A declared-zero-length line *with* the payload comma is still
+        // accepted, matching the C's parser.
+        let ok = parse_line("2020-08-22T13:52:36.981Z,0,127250,255,0,0,").expect("parses");
+        assert!(ok.data.is_empty());
     }
 
     #[test]

--- a/crates/canboat-core/src/output/json.rs
+++ b/crates/canboat-core/src/output/json.rs
@@ -424,6 +424,7 @@ fn write_field_value_debug<W: fmt::Write>(
     w.write_str("\"value\":")?;
     // The "bare value" emission for the inner `value` key.
     match &f.value {
+        FieldValue::Decimal(d) => w.write_str(d)?,
         FieldValue::Number(v) => {
             let p = effective_precision(f.precision(), f.resolution());
             let min_w = if p == 7 && f.unit() == Some("deg") {
@@ -744,6 +745,9 @@ fn write_field_value<W: fmt::Write>(
                 w.write_char(']')
             }
         }
+        // canboat prints a DECIMAL's digit pairs bare, so this lands in
+        // JSON as a number literal rather than a string.
+        FieldValue::Decimal(d) => w.write_str(d),
         FieldValue::String(s) => write_field_json_string(w, s),
         FieldValue::Date(d) => {
             let mut buf = String::with_capacity(10);

--- a/crates/canboat-core/src/output/json.rs
+++ b/crates/canboat-core/src/output/json.rs
@@ -576,7 +576,13 @@ fn write_field_value_debug<W: fmt::Write>(
                     if !opts.include_empty && matches!(sf.value, FieldValue::NotAvailable) {
                         continue;
                     }
-                    if matches!(sf.value, FieldValue::Spare { .. }) {
+                    // A SPARE is dropped only when it is zero, the same
+                    // rule the top level applies: the C recurses into the
+                    // embedded 60928 through the very same `printFields`,
+                    // so `fieldPrintSpare` decides here too. Navico's
+                    // 130822/130840 carry a NAME whose Spare bit is set,
+                    // and canboat renders it as "01".
+                    if matches!(&sf.value, FieldValue::Spare { value, .. } if *value == 0) {
                         continue;
                     }
                     w.write_str(sep)?;
@@ -843,7 +849,13 @@ fn write_field_value<W: fmt::Write>(
                     if !opts.include_empty && matches!(sf.value, FieldValue::NotAvailable) {
                         continue;
                     }
-                    if matches!(sf.value, FieldValue::Spare { .. }) {
+                    // A SPARE is dropped only when it is zero, the same
+                    // rule the top level applies: the C recurses into the
+                    // embedded 60928 through the very same `printFields`,
+                    // so `fieldPrintSpare` decides here too. Navico's
+                    // 130822/130840 carry a NAME whose Spare bit is set,
+                    // and canboat renders it as "01".
+                    if matches!(&sf.value, FieldValue::Spare { value, .. } if *value == 0) {
                         continue;
                     }
                     w.write_str(sep)?;

--- a/crates/canboat-core/src/output/json.rs
+++ b/crates/canboat-core/src/output/json.rs
@@ -480,18 +480,27 @@ fn write_field_value_debug<W: fmt::Write>(
                         w.write_char(',')?;
                     }
                     write!(w, "{{\"value\":{},\"name\":", bv)?;
-                    write_json_string(w, n)?;
+                    match n {
+                        Some(n) => write_json_string(w, n)?,
+                        // A set bit the enumeration does not name.
+                        None => w.write_str("null")?,
+                    }
                     w.write_char('}')?;
                 }
                 w.write_char(']')?;
             } else {
                 // Plain JSON: array of bare strings.
                 w.write_char('[')?;
-                for (i, (_, n)) in bits.iter().enumerate() {
+                for (i, (bv, n)) in bits.iter().enumerate() {
                     if i > 0 {
                         w.write_char(',')?;
                     }
-                    write_json_string(w, n)?;
+                    match n {
+                        Some(n) => write_json_string(w, n)?,
+                        // Unnamed: canboat prints the bit value bare,
+                        // so the array mixes strings and numbers.
+                        None => write!(w, "{}", bv)?,
+                    }
                 }
                 w.write_char(']')?;
             }
@@ -704,18 +713,27 @@ fn write_field_value<W: fmt::Write>(
                         w.write_char(',')?;
                     }
                     write!(w, "{{\"value\":{},\"name\":", bv)?;
-                    write_json_string(w, n)?;
+                    match n {
+                        Some(n) => write_json_string(w, n)?,
+                        // A set bit the enumeration does not name.
+                        None => w.write_str("null")?,
+                    }
                     w.write_char('}')?;
                 }
                 w.write_char(']')
             } else {
                 // Plain JSON: bare-string array.
                 w.write_char('[')?;
-                for (i, (_, n)) in bits.iter().enumerate() {
+                for (i, (bv, n)) in bits.iter().enumerate() {
                     if i > 0 {
                         w.write_char(',')?;
                     }
-                    write_json_string(w, n)?;
+                    match n {
+                        Some(n) => write_json_string(w, n)?,
+                        // Unnamed: canboat prints the bit value bare,
+                        // so the array mixes strings and numbers.
+                        None => write!(w, "{}", bv)?,
+                    }
                 }
                 w.write_char(']')
             }

--- a/crates/canboat-core/src/output/json.rs
+++ b/crates/canboat-core/src/output/json.rs
@@ -198,22 +198,20 @@ fn write_json_inner<W: fmt::Write>(
         {
             continue;
         }
-        // Reserved fields whose raw value is all-ones (the "unused"
+        // Reserved fields whose value is all-ones (the "unused"
         // default) are skipped entirely — even under -debug, matching
-        // canboat. Other Reserved values flow through and emit their
-        // hex string.
-        if let FieldValue::Reserved {
-            value, bit_length, ..
-        } = &f.value
-        {
-            let max = if *bit_length >= 64 {
-                u64::MAX
-            } else {
-                (1u64 << bit_length) - 1
-            };
-            if *value == max {
-                continue;
-            }
+        // canboat's `fieldPrintReserved`. Other Reserved values flow
+        // through and emit their hex string.
+        //
+        // The decoder makes that call and signals it by returning no
+        // bytes; do not re-derive it from `bit_length` here. On a short
+        // frame the extractor truncates the field, so "all ones" means
+        // all ones of the *truncated* width — PGN 129039's trailing
+        // 15-bit Reserved on a 26-byte AIS Class B report reads 7 bits
+        // of 0xFF, which is not 0x7FFF, and the two computations
+        // disagreed.
+        if matches!(&f.value, FieldValue::Reserved { bytes, .. } if bytes.is_empty()) {
+            continue;
         }
         // Empty BITLOOKUPs (no bits set) are dropped in JSON output —
         // canboat doesn't emit them either. The text formatter, by

--- a/crates/canboat-core/src/output/json.rs
+++ b/crates/canboat-core/src/output/json.rs
@@ -651,10 +651,7 @@ fn write_field_value<W: fmt::Write>(
                 write!(w, "{}", v)
             }
         }
-        FieldValue::Float(v) => {
-            // canboat uses %g — Rust's `{}` is acceptably close.
-            write!(w, "{}", v)
-        }
+        FieldValue::Float(v) => super::write_c_g(w, *v),
         FieldValue::Binary(bytes) => {
             // canboat emits binary as uppercase hex with space-separated
             // bytes (matches fieldPrintBinary's `%s%2.02X` w/ " " sep).

--- a/crates/canboat-core/src/output/json.rs
+++ b/crates/canboat-core/src/output/json.rs
@@ -179,10 +179,13 @@ fn write_json_inner<W: fmt::Write>(
         {
             continue;
         }
-        // Under `-debug` we keep unavailable fields so the byte/bit
-        // diagnostic is preserved; otherwise honour the canboat
-        // suppress rule.
-        if !opts.include_empty && !opts.debug && matches!(f.value, FieldValue::NotAvailable) {
+        // All three top-of-range sentinels — Unknown, Out Of Range and
+        // Reserved — are dropped from JSON. canboat routes every one of
+        // them through `printEmpty` (print.c), which in JSON mode emits
+        // `null` under `-empty` and otherwise sets `g_skip`. The
+        // "Out Of Range" / "Reserved" spellings are text-mode only.
+        // `-debug` still keeps them, so the byte/bit diagnostic survives.
+        if !opts.include_empty && !opts.debug && f.value.is_sentinel() {
             continue;
         }
         // SPARE fields: canboat C's `fieldPrintSpare` (print.c:900)
@@ -593,15 +596,12 @@ fn write_field_value_debug<W: fmt::Write>(
         FieldValue::Spare { .. } | FieldValue::NotAvailable => {
             w.write_str("null")?;
         }
-        FieldValue::OutOfRange { .. } => {
-            // Schema-2.4.0 `OutOfRangeValue` sentinel — render as the
-            // canboat C label. Matches `analyzer/print.c` after PR #672.
-            // TODO: thread the raw u64 through `-debug` byte/bit suffix.
-            write_json_string(w, "Out Of Range")?;
-        }
-        FieldValue::ReservedValue { .. } => {
-            // Schema-2.4.0 `ReservedValue` sentinel. See above.
-            write_json_string(w, "Reserved")?;
+        FieldValue::OutOfRange { .. } | FieldValue::ReservedValue { .. } => {
+            // Reached only under `-empty` / `-debug`, the filter above
+            // having dropped these otherwise. canboat's `printEmpty`
+            // spells every sentinel `null` in JSON; the "Out Of Range"
+            // and "Reserved" labels belong to text output.
+            w.write_str("null")?;
         }
         FieldValue::Unsupported { field_type } => {
             let mut buf = String::with_capacity(field_type.len() + 16);
@@ -845,9 +845,9 @@ fn write_field_value<W: fmt::Write>(
                 write!(w, "{}", value)
             }
         }
-        FieldValue::NotAvailable => w.write_str("null"),
-        FieldValue::OutOfRange { .. } => write_json_string(w, "Out Of Range"),
-        FieldValue::ReservedValue { .. } => write_json_string(w, "Reserved"),
+        FieldValue::NotAvailable
+        | FieldValue::OutOfRange { .. }
+        | FieldValue::ReservedValue { .. } => w.write_str("null"),
         FieldValue::Unsupported { field_type } => {
             // Encode as a string so the JSON stays valid; consumers can
             // detect by leading "<".
@@ -1034,6 +1034,48 @@ mod tests {
         )
         .unwrap();
         assert!(out.contains(r#""Offset":null"#), "got: {}", out);
+    }
+
+    #[test]
+    fn out_of_range_and_reserved_are_dropped_from_json() {
+        // canboat funnels all three top-of-range sentinels through
+        // `printEmpty`, which in JSON mode sets `g_skip` — the field
+        // simply isn't there. "Out Of Range" and "Reserved" are the
+        // text formatter's spellings and must never reach JSON.
+        for sentinel in [
+            FieldValue::OutOfRange { value: 254 },
+            FieldValue::ReservedValue { value: 253 },
+        ] {
+            let mut pgn = sample_pgn();
+            pgn.fields[0].value = sentinel;
+            let mut out = String::new();
+            write_json(&mut out, &pgn, &JsonOptions::default()).unwrap();
+            assert!(!out.contains("\"fields\""), "sentinel leaked: {out}");
+        }
+    }
+
+    #[test]
+    fn include_empty_spells_every_sentinel_null() {
+        // Under `-empty` canboat prints `null` for all of them, not the
+        // text labels.
+        for sentinel in [
+            FieldValue::OutOfRange { value: 254 },
+            FieldValue::ReservedValue { value: 253 },
+        ] {
+            let mut pgn = sample_pgn();
+            pgn.fields[0].value = sentinel;
+            let mut out = String::new();
+            write_json(
+                &mut out,
+                &pgn,
+                &JsonOptions {
+                    include_empty: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            assert!(out.contains(r#""Offset":null"#), "got: {out}");
+        }
     }
 
     #[test]

--- a/crates/canboat-core/src/output/mod.rs
+++ b/crates/canboat-core/src/output/mod.rs
@@ -94,8 +94,8 @@ pub(crate) fn write_fixed_float<W: std::fmt::Write>(
     // along with proper negatives.
     let neg = v.is_sign_negative();
     if precision == 0 {
-        // Whole-number path: round half-away-from-zero, integer fmt.
-        let rounded = v.round() as i64;
+        // Whole-number path: integer fmt. Ties go to even, see below.
+        let rounded = v.round_ties_even() as i64;
         let mut buf = itoa::Buffer::new();
         let s = buf.format(rounded.unsigned_abs());
         let signed_len = (if neg && rounded != 0 { 1 } else { 0 }) + s.len();
@@ -111,7 +111,13 @@ pub(crate) fn write_fixed_float<W: std::fmt::Write>(
     // padded fractional digits — no float formatter on the hot path.
     let scale = 10f64.powi(precision as i32);
     let scaled = v * scale;
-    let rounded = scaled.round() as i128;
+    // Ties go to EVEN, not away from zero. canboat prints through printf,
+    // which rounds under the current FP mode -- FE_TONEAREST, i.e. half to
+    // even. `f64::round` rounds half away from zero, so an exact tie came out
+    // one ulp high: 127489's Power factor is 30976/16384 = 1.890625 exactly,
+    // scaling to 189062.5 at precision 5, and printed 1.89063 where canboat
+    // prints 1.89062.
+    let rounded = scaled.round_ties_even() as i128;
     let abs = rounded.unsigned_abs();
     let pow = 10u128.pow(precision as u32);
     let int_part = (abs / pow) as u64;

--- a/crates/canboat-core/src/output/mod.rs
+++ b/crates/canboat-core/src/output/mod.rs
@@ -141,6 +141,60 @@ pub(crate) fn write_fixed_float<W: std::fmt::Write>(
     w.write_str(frac_str)
 }
 
+/// C `printf("%g")` — how canboat prints FLOAT fields
+/// (`fieldPrintFloat`, print.c).
+///
+/// Six significant digits: `%e` when the decimal exponent is below -4
+/// or at least 6, `%f` otherwise, then trailing fractional zeros and a
+/// bare `.` are stripped. C's exponent always carries a sign and at
+/// least two digits, which Rust's `{:e}` does not.
+///
+/// This is not the same function as Rust's `{}`, which prints the
+/// shortest string that round-trips. The two diverge exactly where a
+/// FLOAT field is a widened `f32`: Garmin's `Heading to Steer` is
+/// `2.7274` under `%g` and `2.7273988723754883` under `{}`.
+///
+/// Allocates, unlike the rest of this module — but only on the FLOAT
+/// path, which a handful of PGNs use.
+pub(crate) fn write_c_g<W: std::fmt::Write>(w: &mut W, v: f64) -> std::fmt::Result {
+    const PRECISION: i32 = 6;
+
+    if v.is_nan() {
+        return w.write_str("nan");
+    }
+    if v.is_infinite() {
+        return w.write_str(if v > 0.0 { "inf" } else { "-inf" });
+    }
+
+    // Take the exponent from the rounded `%e` form rather than from
+    // `log10`, so a value that rounds up into the next decade (9.9999995
+    // → 1e+01) picks the exponent it will actually be printed with.
+    let sci = format!("{:.*e}", (PRECISION - 1) as usize, v);
+    let (mantissa, exp_str) = sci.split_once('e').expect("{:e} always emits an 'e'");
+    let exp: i32 = exp_str
+        .parse()
+        .expect("{:e} always emits an integer exponent");
+
+    fn trim(s: &str) -> &str {
+        match s.split_once('.') {
+            Some(_) => s.trim_end_matches('0').trim_end_matches('.'),
+            None => s,
+        }
+    }
+
+    // Spelled as C's own condition rather than a range test, so it
+    // reads against the standard's wording for %g.
+    #[allow(clippy::manual_range_contains)]
+    let scientific = exp < -4 || exp >= PRECISION;
+    if scientific {
+        w.write_str(trim(mantissa))?;
+        write!(w, "e{}{:02}", if exp < 0 { '-' } else { '+' }, exp.abs())
+    } else {
+        let decimals = (PRECISION - 1 - exp).max(0) as usize;
+        w.write_str(trim(&format!("{v:.decimals$}")))
+    }
+}
+
 /// Format days-since-1970-01-01 as `YYYY.MM.DD` (canboat text style).
 pub fn format_date(days: u16, w: &mut dyn std::fmt::Write) -> std::fmt::Result {
     let (y, m, d) = days_to_ymd(days as i64);
@@ -227,5 +281,61 @@ mod tests {
         let mut out = String::new();
         format_time(3661.5, 3, false, &mut out).unwrap();
         assert_eq!(out, "01:01:01.500");
+    }
+}
+
+#[cfg(test)]
+mod c_g_tests {
+    use super::write_c_g;
+
+    fn g(v: f32) -> String {
+        let mut s = String::new();
+        write_c_g(&mut s, v as f64).unwrap();
+        s
+    }
+
+    #[test]
+    fn matches_c_printf_g() {
+        // Expected strings produced by a C program printing `%g` of the
+        // same `(double)` promotions, compiled and run on this platform.
+        let cases: &[(f32, &str)] = &[
+            (2.727_398_9, "2.7274"), // Garmin Heading to Steer
+            (0.0, "0"),
+            (-0.0, "-0"),
+            (1.0, "1"),
+            (10.0, "10"),
+            (100_000.0, "100000"),  // last %f exponent
+            (1_000_000.0, "1e+06"), // first %e exponent
+            (1_234_567.0, "1.23457e+06"),
+            (0.0001, "0.0001"), // last %f exponent going down
+            (0.00001, "1e-05"), // first %e exponent going down
+            (9.999_999, "10"),  // rounds up into the next decade
+            (-core::f32::consts::PI, "-3.14159"),
+            (123_456.0, "123456"),
+            (0.5, "0.5"),
+            (1e-10, "1e-10"),
+            (1e20, "1e+20"),
+            (65535.0, "65535"),
+            (2.5e-5, "2.5e-05"),
+            (999_999.5, "1e+06"),
+            (1e6, "1e+06"),
+            (0.000_123_456, "0.000123456"),
+        ];
+        for (v, want) in cases {
+            assert_eq!(&g(*v), want, "%g of {v}");
+        }
+    }
+
+    #[test]
+    fn handles_non_finite() {
+        let mut s = String::new();
+        write_c_g(&mut s, f64::NAN).unwrap();
+        assert_eq!(s, "nan");
+        s.clear();
+        write_c_g(&mut s, f64::INFINITY).unwrap();
+        assert_eq!(s, "inf");
+        s.clear();
+        write_c_g(&mut s, f64::NEG_INFINITY).unwrap();
+        assert_eq!(s, "-inf");
     }
 }

--- a/crates/canboat-core/src/output/mod.rs
+++ b/crates/canboat-core/src/output/mod.rs
@@ -93,6 +93,30 @@ pub(crate) fn write_fixed_float<W: std::fmt::Write>(
     // still emit it as `-0.0`. Use `is_sign_negative` to catch that
     // along with proper negatives.
     let neg = v.is_sign_negative();
+    // Scaling by 10^precision can land exactly on .5 for a value that is
+    // not really a tie: `5 * 0.0001` is 0.000500000000000000010408…, above
+    // the tie, but multiplying by 1000 rounds the product to exactly 0.5 and
+    // the information is gone. printf never scales — it rounds off the
+    // double's own decimal expansion — so PGN 126208's `Air pressure offset`
+    // came out 0.000 where canboat prints 0.001.
+    //
+    // Hand an exact .5 to core::fmt, which is correctly rounded from the
+    // original value: a real tie (127489's 1.890625, a dyadic fraction)
+    // still goes to even, and a near-tie goes the way its true value points.
+    // Rare, so the fast path below keeps the common case.
+    fn lands_on_a_tie(v: f64, precision: usize) -> bool {
+        let scaled = v * 10f64.powi(precision as i32);
+        scaled.fract().abs() == 0.5
+    }
+    if lands_on_a_tie(v, precision) {
+        return write!(
+            w,
+            "{:>width$.prec$}",
+            v,
+            width = min_width,
+            prec = precision
+        );
+    }
     if precision == 0 {
         // Whole-number path: integer fmt. Ties go to even, see below.
         let rounded = v.round_ties_even() as i64;
@@ -324,6 +348,27 @@ mod c_g_tests {
         for (v, want) in cases {
             assert_eq!(&g(*v), want, "%g of {v}");
         }
+    }
+
+    #[test]
+    fn rounds_a_near_tie_the_way_printf_does() {
+        use super::write_fixed_float;
+        fn f(v: f64, p: usize) -> String {
+            let mut s = String::new();
+            write_fixed_float(&mut s, v, p, 0).unwrap();
+            s
+        }
+        // 5 * 0.0001 is 0.000500000000000000010408…, just *above* the
+        // tie, so printf rounds it up. Scaling by 1000 collapses the
+        // product onto exactly 0.5 and loses that. PGN 126208's
+        // `Air pressure offset` in samples/scx20-setting-tool-offsets.raw.
+        assert_eq!(f(5.0 * 0.0001, 3), "0.001");
+        // A genuine tie — 30976/16384 is exactly 1.890625 — still goes
+        // to even, as printf does under FE_TONEAREST. PGN 127489.
+        assert_eq!(f(30976.0 / 16384.0, 5), "1.89062");
+        // …and the even-side tie rounds up to the even digit.
+        assert_eq!(f(0.125, 2), "0.12");
+        assert_eq!(f(0.375, 2), "0.38");
     }
 
     #[test]

--- a/crates/canboat-core/src/output/text.rs
+++ b/crates/canboat-core/src/output/text.rs
@@ -296,9 +296,7 @@ fn write_field_value<W: fmt::Write>(
             Ok(())
         }
         FieldValue::Float(v) => {
-            // canboat uses %g for floats — Rust's `{}` for f64 is close
-            // enough for v0.
-            write!(w, "{}", v)?;
+            super::write_c_g(w, *v)?;
             if let Some(unit) = &f.unit() {
                 write!(w, " {}", unit)?;
             }

--- a/crates/canboat-core/src/output/text.rs
+++ b/crates/canboat-core/src/output/text.rs
@@ -324,11 +324,15 @@ fn write_field_value<W: fmt::Write>(
                 // BITLOOKUP rather than omitting the field.
                 w.write_str("None")
             } else {
-                for (i, (_, n)) in bits.iter().enumerate() {
+                for (i, (bv, n)) in bits.iter().enumerate() {
                     if i > 0 {
                         w.write_char(',')?;
                     }
-                    w.write_str(n)?;
+                    match n {
+                        Some(n) => w.write_str(n)?,
+                        // Unnamed set bit — canboat prints its value.
+                        None => write!(w, "{}", bv)?,
+                    }
                 }
                 Ok(())
             }

--- a/crates/canboat-core/src/output/text.rs
+++ b/crates/canboat-core/src/output/text.rs
@@ -275,6 +275,7 @@ fn write_field_value<W: fmt::Write>(
     payload: &[u8],
 ) -> fmt::Result {
     match &f.value {
+        FieldValue::Decimal(d) => w.write_str(d),
         FieldValue::Number(v) => {
             // Lat/lon are width 10, precision 7, and intentionally
             // suppress the `deg` unit (canboat's fieldPrintLatLon

--- a/crates/canboat-schema/src/lib.rs
+++ b/crates/canboat-schema/src/lib.rs
@@ -94,6 +94,14 @@ pub struct FieldInfo {
     /// the decoder's dynamic-length dispatch doesn't `memcmp` every
     /// field.
     pub is_dynamic_length_marker: bool,
+    /// Bytes of per-record header that sit between this
+    /// `DYNAMIC_FIELD_LENGTH` field and the value it sizes, and that the
+    /// reported length counts. Subtract to get the value's own width.
+    ///
+    /// Navico's 130822/130823 dumps report the length of the whole
+    /// record — a class byte and a 16-bit data-type id ahead of the
+    /// value — so their overhead is 3. `0` everywhere else.
+    pub dynamic_field_length_overhead: u32,
 }
 
 /// A PGN definition.


### PR DESCRIPTION
Brings `canboat convert` to byte-for-byte agreement with the C `analyzer` over the sample corpus, and fixes the C where it was the one that was wrong.

**Corpus differential** — `analyzer -json -nv` vs `canboat convert --to json --nv` over `samples/`, measured against a control build at every step:

| | before | after |
|---|---|---|
| byte-identical files | 55 / 105 | **104 / 105** |
| differing lines | 53725 | **8923** |

Every one of the 8923 remaining lines is `samples/ikonvert.log`, which is deliberately out of scope. Excluding it the corpus is exact. **No step regressed a single file** — each commit was measured independently, and where two fixes landed together they were re-measured separately to attribute them honestly.

## What was wrong

Grouped by cause rather than by commit.

**Resolving what a field even is**
- **126208 parameter targets** — a VARIABLE parameter names a field of another PGN, and the first definition was taken. canboat uses the parameter list as *evidence* (`getMatchingPgnByParameters`), walking `{index, value}` pairs with each candidate's own field widths, and only borrows the catch-all when nothing matches. A coarser "several definitions → catch-all" rule looks equivalent and is not: it regresses the SCX-20 captures, where `Manufacturer = Furuno` genuinely resolves a variant.
- **`DynamicFieldLengthOverhead`** — the attribute existed in `canboat.json` and in keel, and was dropped on the floor by the Rust schema. Navico's 130822/130823 records count their own 3-byte header in the declared length, so every value read three bytes too many and each record after the first started mid-field.
- **`DECIMAL`** was dispatched to the NUMBER decoder — not implemented at all. A DSC address of `33 14 00 5F 1E` is `5120009530` (decimal *pairs*), not the integer `130442859571`.

**Sentinels — in both directions**
- JSON never carries `"Out Of Range"` or `"Reserved"`; canboat routes all three sentinels through `printEmpty`, which omits the field (or writes `null` under `-empty`). Those spellings are text-mode only. PGN 65340's field `C` reads 254 on nearly every Simnet frame.
- An **ISO NAME** reserves its top *two* values via `fieldPrintName`, not through the per-field machinery (suppressed at 64 bits anyway). Expanding one invented a device that isn't on the wire.
- A **dynamic value** strips *no* sentinel: it decodes against a pseudo-field from a fieldtype lookup, and `reservedCount` is resolved in a pass over `pgnList`'s fields, which a lookup entry is not in. B&G's `Trip Time` reads all-ones until a trip starts and canboat prints `1193:02:47.295`.
- An **MMSI** does the opposite — `Sentinels: None` only keeps hints out of the document; the C still reserves the top three from `RangeMax`.
- An **all-ones DECIMAL** was mishandled by *both*: the C printed nothing and then discarded the entire record (see below); the Rust printed `1099511627775`.

**Field rendering**
- RESERVED/SPARE bytes are printed **in place** — `fieldPrintBinary` masks the first byte and shifts it back — not normalised to bit 0.
- A BITLOOKUP emits **every set bit**, naming it if the enumeration has an entry and writing `null` if not. Walking the enumeration instead made unnamed set bits invisible.
- FLOAT prints via `%g`, six significant digits — a different function from Rust's shortest-round-trip `{}`.
- Fixed-precision rounding must not scale first: `5 × 0.0001` is *above* the tie, but scaling by 1000 collapses the product onto exactly `0.5`.
- Strings trim all of `isspace()`, not just a space.
- A zero-width BINARY takes its width in *bits* from the preceding field.
- A non-zero SPARE inside an ISO NAME is rendered, not dropped.

**Truncated and malformed input**
- `STRING_FIX` caps to what arrived rather than demanding its full declared width.
- A trailing RESERVED cut short by a short frame is all-ones over the *truncated* width — the decoder already decided that, and the writer was re-deriving it and disagreeing.
- A line that stops after the length field has no payload section and canboat rejects it; accepting it produced a fields-less record for a PGN that doesn't exist and shifted every record after it.

## Two fixes to the C

Both are cases where the C was wrong and the Rust was right, or where both were:

1. **`fieldPrintTime` printed a sub-second fraction as raw resolution units**, zero-padded to `log10` of the units-per-second. Only correct at power-of-ten resolutions. `DURATION_UFIX8_5MS` has 200/s, so it was wrong twice over: raw 19 (0.095 s) printed `.19`, and raw 150 (0.750 s) printed `.150` — three digits in a two-digit field. Six fields move; the other 78 are untouched.
2. **`fieldPrintDecimal` destroyed whole records.** An absent field is all ones, every byte is 255, every byte fails its own `value < 100` test, so the routine printed nothing while returning true — and `printField`'s "did not print anything" guard then discarded the entire PGN. A DSC distress call whose `MMSI of Ship In Distress` simply wasn't carried took every other field with it.

## Public API

Two breaking changes to `FieldValue`, neither published to crates.io:
- `BitField`'s `bits` becomes `Vec<(u64, Option<&'static str>)>` — an unnamed set bit has no name to give.
- a new `Decimal(String)` variant — the digits are text so a leading `00` pair survives; both formatters emit it bare, so it still lands in JSON as a number literal.

## Gates

472 Rust tests with `CANBOAT_GOLDEN=required` · C test suite · clippy `-D warnings` · rustfmt · contract gate `patch` · 3-OS build, MSRV, docs, keel dependency closure.

Every regression test was checked to **fail with its fix backed out**. That caught two that passed with the bug present — one because two code paths set the same value and only the later one mattered, another because the synthetic frame never produced the field being asserted on.

## Known, deliberately not fixed

- **`samples/ikonvert.log`** — out of scope by agreement.
- **Local-vs-UTC date on time-only timestamps** (YDWG02). The C fills the date from `localtime`, the Rust from UTC; they agree except between local midnight and UTC midnight. Not clearly arguable either way — quite possibly neither should synthesise a date at all.
- **`fieldPrintDecimal`'s `>= 100` skip** silently drops an invalid byte, yielding a *wrong* address rather than a short one. Separate from the absent-field case and unexercised by any capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
