### PR TITLE
ci: add dependabot config for actions, cargo and docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
-# Keep the repo's dependencies up to date. Each ecosystem gets a single
-# grouped weekly PR so versions stop drifting (e.g. actions/checkout@v4
-# pinning the deprecated Node 20 runtime).
+# Keep the repo's dependencies up to date on a weekly schedule so versions
+# stop drifting (e.g. actions/checkout@v4 pinning the deprecated Node 20
+# runtime). Actions and cargo bumps arrive grouped into one PR each; the
+# Dockerfile has a single dependency (the base image), so no group needed.
 #
 # Covered ecosystems: GitHub Actions, the root cargo workspace (keel and
 # crates/* are members and share the root Cargo.lock), and the Dockerfile

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,11 @@
-# Keep GitHub Actions in the workflows up to date. Bumps arrive as a single
-# grouped weekly PR so the workflows stop drifting onto deprecated action
-# versions (e.g. actions/checkout@v4 pinning the deprecated Node 20 runtime).
+# Keep the repo's dependencies up to date. Each ecosystem gets a single
+# grouped weekly PR so versions stop drifting (e.g. actions/checkout@v4
+# pinning the deprecated Node 20 runtime).
+#
+# Covered ecosystems: GitHub Actions, the root cargo workspace (keel and
+# crates/* are members and share the root Cargo.lock), and the Dockerfile
+# base image. The Rust toolchain itself tracks `stable` via
+# rust-toolchain.toml and needs no updater.
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -11,3 +16,17 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      cargo:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Keep GitHub Actions in the workflows up to date. Bumps arrive as a single
+# grouped weekly PR so the workflows stop drifting onto deprecated action
+# versions (e.g. actions/checkout@v4 pinning the deprecated Node 20 runtime).
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Recent CI runs (e.g. https://github.com/canboat/canboat/actions/runs/30875454331) warn on every job that actions/checkout@v4 targets the deprecated Node 20 runtime. This adds a Dependabot config so dependency versions stop drifting, covering everything Dependabot can manage in this repo:

- github-actions: all action bumps grouped into one weekly PR (this is what fixes the checkout@v4 warnings — Dependabot will file the v4 → v6 bump itself after merge)
- cargo: the root workspace (keel and crates/* are members sharing the root Cargo.lock), grouped into one weekly PR
- docker: the Dockerfile base image (ubuntu:22.04)

Not covered because there is nothing to manage: the Rust toolchain tracks `stable` via rust-toolchain.toml, and there are no npm/Python/submodule/devcontainer manifests. One observation while auditing: keel/Cargo.lock looks like a leftover from the Rust port — as a workspace member keel resolves against the root Cargo.lock, so that file is dead weight and could be deleted (left out of this PR to keep it scoped).

Tested: CodeRabbit review of the change came back clean (one comment-wording nit, addressed).