### PR TITLE
docs: name the helper-script languages correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ names (`analyzer`, `n2kd`, `actisense-serial`, …). It never takes a name that
 another program already holds, so it is safe to run in a directory that has the
 C tools installed — it reports what it left alone.
 
-The remaining C converters and the Python helper scripts will most likely move
-to Rust in time; the C `n2kd` and `n2kd_monitor` already have, and were removed
-in v8.
+The remaining C converters, the helper scripts in `util/` (PHP, perl and ksh)
+and the Python tooling will most likely move to Rust in time; the C `n2kd` and
+`n2kd_monitor` already have, and were removed in v8.
 
 ## The library
 


### PR DESCRIPTION
The scripts in `util/` are **PHP, perl and ksh93** — not Python. Python lives in `dbc-exporter/` and the `analyzer/` build helpers. Checked by reading every shebang in `util/` rather than assuming:

```
<?php            util/format-message, util/list-product-information, util/hex-to-raw.php, util/canboat-default.inc
#!/bin/ksh93     util/emulate-classa, util/emulate-classa-broken, util/emulate-sar
#!/usr/bin/env perl   util/replay
#!/bin/bash      util/update-copyright.sh
```

## Why this is a separate PR

This was committed to #785's branch as `e7b7b54`, but the push landed a few seconds *after* that PR was merged — the merge captured `775d7fe` and the correction was left stranded on the branch. So master still claims "the Python helper scripts". Cherry-picked onto current master here.

Nothing else was stranded: `chore/remove-c-n2kd`, `fix/install-shims-no-clobber` and `chore/release-as-8.0.0-beta1` are all fully contained in master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)