### PR TITLE
refactor(socketcan): fragment fast-packet TX through the shared helper

### DIFF
--- a/crates/canboat-io/src/device/socketcan.rs
+++ b/crates/canboat-io/src/device/socketcan.rs
@@ -1376,4 +1376,73 @@ mod imp {
             }
         }
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        /// Run one `send_pgn` against a fresh (or provided) TX ring and
+        /// return every queued CAN payload, so the tests pin the exact
+        /// wire bytes the chunking produces.
+        fn send(tx_buf: &mut TxBuffer, pgn: u32, data: &[u8]) -> Vec<Vec<u8>> {
+            let before = tx_buf.queue.len();
+            let (frames_tx, _frames_rx) = mpsc::channel();
+            let mut bus = Bus {
+                tx_buf,
+                frames_tx: &frames_tx,
+            };
+            bus.send_pgn(6, pgn, 42, ADDR_GLOBAL, data, false);
+            bus.tx_buf
+                .queue
+                .iter()
+                .skip(before)
+                .map(|f| f.data().to_vec())
+                .collect()
+        }
+
+        /// PGN 127508 (Battery Status) is single-frame even at exactly
+        /// 8 bytes of payload: no fast-packet shell.
+        #[test]
+        fn single_frame_pgn_goes_out_verbatim() {
+            let data: Vec<u8> = (1..=8).collect();
+            let frames = send(&mut TxBuffer::new(), 127508, &data);
+            assert_eq!(frames, vec![data]);
+        }
+
+        /// A fast-packet payload splits per ISO 11783-3: 6 bytes after
+        /// the (seq|index, length) header, then 7 per continuation,
+        /// last frame padded to 8 with 0xff.
+        #[test]
+        fn fast_packet_frame_layout_is_pinned() {
+            let data: Vec<u8> = (1..=17).collect();
+            let frames = send(&mut TxBuffer::new(), 126996, &data);
+            assert_eq!(
+                frames,
+                vec![
+                    vec![0x00, 17, 1, 2, 3, 4, 5, 6],
+                    vec![0x01, 7, 8, 9, 10, 11, 12, 13],
+                    vec![0x02, 14, 15, 16, 17, 0xff, 0xff, 0xff],
+                ]
+            );
+        }
+
+        /// A fast-packet PGN keeps its shell even when the payload fits
+        /// a single CAN frame: receivers key framing on the PGN type.
+        #[test]
+        fn short_fast_packet_payload_keeps_the_shell() {
+            let frames = send(&mut TxBuffer::new(), 126208, &[9, 8, 7, 6, 5, 4]);
+            assert_eq!(frames, vec![vec![0x00, 6, 9, 8, 7, 6, 5, 4]]);
+        }
+
+        /// Consecutive sends of the same (pgn, src) advance the 3-bit
+        /// sequence counter in the upper bits of byte 0.
+        #[test]
+        fn fast_seq_advances_between_sends() {
+            let mut tx_buf = TxBuffer::new();
+            let first = send(&mut tx_buf, 126996, &[0xaa; 10]);
+            let second = send(&mut tx_buf, 126996, &[0xaa; 10]);
+            assert_eq!(first[0][0], 0x00);
+            assert_eq!(second[0][0], 0x20);
+        }
+    }
 }

--- a/crates/canboat-io/src/device/socketcan.rs
+++ b/crates/canboat-io/src/device/socketcan.rs
@@ -344,34 +344,9 @@ mod imp {
             if !is_fast {
                 self.tx_buf.push(can_id, data);
             } else {
-                // Per ISO 11783-3: every fast-packet CAN frame is
-                // exactly 8 bytes; the last chunk is padded with 0xff.
-                // The first byte is `(seq << 5) | index`, with `seq`
-                // incrementing per-(pgn, src) instance so consecutive
-                // first frames are distinguishable from continuations.
                 let seq = self.tx_buf.next_fast_seq(pgn, src);
-                let mut index: u8 = 0;
-                let mut remaining = data.len();
-                let mut offset = 0;
-                while remaining > 0 {
-                    let mut frame = [0xffu8; 8];
-                    frame[0] = (seq << 5) | (index & 0x1f);
-                    let chunk;
-                    let payload_start;
-                    if index == 0 {
-                        frame[1] = data.len() as u8;
-                        chunk = remaining.min(6);
-                        payload_start = 2;
-                    } else {
-                        chunk = remaining.min(7);
-                        payload_start = 1;
-                    }
-                    frame[payload_start..payload_start + chunk]
-                        .copy_from_slice(&data[offset..offset + chunk]);
-                    self.tx_buf.push(can_id, &frame[..]);
-                    offset += chunk;
-                    remaining -= chunk;
-                    index = index.wrapping_add(1);
+                for frame in fastpacket::fragment(seq, data) {
+                    self.tx_buf.push(can_id, &frame);
                 }
             }
             if emit {

--- a/crates/canboat-io/src/fastpacket.rs
+++ b/crates/canboat-io/src/fastpacket.rs
@@ -64,7 +64,8 @@ pub fn packet_type(pgn: u32) -> FramePacketType {
 /// frames: every frame is exactly 8 bytes, byte 0 is
 /// `(seq << 5) | index`, frame 0 carries the total length in byte 1,
 /// and the last frame is padded with 0xff. The caller owns the
-/// per-(pgn, src) sequence counter. Mirrors the socketcan TX path.
+/// per-(pgn, src) sequence counter. Both TX paths — socketcan and the
+/// line gateways — fragment through here.
 pub fn fragment(seq: u8, data: &[u8]) -> Vec<[u8; 8]> {
     let mut out = Vec::with_capacity(data.len() / 7 + 1);
     let mut index: u8 = 0;

--- a/crates/canboat/tests/golden.rs
+++ b/crates/canboat/tests/golden.rs
@@ -26,19 +26,20 @@ use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
-/// Where the canboat C repo's `analyzer/tests/` lives, relative to
-/// this crate.
+/// Where `analyzer/tests/` lives, relative to this crate.
 ///
 /// Resolution order, first match wins:
 ///
 /// 1. `$CANBOAT_DIR` (when set) — explicit override for CI / local
-///    development against an in-flight branch.
-/// 2. `../canboat-*` — every sibling worktree (alphabetical, so a
-///    `canboat-fix-pk` worktree carrying staged schema changes is
-///    preferred over the main `canboat/` checkout while the PR is
-///    open). Skip non-directories and any entry whose
-///    `analyzer/tests/` doesn't exist.
-/// 3. `../canboat` — the default sibling clone.
+///    development against another checkout.
+/// 2. The repo this crate is part of (`../../analyzer/tests`) — the
+///    fixtures and the code under test come from the same tree. This
+///    must come before any sibling scan: a stale checkout next door
+///    (e.g. a leftover worktree on an old branch) would otherwise
+///    shadow the tree actually being tested.
+/// 3. `../canboat-*` sibling checkouts (alphabetical), then
+///    `../canboat` — legacy fallbacks from when the Rust crates lived
+///    outside the canboat repo; kept for out-of-tree builds.
 ///
 /// Returns `None` only when none of the above resolves — in that
 /// case `run_case_skipping` skips the test gracefully so users
@@ -51,6 +52,10 @@ fn canboat_tests_dir() -> Option<PathBuf> {
         }
     }
     let manifest: PathBuf = env!("CARGO_MANIFEST_DIR").into();
+    let own = manifest.parent()?.parent()?.join("analyzer").join("tests");
+    if own.is_dir() {
+        return Some(own);
+    }
     let github_root = manifest.parent()?.parent()?.parent()?; // …/github
     let mut worktree_candidates: Vec<PathBuf> = std::fs::read_dir(github_root)
         .ok()?


### PR DESCRIPTION
send_pgn still carried its own copy of the ISO 11783-3 chunking loop that #807 extracted into fastpacket::fragment for the line gateways — the helper was cut from this very loop, but the original was left in place to keep that PR reviewable. This routes the socketcan TX path through the helper too, so there is exactly one fragmenter.

The first commit pins the current wire bytes with unit tests before anything changes: single-frame PGNs go out verbatim (127508 at exactly 8 bytes), fast-packet PGNs get the 6+7*n split with 0xff tail padding, the shell is kept even for sub-8-byte payloads (126208 ACK case), and the per-(pgn,src) sequence counter advances between sends. The refactor commit then proves itself against them. The only behavioral difference is unreachable in practice: an empty payload on a fast-packet PGN now emits the bare header frame instead of nothing, which is the helper's convention.

The third commit fixes a test-harness trap this work exposed: golden.rs still used the split-repo fixture resolution order (scan ../canboat-* siblings first), so a stale checkout next door shadowed the fixtures of the tree actually under test and failed the golden suite with what looked like decoder regressions. The repo's own analyzer/tests now resolves first; $CANBOAT_DIR override and the sibling fallbacks stay for out-of-tree builds.

Tested: cargo test --workspace green (the new pinning tests pass against both the old loop and the refactor); A/B end-to-end on a vcan interface — master binary vs this branch, same stdin JSON (an ISO request and a 126208 command), byte-identical candump traces covering a single-frame TX, a 2-frame fast-packet, and the 20-frame 126996 Product Information burst.