### PR TITLE
fix(convert): keep the human PGN description in camelCase mode

### DIFF
--- a/crates/canboat-core/src/output/json.rs
+++ b/crates/canboat-core/src/output/json.rs
@@ -36,9 +36,14 @@ fn field_display_name(field: &DecodedField, mode: CamelCase) -> std::borrow::Cow
     }
 }
 
-/// Display description for a PGN. canboat uses `id` as the camelized
-/// form (e.g. `isoAddressClaim`), so the same id maps cleanly.
-fn pgn_display_description(pgn: &DecodedPgn, mode: CamelCase) -> std::borrow::Cow<'_, str> {
+/// Wrapper-object key for a record under `-camel` / `-upper-camel`.
+/// canboat uses `id` as the camelized form (e.g. `isoAddressClaim`,
+/// C: `pgn->camelDescription`). Only the wrapper key camelizes — the
+/// `description` field inside the record stays the human-readable
+/// string in every mode (see `analyzer/analyzer.c::printPgn`), and
+/// consumers rely on that: n2k-signalk's Seatalk mapper filters on
+/// `description === 'Seatalk: Pilot Heading'`.
+fn pgn_wrapper_key(pgn: &DecodedPgn, mode: CamelCase) -> std::borrow::Cow<'_, str> {
     use std::borrow::Cow;
     match mode {
         CamelCase::Off => Cow::Borrowed(pgn.description),
@@ -119,7 +124,7 @@ pub fn write_json<W: fmt::Write>(w: &mut W, pgn: &DecodedPgn, opts: &JsonOptions
     if wrap {
         w.write_char('{')?;
         w.write_str("\"")?;
-        w.write_str(pgn_display_description(pgn, opts.camel_case).as_ref())?;
+        w.write_str(pgn_wrapper_key(pgn, opts.camel_case).as_ref())?;
         w.write_str("\":")?;
     }
     w.write_char('{')?;
@@ -134,7 +139,7 @@ pub fn write_json<W: fmt::Write>(w: &mut W, pgn: &DecodedPgn, opts: &JsonOptions
         pgn.prio, pgn.src, pgn.dst, pgn.pgn
     )?;
     w.write_str(",\"description\":")?;
-    write_json_string(w, pgn_display_description(pgn, opts.camel_case).as_ref())?;
+    write_json_string(w, pgn.description)?;
 
     // Build the body of the `fields` object into a buffer so we can
     // skip the wrapping `,"fields":{ ... }` entirely when no field
@@ -1029,6 +1034,27 @@ mod tests {
         assert_eq!(
             out,
             r#"{"timestamp":"2018-10-16T22:25:25.166Z","prio":3,"src":35,"dst":255,"pgn":128267,"description":"Water Depth","fields":{"Offset":0.000}}"#
+        );
+    }
+
+    #[test]
+    fn camel_mode_keeps_the_human_description() {
+        // canboat C camelizes only the wrapper key and the field names;
+        // the description field stays human-readable in every mode
+        // (analyzer.c uses pgn->camelDescription for the key and
+        // pgn->description for the field). n2k-signalk's Seatalk
+        // mapper matches on the human string, so this is contract,
+        // not cosmetics.
+        let pgn = sample_pgn();
+        let mut out = String::new();
+        let opts = JsonOptions {
+            camel_case: CamelCase::Lower,
+            ..JsonOptions::default()
+        };
+        write_json(&mut out, &pgn, &opts).unwrap();
+        assert_eq!(
+            out,
+            r#"{"waterDepth":{"timestamp":"2018-10-16T22:25:25.166Z","prio":3,"src":35,"dst":255,"pgn":128267,"description":"Water Depth","fields":{"offset":0.000}}}"#
         );
     }
 


### PR DESCRIPTION
The C analyzer camelizes only the wrapper key and the field names under -camel / -upper-camel; the description field inside the record is always pgn->description, the human-readable string (analyzer.c uses pgn->camelDescription for the key and pgn->description for the field). The Rust writer emitted the camel id in both places.

That divergence is not cosmetic. n2k-signalk's Seatalk mapper filters records on description === 'Seatalk: Pilot Heading', so a pipeline running the Rust analyzer silently dropped the pilot-heading delta that the C pipeline produced — this was the one-PGN parity gap I had been carrying between the two analyzers. The fix camelizes only the wrapper key (the helper is renamed pgn_wrapper_key to say exactly that) and pins the contract with a regression test, since no existing test covered it — which is how the drift went unnoticed.

Tested: cargo test --workspace green including the new pinned-output test; single-record output for the Seatalk 65359 case is now byte-identical to the C analyzer in -json -si -camel -nv mode; over a 7595-frame live NMEA 2000 capture the description-field multiset now matches the C analyzer exactly (the only remaining record-count difference is three Maretron Alert Text fast-packets the C analyzer fails to decode at all); a Signal K delta-parity harness over the canboatjs test corpus went from 82/91 to 83/91 — equal to the C analyzer, with the restored case being exactly Seatalk 65359.