### PR TITLE
feat(canboat): wasm32 support — target fixes and the JSON input driver as a library feature

### DIFF
--- a/crates/canboat-core/src/format/ydwg02.rs
+++ b/crates/canboat-core/src/format/ydwg02.rs
@@ -97,6 +97,7 @@ pub fn parse_line(line: &str) -> Result<RawFrame, ParseError> {
 /// environment freezes time). Mirrors canboat's `parseRawFormatYDWG02`
 /// which does `localtime_r + strftime("%Y-%m-%dT")` then appends the
 /// parsed time-of-day verbatim.
+#[cfg(not(target_arch = "wasm32"))]
 fn synth_iso_timestamp(time: &str) -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
     let secs = SystemTime::now()
@@ -110,6 +111,15 @@ fn synth_iso_timestamp(time: &str) -> String {
     let days = secs.div_euclid(86_400);
     let (y, m, d) = days_to_ymd(days);
     format!("{y:04}-{m:02}-{d:02}T{time}")
+}
+
+/// wasm32-unknown-unknown has no host clock — `SystemTime::now()`
+/// PANICS there rather than erroring. Keep the `<date>T<time>` shape
+/// every consumer expects and degrade only the date to the epoch, the
+/// same result the native path produces when the clock reads as 0.
+#[cfg(target_arch = "wasm32")]
+fn synth_iso_timestamp(time: &str) -> String {
+    format!("1970-01-01T{time}")
 }
 
 #[cfg(test)]

--- a/crates/canboat-core/src/os.rs
+++ b/crates/canboat-core/src/os.rs
@@ -50,6 +50,18 @@ fn machine_string() -> Option<String> {
     Some(line[start..end].to_string())
 }
 
+// Targets without an OS machine identifier (wasm32, BSDs, …): no
+// fingerprint. get_machine_id() then hashes just the salt — stable,
+// but IDENTICAL on every host. That is fine for the wasm bindings
+// (pure decode/encode, no bus identity), but a bus-facing consumer on
+// such a target must supply an explicit unique number for its ISO
+// NAME instead of relying on this value, or two hosts on one bus
+// would claim with colliding NAMEs.
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+fn machine_string() -> Option<String> {
+    None
+}
+
 #[cfg(target_os = "windows")]
 fn machine_string() -> Option<String> {
     // Shell out to `reg query` to stay dependency-free.

--- a/crates/canboat/Cargo.toml
+++ b/crates/canboat/Cargo.toml
@@ -41,8 +41,13 @@ ais      = ["decode"]                      # output::write_ais
 # ── the CLI (not part of the public library surface) ──
 # `canboat-bridge` hosts the server/n2kd subcommand implementations (lifted out
 # of this crate); the CLI dispatches into it.
+# JSON record -> wire frame driver (`convert --from json`, gateway stdin
+# TX, and the wasm bindings). A real JSON parser is warranted here, so it
+# pulls serde_json — kept out of the default library surface.
+json-input = ["decode", "dep:serde_json", "dep:anyhow", "dep:chrono"]
+
 cli = [
-    "decode", "io", "bridge", "nmea0183", "ais",
+    "decode", "io", "bridge", "nmea0183", "ais", "json-input",
     "canboat-bridge/cli",
     "dep:canboat-cli", "dep:clap", "dep:env_logger", "dep:anyhow",
     "dep:serde", "dep:serde_json", "dep:tokio", "dep:crossterm",

--- a/crates/canboat/src/convert.rs
+++ b/crates/canboat/src/convert.rs
@@ -309,7 +309,7 @@ fn convert_raw<W: Write>(
         } else {
             canboat_core::Units::Metric
         };
-        Box::new(crate::json_input::JsonFrameReader::new(
+        Box::new(canboat::json_input::JsonFrameReader::new(
             source,
             canboat_core::PgnDatabase::embedded(units),
         ))
@@ -410,7 +410,7 @@ fn convert_decoded<W: Write>(
         let mut reader: Box<dyn FrameReader> = if ebl {
             Box::new(EblReader::new(source))
         } else {
-            Box::new(crate::json_input::JsonFrameReader::new(source, db))
+            Box::new(canboat::json_input::JsonFrameReader::new(source, db))
         };
         let mut sink = sink;
         while let Some(frame) = reader.read_frame().context("reading input")? {

--- a/crates/canboat/src/interface.rs
+++ b/crates/canboat/src/interface.rs
@@ -217,7 +217,7 @@ fn pump_stdin(sender: &mut device::FrameSender) -> io::Result<()> {
             continue;
         }
         if t.starts_with('{') {
-            match crate::json_input::frame_from_json(db, t) {
+            match canboat::json_input::frame_from_json(db, t) {
                 Ok(Some(frame)) => sender.write_frame(&frame)?,
                 Ok(None) => {}
                 Err(e) => log::warn!("stdin json: {e:#}"),

--- a/crates/canboat/src/json_input.rs
+++ b/crates/canboat/src/json_input.rs
@@ -60,6 +60,7 @@ pub struct JsonFrameReader<R> {
 }
 
 impl<R: BufRead> JsonFrameReader<R> {
+    /// Read analyzer-JSON lines from `src`, encoding against `db`.
     pub fn new(src: R, db: &'static PgnDatabase) -> Self {
         Self {
             src,

--- a/crates/canboat/src/lib.rs
+++ b/crates/canboat/src/lib.rs
@@ -382,6 +382,15 @@ pub mod bridge {
     pub use canboat_bridge::server::{Bridge, BridgeConfig, QuirkKind as Quirk, Transmitter};
 }
 
+// ───────────────────────────── json input ────────────────────────────────
+
+/// Analyzer/canboatjs JSON records → wire frames (`convert --from json`,
+/// the gateway bridges' stdin TX, and the wasm bindings). Behind its own
+/// feature because it is the one place a real JSON parser (serde_json)
+/// is warranted.
+#[cfg(feature = "json-input")]
+pub mod json_input;
+
 // ─────────────────────────────── prelude ─────────────────────────────────
 
 /// The 90% path in one glob import: `use canboat::prelude::*;`.

--- a/crates/canboat/src/main.rs
+++ b/crates/canboat/src/main.rs
@@ -24,7 +24,6 @@ use clap::{Parser, Subcommand};
 mod convert;
 mod format_message;
 mod interface;
-mod json_input;
 mod legacy;
 mod replay;
 mod tui;


### PR DESCRIPTION
Two prerequisites for canboat/canboat-wasm, which compiles this codebase to WebAssembly as the npm-facing decode/encode package.

The first commit makes the tree build and run on wasm32 (and other non-linux/macos/windows targets): machine_string() gains a no-fingerprint fallback arm — with a comment spelling out that bus-facing consumers on such targets must supply an explicit ISO NAME unique number rather than rely on the now-identical machine id — and ydwg02's timestamp synthesis no longer calls SystemTime::now(), which panics on wasm32-unknown-unknown rather than erroring; it keeps the <date>T<time> shape and degrades only the date to the epoch, exactly what the native path produces when the clock reads as zero, so the existing format contract and tests hold on every target.

The second commit moves the JSON input driver (frame_from_json / JsonFrameReader) from the binary into the library behind a new json-input feature carrying its serde_json/anyhow/chrono dependencies. The cli feature folds it in, so the binary is unchanged; library consumers — the wasm bindings, or any embedder wanting JSON-record TX — can now reach the canboatjs-dialect JSON-to-frame driver without the CLI.

Tested: cargo test --workspace green (26 suites) plus make rust-precommit; cargo check --target wasm32-unknown-unknown clean for canboat-core and for canboat with json-input; downstream, canboat/canboat-wasm builds against these commits and its wasm output is RX byte-identical to the native binary across a 7595-record live capture, TX-identical on the shared corpus, and equal to the analyzer baseline in Signal K delta parity.