### PR TITLE
feat(release): publish the Rust canboat binary with every release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,6 +86,24 @@ jobs:
       - name: Build C tools
         run: make
 
+      # The Rust `canboat` binary (analyzer + gateway shims + convert/n2kd/
+      # pipeline via argv[0] dispatch) uses the same static-musl treatment as
+      # keel on linux, so one binary runs on any distro/glibc. It is built
+      # BEFORE the archive is packed so it ships inside the platform tarball
+      # (next to the C tools) and is also uploaded standalone as
+      # canboat-rust-<os>-<arch> for direct fetch.
+      - name: Build canboat (Rust)
+        run: |
+          if [ -n "${{ matrix.rust_target }}" ]; then
+            rustup target add "${{ matrix.rust_target }}"
+            cargo build --release -p canboat --target "${{ matrix.rust_target }}"
+            cp "target/${{ matrix.rust_target }}/release/canboat" "canboat-rust-${{ matrix.os }}-${{ matrix.arch }}"
+          else
+            cargo build --release -p canboat
+            cp target/release/canboat "canboat-rust-${{ matrix.os }}-${{ matrix.arch }}"
+          fi
+          cp "canboat-rust-${{ matrix.os }}-${{ matrix.arch }}" "rel/${{ matrix.os }}-${{ matrix.arch }}/canboat"
+
       - name: Package canboat archive
         run: |
           plat="${{ matrix.os }}-${{ matrix.arch }}"
@@ -111,6 +129,7 @@ jobs:
           prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             canboat-${{ matrix.os }}-${{ matrix.arch }}-${{ github.ref_name }}.tar.gz
+            canboat-rust-${{ matrix.os }}-${{ matrix.arch }}
             keel-${{ matrix.os }}-${{ matrix.arch }}
 
   # Intel macOS: cross-built on the Apple-Silicon runner (-arch x86_64), so we
@@ -125,6 +144,13 @@ jobs:
 
       - name: Build C tools (x86_64)
         run: make PLATFORM=darwin-x86_64 CFLAGS="-Wall -O2 -arch x86_64" LDFLAGS="-arch x86_64"
+
+      - name: Build canboat (Rust, x86_64)
+        run: |
+          rustup target add x86_64-apple-darwin
+          cargo build --release -p canboat --target x86_64-apple-darwin
+          cp target/x86_64-apple-darwin/release/canboat canboat-rust-darwin-x86_64
+          cp canboat-rust-darwin-x86_64 rel/darwin-x86_64/canboat
 
       - name: Package canboat archive
         run: tar czf "canboat-darwin-x86_64-${GITHUB_REF_NAME}.tar.gz" --exclude venv -C rel/darwin-x86_64 .
@@ -141,6 +167,7 @@ jobs:
           prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             canboat-darwin-x86_64-${{ github.ref_name }}.tar.gz
+            canboat-rust-darwin-x86_64
             keel-darwin-x86_64
 
   # 32-bit ARM (e.g. Raspberry Pi): static musl cross-build of both the C tools
@@ -172,6 +199,16 @@ jobs:
           export BUILDDIR="rel/${TARGET}"
           make
 
+      - name: Build canboat (Rust, static musl)
+        run: |
+          rustup target add "${RUST_TARGET}"
+          cc="$HOME/musl/${TARGET}-cross/bin/${TARGET}-gcc"
+          export CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER="$cc"
+          export CC_armv7_unknown_linux_musleabihf="$cc"
+          cargo build --release -p canboat --target "${RUST_TARGET}"
+          cp "target/${RUST_TARGET}/release/canboat" canboat-rust-linux-armv7l
+          cp canboat-rust-linux-armv7l "rel/${TARGET}/canboat"
+
       - name: Package canboat archive
         run: |
           tar czf "canboat-linux-armv7l-${GITHUB_REF_NAME}.tar.gz" --exclude venv -C "rel/${TARGET}" .
@@ -191,6 +228,7 @@ jobs:
           prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             canboat-linux-armv7l-${{ github.ref_name }}.tar.gz
+            canboat-rust-linux-armv7l
             keel-linux-armv7l
 
   windows:

--- a/crates/canboat-io/src/device/socketcan.rs
+++ b/crates/canboat-io/src/device/socketcan.rs
@@ -960,7 +960,10 @@ mod imp {
                 fd,
                 batch.msgs.as_mut_ptr(),
                 RX_BATCH as libc::c_uint,
-                libc::MSG_DONTWAIT,
+                // The flags parameter is c_int on glibc but c_uint on musl;
+                // `as _` lets the same call compile for both libc targets
+                // (the static-musl release build needs this).
+                libc::MSG_DONTWAIT as _,
                 std::ptr::null_mut(),
             )
         };


### PR DESCRIPTION
Every release ships the C tools per platform, but the Rust `canboat` binary is build-from-source only. Downstream consumers that want the Rust analyzer/gateway shims (I'm activating signalk-server's native N2K decode path in container images) have no way to obtain it without a toolchain.

This builds the `canboat` binary alongside keel in the native, macos-x86_64 and armv7 release jobs with the same static-musl treatment on linux, and ships it both inside the platform tarball (as `canboat`, next to the C tools) and as a standalone `canboat-rust-<os>-<arch>` asset.

The musl build surfaced one portability issue: libc declares `recvmmsg`'s flags as `c_int` on glibc but `c_uint` on musl, so the socketcan batch receive did not compile for `*-musl` targets; an `as _` cast fixes both flavours.

Tested: `cargo build --release -p canboat --target x86_64-unknown-linux-musl` builds and the resulting static binary runs (`--version`, argv[0] analyzer dispatch, `convert`) on Debian trixie and Ubuntu 26.04.