### PR TITLE
feat(release): publish the Rust canboat binary for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,5 +133,9 @@ jobs:
             packages: make gcc-core
             hardlinks: 1
 
+      # Derived from GITHUB_WORKSPACE (the login shell starts in the Cygwin
+      # home): a hardcoded /cygdrive/d/a/canboat/canboat path only exists
+      # when the repository is literally named "canboat", which breaks
+      # running the workflow from a fork.
       - name: make
-        run: make -C /cygdrive/d/a/canboat/canboat
+        run: make -C "$(cygpath -u "$GITHUB_WORKSPACE")"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -264,6 +264,21 @@ jobs:
           prerelease: ${{ contains(github.ref_name, '-') }}
           files: rel/*.zip
 
+      # Like keel below, the Rust canboat binary is a native MSVC build
+      # released standalone — the zip above stays Cygwin-only. Each asset
+      # uploads right after its build so no later build issue blocks it.
+      - name: Build canboat (Rust, MSVC)
+        shell: pwsh
+        run: |
+          cargo build --release -p canboat
+          Copy-Item target/release/canboat.exe canboat-rust-windows-x86_64.exe
+
+      - name: Add canboat-rust asset
+        uses: softprops/action-gh-release@v3
+        with:
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          files: canboat-rust-windows-x86_64.exe
+
       - name: Build keel (MSVC)
         shell: pwsh
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -248,12 +248,17 @@ jobs:
             packages: make gcc-core zip
             hardlinks: 1
 
+      # The login shell starts in the Cygwin home directory, so the repo
+      # path must be spelled out — but derived from GITHUB_WORKSPACE, not
+      # hardcoded: a hardcoded /cygdrive/d/a/canboat/canboat only exists
+      # when the repository is literally named "canboat", which breaks
+      # running the workflow from a fork.
       - name: make
-        run: make -C /cygdrive/d/a/canboat/canboat
+        run: make -C "$(cygpath -u "$GITHUB_WORKSPACE")"
 
       - name: zip
         run: |
-          cd /cygdrive/d/a/canboat/canboat/rel/cygwin*/
+          cd "$(cygpath -u "$GITHUB_WORKSPACE")"/rel/cygwin*/
           zip "../canboat-windows-x86_64-${GITHUB_REF##*/}.zip" *.exe *.dll
 
       # Upload the C-tool archive before building keel, so a keel build issue


### PR DESCRIPTION
The Windows release job built the Cygwin C-tool zip and the MSVC keel binary, but never the Rust canboat binary — every other platform has shipped it standalone (canboat-rust-<os>-<arch>) since #799. This builds it with the same native MSVC toolchain keel already uses and uploads it as canboat-rust-windows-x86_64.exe, with its own isolated upload step so no later build issue can block earlier assets.

While end-to-end testing this on my fork, the Windows job failed before reaching the new step: both ci.yml and release.yaml hardcoded the checkout path as /cygdrive/d/a/canboat/canboat, which only exists when the repository is literally named canboat. The second commit derives the path from GITHUB_WORKSPACE via cygpath instead, so the workflows also run from forks (the login shell still needs an absolute path because it starts in the Cygwin home directory).

Tested: full release workflow run on my fork with a v8.0.0-beta1 tag — all seven jobs green, all 21 assets uploaded including canboat-rust-windows-x86_64.exe (verified PE32+ x86-64 console executable; the linux x86_64 asset runs and reports canboat 8.0.0-beta1). The rust-ci workflow already builds and tests the workspace on windows-latest every run, so the MSVC compile itself was already covered.