### PR TITLE
docs(navico): expand the autopilot command section

### DIFF
--- a/docs/navico_alarms_and_commands.html
+++ b/docs/navico_alarms_and_commands.html
@@ -168,7 +168,55 @@ a { color: #1a73e8; }
 <p>A man-overboard is an alarm-class event (byte 5 = 255) with byte 6 = <strong>107 MOB Activated</strong> / <strong>108 MOB Cancelled</strong>, broadcast to all groups (byte 4 = <code>0xff</code>, no alarm id). Unlike depth/wind alarms — which burst from several devices — the MOB is emitted only by the <strong>originating display</strong> and is not re-broadcast by the other devices.</p>
 <p>The MOB <strong>position</strong> does not ride 130850; it rides the standard NMEA 2000 PGN <strong>127233 (Man Overboard Notification)</strong>, emitted by the same source at the same instant. So a complete MOB is a <em>pair</em>: 130850 carries the lifecycle (Activated/Cancelled) and 127233 carries the latitude/longitude. To follow a MOB in a capture, watch for the 130850 <code>MOB Activated</code> and read the position from the paired 127233.</p>
 <h2 id="autopilot-commands-pgn-130850-byte-5-10">Autopilot commands — PGN 130850, byte 5 = 10</h2>
-<p>Autopilot mode changes (Auto, Wind, Nav, No Drift), heading/course adjustments and the like ride 130850 with byte 5 = 10 (AP Command). The autopilot computer echoes accepted commands back on PGN 130851 (AP command reply). These share the same 12-byte frame and the same byte-4 network group as the alarm and timer families.</p>
+<p>Autopilot mode changes (Auto, Wind, Nav, No Drift), heading/course adjustments and the like ride 130850 with byte 5 = 10 (AP Command). These share the same 12-byte frame and the same byte-4 network group as the alarm and timer families.</p>
+<h3 id="finding-the-autopilot">Finding the autopilot</h3>
+<p>Every device broadcasts <strong>PGN 60928 (ISO Address Claim)</strong> at startup and after renumbering; the autopilot is the one claiming <strong>Device Function 150</strong>. Beware that <code>DEVICE_FUNCTION</code> is an <em>indirect</em> lookup — the function number only has meaning together with the <strong>Device Class</strong>. Function 150 is <code>Autopilot</code> only in class <strong>40</strong> (Steering and Control surfaces); in other classes the same 150 means Camera (class 20), Bridge (25), Function Controller (30) or Engine Controller (50). Matching on the function alone will latch onto the wrong device:</p>
+<pre><code>on PGN 60928:
+    if Device Class == 40 and Device Function == 150:
+        autopilot_address = message.src</code></pre>
+<p>The autopilot's address also appears in byte 2 of every 130851 reply, so watching the replies is an alternative to address-claim tracking.</p>
+<h3 id="the-command-set">The command set</h3>
+<p>Byte 6 carries the action, from <code>SIMNET_AP_EVENTS</code>. The commands canboat models as their own 130850 variants:</p>
+<table>
+<thead><tr>
+<th>Byte 6</th>
+<th>Command</th>
+<th>canboat id</th>
+</tr></thead>
+<tbody>
+<tr><td>6</td><td>Standby (disengage)</td><td><code>simnetCommandApStandby</code></td></tr>
+<tr><td>9</td><td>Heading mode</td><td><code>simnetCommandApHeading</code></td></tr>
+<tr><td>10</td><td>Nav mode</td><td><code>simnetCommandApNav</code></td></tr>
+<tr><td>12</td><td>No Drift mode</td><td><code>simnetCommandApNodrift</code></td></tr>
+<tr><td>15</td><td>Wind mode</td><td><code>simnetCommandApWind</code></td></tr>
+<tr><td>17</td><td>Tack</td><td><code>simnetCommandApTack</code></td></tr>
+<tr><td>26</td><td>Change course</td><td><code>simnetCommandApChangeCourse</code></td></tr>
+</tbody>
+</table>
+<p>The mode commands carry no parameters — bytes 8–11 are <code>0xff</code>. Only <em>Change course</em> uses the trailing bytes:</p>
+<table>
+<thead><tr>
+<th>Byte</th>
+<th>Field</th>
+<th>Meaning</th>
+</tr></thead>
+<tbody>
+<tr><td>8</td><td><strong>Direction</strong></td><td><code>SIMNET_DIRECTION</code>: 2 = Port, 3 = Starboard (4/5 = left/right rudder)</td></tr>
+<tr><td>9–10</td><td><strong>Angle</strong></td><td><code>ANGLE_UFIX16</code>, radians in units of 0.0001, little-endian</td></tr>
+</tbody>
+</table>
+<p>The angle is an unsigned magnitude; the sign lives in Direction. 10° to port is <code>Direction = 2</code>, <code>Angle = 1745</code> (0x06d1), because 10 × π/180 = 0.1745 rad.</p>
+<h3 id="the-autopilot-acknowledges-pgn-130851">The autopilot acknowledges — PGN 130851</h3>
+<p>An addressed 130850 AP command <strong>is</strong> acknowledged: the autopilot echoes it back on <strong>PGN 130851 (<code>Simnet: AP command Reply</code>)</strong> byte-for-byte, exactly one reply per command, within roughly 20–70 ms, with byte 2 set to its own address. Commands sent to Address <code>0xff</code> (broadcast) are <em>not</em> acknowledged.</p>
+<p>So the reply is the direct success/failure signal, and is more reliable than inferring the outcome from state broadcasts. Watching only the state PGNs is still useful as a cross-check:</p>
+<ul>
+<li><strong>PGN 65341 (<code>Simnet: Autopilot Angle</code>)</strong> — current mode (<code>SIMNET_AP_MODE</code>) and angle.</li>
+<li><strong>PGN 127237 (Heading/Track Control)</strong> — the standard PGN, carrying the active heading-to-steer.</li>
+</ul>
+<p>An accepted command does not mean the mode engaged: the autopilot refuses Heading/Wind/Nav when its sensor stack is incomplete (a Triton² logs "Reduced functionality" when a heading or wind source is missing), so confirm the mode actually changed rather than trusting the acknowledgement alone.</p>
+<blockquote>
+<p><strong>Frame length caveat.</strong> Captured mode-command frames are 12 bytes, matching the fixed layout above, but canboat currently models the mode-command variants with only 11 (their trailing <code>Reserved</code> is 24 bits where the wire shows 32). The extra <code>0xff</code> is harmless and decodes fine; <code>simnetCommandApChangeCourse</code> and the 130851 reply are modelled at the full 12.</p>
+</blockquote>
 <h2 id="propagation-why-an-alarm-sometimes-stays-local">Propagation — why an alarm sometimes stays local</h2>
 <p>An alarm is only network-wide if it is actually broadcast. The same alarm type can behave differently depending on where it is enabled:</p>
 <ul>

--- a/research/navico_alarms_and_commands.md
+++ b/research/navico_alarms_and_commands.md
@@ -258,9 +258,80 @@ paired 127233.
 ## Autopilot commands — PGN 130850, byte 5 = 10
 
 Autopilot mode changes (Auto, Wind, Nav, No Drift), heading/course adjustments and
-the like ride 130850 with byte 5 = 10 (AP Command). The autopilot computer echoes
-accepted commands back on PGN 130851 (AP command reply). These share the same
-12-byte frame and the same byte-4 network group as the alarm and timer families.
+the like ride 130850 with byte 5 = 10 (AP Command). These share the same 12-byte
+frame and the same byte-4 network group as the alarm and timer families.
+
+### Finding the autopilot
+
+Every device broadcasts **PGN 60928 (ISO Address Claim)** at startup and after
+renumbering; the autopilot is the one claiming **Device Function 150**. Beware
+that `DEVICE_FUNCTION` is an *indirect* lookup — the function number only has
+meaning together with the **Device Class**. Function 150 is `Autopilot` only in
+class **40** (Steering and Control surfaces); in other classes the same 150 means
+Camera (class 20), Bridge (25), Function Controller (30) or Engine Controller
+(50). Matching on the function alone will latch onto the wrong device:
+
+```
+on PGN 60928:
+    if Device Class == 40 and Device Function == 150:
+        autopilot_address = message.src
+```
+
+The autopilot's address also appears in byte 2 of every 130851 reply, so watching
+the replies is an alternative to address-claim tracking.
+
+### The command set
+
+Byte 6 carries the action, from `SIMNET_AP_EVENTS`. The commands canboat models
+as their own 130850 variants:
+
+| Byte 6 | Command | canboat id |
+|-------:|---------|------------|
+| 6 | Standby (disengage) | `simnetCommandApStandby` |
+| 9 | Heading mode | `simnetCommandApHeading` |
+| 10 | Nav mode | `simnetCommandApNav` |
+| 12 | No Drift mode | `simnetCommandApNodrift` |
+| 15 | Wind mode | `simnetCommandApWind` |
+| 17 | Tack | `simnetCommandApTack` |
+| 26 | Change course | `simnetCommandApChangeCourse` |
+
+The mode commands carry no parameters — bytes 8–11 are `0xff`. Only *Change
+course* uses the trailing bytes:
+
+| Byte | Field | Meaning |
+|------|-------|---------|
+| 8 | **Direction** | `SIMNET_DIRECTION`: 2 = Port, 3 = Starboard (4/5 = left/right rudder) |
+| 9–10 | **Angle** | `ANGLE_UFIX16`, radians in units of 0.0001, little-endian |
+
+The angle is an unsigned magnitude; the sign lives in Direction. 10° to port is
+`Direction = 2`, `Angle = 1745` (0x06d1), because 10 × π/180 = 0.1745 rad.
+
+### The autopilot acknowledges — PGN 130851
+
+An addressed 130850 AP command **is** acknowledged: the autopilot echoes it back
+on **PGN 130851 (`Simnet: AP command Reply`)** byte-for-byte, exactly one reply
+per command, within roughly 20–70 ms, with byte 2 set to its own address.
+Commands sent to Address `0xff` (broadcast) are *not* acknowledged.
+
+So the reply is the direct success/failure signal, and is more reliable than
+inferring the outcome from state broadcasts. Watching only the state PGNs is
+still useful as a cross-check:
+
+- **PGN 65341 (`Simnet: Autopilot Angle`)** — current mode (`SIMNET_AP_MODE`) and
+  angle.
+- **PGN 127237 (Heading/Track Control)** — the standard PGN, carrying the active
+  heading-to-steer.
+
+An accepted command does not mean the mode engaged: the autopilot refuses
+Heading/Wind/Nav when its sensor stack is incomplete (a Triton² logs "Reduced
+functionality" when a heading or wind source is missing), so confirm the mode
+actually changed rather than trusting the acknowledgement alone.
+
+> **Frame length caveat.** Captured mode-command frames are 12 bytes, matching the
+> fixed layout above, but canboat currently models the mode-command variants with
+> only 11 (their trailing `Reserved` is 24 bits where the wire shows 32). The
+> extra `0xff` is harmless and decodes fine; `simnetCommandApChangeCourse` and the
+> 130851 reply are modelled at the full 12.
 
 ## Propagation — why an alarm sometimes stays local
 


### PR DESCRIPTION
Closes #724.

Folds the verified content of the `AUTOPILOT_CONTROL.md` attached to #724 into `research/navico_alarms_and_commands.md`, which the issue offered as its home and which the 130850/130851 definitions already reference via `researchDoc:`.

Every claim was re-checked against the database rather than copied across. **Three did not survive.**

## 1. The commands *are* acknowledged

The attachment said:

> These PGNs are unidirectional commands; the autopilot does not ack them as such. Verify success by watching PGN 65341 / 127237.

@TwoCanPlugIn flagged this on the issue, and it is wrong. An addressed 130850 AP command is echoed back byte-for-byte on **PGN 130851**, one reply per command, within ~20–70 ms, with byte 2 carrying the autopilot's own address; broadcasts to `0xff` are not acknowledged. canboat's own `simnetApCommandReply` explanation already documented exactly this — the attachment simply contradicted it.

The state PGNs are kept as a cross-check, with the caveat that an acknowledged command can still fail to engage (the autopilot refuses Heading/Wind/Nav on an incomplete sensor stack).

## 2. Device Function 150 alone finds the wrong device

The attachment's recipe was `if Device Function == 150: autopilot_address = src`. But `DEVICE_FUNCTION` is a **triplet / indirect** lookup — the function number only means anything alongside the Device Class:

| Class | Function 150 means |
|---|---|
| **40** Steering and Control surfaces | **Autopilot** |
| 20 | Camera |
| 25 | Bridge |
| 30 | Function Controller |
| 50 | Engine Controller |

So the class must be matched too. Also records @TwoCanPlugIn's second point: byte 2 of the 130851 reply is a second source for the address.

## 3. Frame length

The attachment described the mode commands as 11 bytes. All three captured samples in `samples/` are **12**, matching the fixed 130850 layout this document already describes. canboat models the mode-command variants with 11 — their trailing `Reserved` is 24 bits where the wire shows 32, while `simnetCommandApChangeCourse` and the 130851 reply are modelled at the full 12. Recorded as a caveat rather than silently changed; happy to open a separate PR widening that field if wanted.

## Confirmed unchanged

Event codes (6 / 9 / 10 / 12 / 15 / 17 / 26), the Direction values (2 = Port, 3 = Starboard) and the radians × 10⁻⁴ angle encoding all check out against `SIMNET_AP_EVENTS`, `SIMNET_DIRECTION` and the committed 130850 samples — including that 10° → `0x06d1`.

## Not folded in

The merrimac-rs implementation notes and the pipeline injection port, which describe that stack rather than the protocol.

## Verification

Docs-only: `keel check` clean (607 pgns, 0 errors), and `keel generate` writes nothing — `<ResearchDoc>` carries only the document name, not its content, so no generated artifact changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)