### PR TITLE
fix(interface): accept the C maretron-ipg device syntax in the shim

### DIFF
--- a/crates/canboat/src/interface.rs
+++ b/crates/canboat/src/interface.rs
@@ -80,7 +80,9 @@ pub struct Args {
     device: String,
 
     /// Serial baud rate. Defaults to 115200 (ngt1) / 230400 (ikonvert).
-    #[arg(short = 'b', long)]
+    /// `-s` is the C actisense-serial/ikonvert-serial spelling; the
+    /// argv[0] shims must stay drop-in compatible with it.
+    #[arg(short = 'b', long, short_alias = 's')]
     baud: Option<u32>,
 
     /// Read-only: emit received frames, ignore stdin.

--- a/crates/canboat/src/interface.rs
+++ b/crates/canboat/src/interface.rs
@@ -237,8 +237,19 @@ fn open_device(args: &Args) -> Result<DeviceHandle> {
             Ok(device::ikonvert::run(r, w, config))
         }
         Kind::Maretron => {
-            let stream = TcpStream::connect(&args.device)
-                .with_context(|| format!("connecting to {}", args.device))?;
+            // The C maretron-ipg takes `tcp://<host>[:<port>]` with the
+            // port defaulting to 6543; the argv[0] shim must stay
+            // drop-in compatible with that syntax (signalk-server
+            // spawns it exactly so), and the bare `host:port` form
+            // keeps working.
+            let endpoint = args.device.strip_prefix("tcp://").unwrap_or(&args.device);
+            let endpoint = if endpoint.contains(':') {
+                endpoint.to_string()
+            } else {
+                format!("{endpoint}:6543")
+            };
+            let stream = TcpStream::connect(&endpoint)
+                .with_context(|| format!("connecting to {endpoint}"))?;
             let reader: Box<dyn Read + Send> =
                 Box::new(stream.try_clone().context("cloning TCP stream")?);
             let writer: Box<dyn Write + Send> = Box::new(stream);


### PR DESCRIPTION
The C `maretron-ipg` takes `tcp://<host>[:<port>]` with the port defaulting to 6543. The Rust shim required a bare `host:port` and failed name resolution on the scheme-prefixed form — so existing callers broke when the shim replaced the C binary. I hit this live: signalk-server spawns `maretron-ipg tcp://<host>:<port>` for its native Maretron connection, which exited 1 against the Rust binary.

Strip the optional `tcp://` prefix and default the port to 6543; the bare `host:port` form keeps working.

Tested: both `tcp://192.168.0.179:6543` and `tcp://192.168.0.179` connect to a real IPG100 and stream, and `192.168.0.179:6543` still works.