### PR TITLE
feat(json)!: default decoded output to camelCase ids and SI units

### DIFF
--- a/crates/canboat-bridge/src/n2kd/app.rs
+++ b/crates/canboat-bridge/src/n2kd/app.rs
@@ -425,14 +425,18 @@ fn run_stdin_pump(hub: &Hub) -> Result<()> {
             continue;
         }
         // canboat C aborts here unless the first line was the banner; we
-        // are lenient (a bannerless stream is assumed Metric), but warn
-        // once so a misconfigured producer is visible. `-si` streams
-        // *must* carry the banner or their radians decode as degrees.
+        // are lenient (a bannerless stream is assumed Metric, matching
+        // canboat C's default), but warn once so a misconfigured
+        // producer is visible. An SI stream *must* carry the banner or
+        // its radians decode as degrees — and SI is now what `analyzer`
+        // emits by default, so a bannerless producer (`canboat convert`
+        // writes no banner) is more likely to be mismatched than before.
         if !saw_banner && !warned_no_banner {
             log::warn!(
                 "input has no analyzer version banner; assuming Metric units. \
-                 Pipe from `analyzer -json -nv` (add `-si` for SI units) so the \
-                 unit system is declared."
+                 Pipe from `analyzer --json --nv` (which declares its unit \
+                 system, SI unless you pass `--units metric`), or make the \
+                 producer emit Metric."
             );
             warned_no_banner = true;
         }

--- a/crates/canboat-bridge/src/server/bridge.rs
+++ b/crates/canboat-bridge/src/server/bridge.rs
@@ -137,20 +137,9 @@ impl Bridge {
         // The schema is compiled into the binary; no JSON loading, no
         // path discovery, no synthetic-PGN merge — `canboat-core/build.rs`
         // already folded `data/synthetic-pgns.json` into the static tables.
-        let units = if config.si {
-            canboat_core::Units::Si
-        } else {
-            canboat_core::Units::Metric
-        };
+        let units = config.units;
         let db = PgnDatabase::embedded(units);
 
-        let camel_case = if config.upper_camel {
-            canboat_core::output::CamelCase::Upper
-        } else if config.camel {
-            canboat_core::output::CamelCase::Lower
-        } else {
-            canboat_core::output::CamelCase::Off
-        };
         // JsonOptions mirror the pipeline's per-record serializer settings
         // so per-iteration snapshot lines (PGN 130824 etc.) come out
         // byte-identical to the regular `analyzer` port stream.
@@ -158,12 +147,8 @@ impl Bridge {
             include_empty: false,
             name_value: true,
             debug: false,
-            camel_case,
-            // `server` still spells this canboat C's way: `--camel` /
-            // `--upper-camel` both mean "camelCase keys *and* wrap each
-            // record under its PGN id". `convert` / `analyzer` have
-            // since split the two into `--id` and `--wrap`.
-            wrap: config.camel || config.upper_camel,
+            camel_case: config.camel_case,
+            wrap: config.wrap,
         };
 
         // The analyzer version banner (version, commit, units,
@@ -175,7 +160,10 @@ impl Bridge {
         let banner: &'static [u8] = Box::leak(
             format!(
                 "{}\n",
-                crate::build_info::version_banner(config.si, json_opts.name_value)
+                crate::build_info::version_banner(
+                    units == canboat_core::Units::Si,
+                    json_opts.name_value,
+                )
             )
             .into_bytes()
             .into_boxed_slice(),

--- a/crates/canboat-bridge/src/server/bridge.rs
+++ b/crates/canboat-bridge/src/server/bridge.rs
@@ -159,6 +159,11 @@ impl Bridge {
             name_value: true,
             debug: false,
             camel_case,
+            // `server` still spells this canboat C's way: `--camel` /
+            // `--upper-camel` both mean "camelCase keys *and* wrap each
+            // record under its PGN id". `convert` / `analyzer` have
+            // since split the two into `--id` and `--wrap`.
+            wrap: config.camel || config.upper_camel,
         };
 
         // The analyzer version banner (version, commit, units,

--- a/crates/canboat-bridge/src/server/mod.rs
+++ b/crates/canboat-bridge/src/server/mod.rs
@@ -308,25 +308,13 @@ pub struct Args {
     #[arg(long, default_value_t = 2606)]
     overrides_port: u16,
 
-    /// Emit field keys + PGN descriptions as camelCase
-    /// identifiers (`"uniqueNumber"` instead of `"Unique Number"`)
-    /// on the analyzer JSON / snapshot TCP ports. Matches canboat
-    /// C's `-camel`.
-    #[arg(long, conflicts_with = "upper_camel")]
-    camel: bool,
-
-    /// Same as `--camel` but UpperCamelCase (`"UniqueNumber"`).
-    /// Matches canboat C's `-upper-camel`.
-    #[arg(long = "upper-camel")]
-    upper_camel: bool,
-
-    /// Decode numeric fields into strict SI base units (`rad`, `K`,
-    /// `Pa`, …) instead of canboat's humanized Metric (`deg`, `°C`,
-    /// `bar`, …) on the analyzer JSON / snapshot TCP ports. Matches
-    /// canboat C's `-si`. Orthogonal to `--camel`. NMEA 0183 / AIS
-    /// output is unaffected — those always emit their spec units.
-    #[arg(long)]
-    si: bool,
+    /// Shape of the records on the analyzer JSON / snapshot TCP ports:
+    /// identifier spelling (`--id`), unit system (`--units`) and record
+    /// wrapping (`--wrap`), plus their deprecated canboat C spellings.
+    /// Defaults to flat camelCase records in SI. NMEA 0183 / AIS output
+    /// is unaffected — those always emit their spec units.
+    #[command(flatten)]
+    shape: canboat_cli::ShapeArgs,
 
     /// Verbose logging.
     #[arg(short = 'v', long)]
@@ -380,9 +368,17 @@ pub struct BridgeConfig {
     pub config_dir: Option<PathBuf>,
     pub nmea0183_filter_port: u16,
     pub overrides_port: u16,
-    pub camel: bool,
-    pub upper_camel: bool,
-    pub si: bool,
+    /// How field keys and PGN descriptions are spelled on the analyzer
+    /// JSON / snapshot ports (`--id`). Defaults to
+    /// [`CamelCase::Lower`](canboat_core::output::CamelCase::Lower).
+    pub camel_case: canboat_core::output::CamelCase,
+    /// Unit system those ports decode into (`--units`). Defaults to
+    /// [`Units::Si`](canboat_core::Units::Si). NMEA 0183 / AIS output is
+    /// unaffected — those always emit their spec units.
+    pub units: canboat_core::Units,
+    /// Nest each JSON record in `{"<pgnId>":{…}}` (`--wrap`). Off by
+    /// default; canboat C ties this to `-camel`, we don't.
+    pub wrap: bool,
     pub verbose: bool,
     pub quiet: bool,
 }
@@ -418,12 +414,24 @@ impl Default for BridgeConfig {
             config_dir: None,
             nmea0183_filter_port: 2605,
             overrides_port: 2606,
-            camel: false,
-            upper_camel: false,
-            si: false,
+            // Machine-facing defaults, matching `convert` / `analyzer`
+            // and what canboatjs consumers expect.
+            camel_case: canboat_core::output::CamelCase::Lower,
+            units: canboat_core::Units::Si,
+            wrap: false,
             verbose: false,
             quiet: false,
         }
+    }
+}
+
+#[cfg(feature = "cli")]
+impl Args {
+    /// Nudge users off canboat C's `--camel` / `--upper-camel` / `--si`
+    /// spellings. The host binary calls this before converting to a
+    /// [`BridgeConfig`], which only carries the resolved shape.
+    pub fn warn_deprecated(&self) {
+        self.shape.warn_deprecated();
     }
 }
 
@@ -461,9 +469,9 @@ impl From<Args> for BridgeConfig {
             config_dir: a.config_dir,
             nmea0183_filter_port: a.nmea0183_filter_port,
             overrides_port: a.overrides_port,
-            camel: a.camel,
-            upper_camel: a.upper_camel,
-            si: a.si,
+            camel_case: a.shape.camel_case(),
+            units: a.shape.units(),
+            wrap: a.shape.wrap(),
             verbose: a.verbose,
             quiet: a.quiet,
         }

--- a/crates/canboat-bridge/src/server/pipeline.rs
+++ b/crates/canboat-bridge/src/server/pipeline.rs
@@ -572,6 +572,7 @@ mod tests {
                     name_value: true,
                     debug: false,
                     camel_case: canboat_core::output::CamelCase::Off,
+                    wrap: false,
                 },
                 Nmea0183Options {
                     emit_stdout: false,

--- a/crates/canboat-bridge/src/server/tcp.rs
+++ b/crates/canboat-bridge/src/server/tcp.rs
@@ -548,6 +548,7 @@ mod tests {
             name_value: true,
             debug: false,
             camel_case: CamelCase::Off,
+            wrap: false,
         };
         let filter = Mutex::new(filter);
         let out = filter_report_lines(&filter, db, &json_opts);

--- a/crates/canboat-cli/src/lib.rs
+++ b/crates/canboat-cli/src/lib.rs
@@ -2,16 +2,23 @@
 
 //! Shared CLI plumbing for the canboat-rs binaries.
 //!
-//! At the moment the only thing here is [`canboat_argv`], an argv
-//! pre-processor that lets clap accept canboat's single-dash long
-//! options (`-json`, `-rx`, `-fixtime`, …). canboat's C tools use
-//! that form throughout; clap defaults to requiring a double-dash
-//! for any option longer than one character. Each binary calls
-//! `canboat_argv()` to normalise its own argv before handing it to
-//! `Cli::parse_from`.
+//! [`canboat_argv`] is an argv pre-processor that lets clap accept
+//! canboat's single-dash long options (`-json`, `-rx`, `-fixtime`, …).
+//! canboat's C tools use that form throughout; clap defaults to
+//! requiring a double-dash for any option longer than one character.
+//! Each binary calls `canboat_argv()` to normalise its own argv before
+//! handing it to `Cli::parse_from`.
+//!
+//! [`shape`] holds the decoded-output flags every binary that emits
+//! analyzer JSON shares — `--id`, `--units`, `--wrap` — so `convert`,
+//! the `analyzer` shim and `server` can't drift apart.
 
 use std::env;
 use std::ffi::OsString;
+
+pub mod shape;
+
+pub use shape::{IdStyle, ShapeArgs, UnitSystem};
 
 /// The canboat copyright line and schema version, extracted from
 /// `crates/canboat-core/data/canboat.json` at build time by

--- a/crates/canboat-cli/src/shape.rs
+++ b/crates/canboat-cli/src/shape.rs
@@ -1,13 +1,14 @@
 // (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
 
-//! Shared decoded-output shape flags for `canboat convert` and the
-//! `analyzer` shim.
+//! Shared decoded-output shape flags for every canboat binary that
+//! emits analyzer JSON: `canboat convert`, the `analyzer` shim and
+//! `canboat server`.
 //!
-//! Both CLIs decide three orthogonal things about a decoded record: how
+//! Each decides three orthogonal things about a decoded record: how
 //! field keys and PGN descriptions are spelled (`--id`), which unit
 //! system numeric fields are decoded into (`--units`), and whether the
 //! record is nested under its PGN id (`--wrap`). They are declared once
-//! here and `#[command(flatten)]`ed into both parsers so the two can't
+//! here and `#[command(flatten)]`ed into each parser so they can't
 //! drift.
 //!
 //! **The defaults are camelCase identifiers, strict SI units and no

--- a/crates/canboat-core/src/analyzer_json.rs
+++ b/crates/canboat-core/src/analyzer_json.rs
@@ -29,6 +29,54 @@ pub(crate) fn camel_wrapper_id(line: &str) -> Option<&str> {
     }
 }
 
+/// Top-level keys every analyzer record carries. A field whose `id` or
+/// `name` collides with one of these can't tell us anything about the
+/// record's key style, so [`uses_camel_keys`] skips it.
+const RECORD_KEYS: [&str; 7] = [
+    "timestamp",
+    "prio",
+    "src",
+    "dst",
+    "pgn",
+    "description",
+    "fields",
+];
+
+/// True when `msg` contains `"<field>":` as an object key.
+/// Allocation-free, unlike the `format!`-based scan in [`value`] — this
+/// runs per record on the n2kd hot path.
+pub(crate) fn has_key(msg: &str, field: &str) -> bool {
+    msg.match_indices(field).any(|(i, _)| {
+        i > 0 && msg.as_bytes()[i - 1] == b'"' && msg[i + field.len()..].starts_with("\":")
+    })
+}
+
+/// Whether a record keys its fields by camelCase `id` rather than human
+/// `name`.
+///
+/// canboat C ties camelCase keys to the `{"<pgnId>":{…}}` wrapper, so
+/// [`camel_wrapper_id`] alone used to answer this. The Rust binaries
+/// default to camelCase keys on an *unwrapped* record (`--id camel`
+/// without `--wrap`), so an unwrapped line has to be sniffed: the first
+/// field whose `id` or `name` shows up as a key decides.
+pub(crate) fn uses_camel_keys(line: &str, fields: &[crate::types::FieldInfo]) -> bool {
+    for fi in fields {
+        // `id == name` (e.g. all-lowercase one-word names) is
+        // indistinguishable, and a field called `pgn` or `src` would
+        // match the record's own keys in either style.
+        if fi.id == fi.name || RECORD_KEYS.contains(&fi.id) || RECORD_KEYS.contains(&fi.name) {
+            continue;
+        }
+        if has_key(line, fi.id) {
+            return true;
+        }
+        if has_key(line, fi.name) {
+            return false;
+        }
+    }
+    false
+}
+
 /// Pull `"<field>":<value>` out of `msg`. Returns the value as a
 /// borrowed slice with any surrounding quotes stripped. Skips
 /// whitespace between `:` and the value. Returns `None` if the

--- a/crates/canboat-core/src/db.rs
+++ b/crates/canboat-core/src/db.rs
@@ -55,12 +55,15 @@ pub struct PgnDatabase {
 #[non_exhaustive]
 pub enum Units {
     /// Strict SI base units: `rad`, `K`, `Pa`, `C` (coulomb). What a
-    /// physics-facing consumer (Signal K, control code) wants. Matches
-    /// canboat C's `analyzer -si`.
+    /// physics-facing consumer (Signal K, control code) wants — and
+    /// therefore **the default**. Matches `--units si` (canboat C's
+    /// `analyzer -si`).
+    #[default]
     Si,
     /// canboat's practical humanized units: `deg`, `°C`, `bar`, `Ah`.
-    /// The default, matching canboat C's `analyzer` without `-si`.
-    #[default]
+    /// What a human reads; matches `--units metric`, i.e. canboat C's
+    /// `analyzer` without `-si`. Was the default before the Rust
+    /// binaries standardised on SI.
     Metric,
 }
 

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -2472,7 +2472,7 @@ mod tests {
         )
         .unwrap();
         assert!(
-            json.contains(r#""Mode":[{"value":2,"name":null},{"value":8,"name":"Standby"}]"#),
+            json.contains(r#""mode":[{"value":2,"name":null},{"value":8,"name":"Standby"}]"#),
             "got: {json}"
         );
     }
@@ -2573,7 +2573,12 @@ mod tests {
         let dec = db().decode(&frame).expect("decode");
         let mut json = String::new();
         crate::output::write_json(&mut json, &dec, &crate::output::JsonOptions::default()).unwrap();
-        assert!(!json.contains("Reserved"), "got: {json}");
+        // Default output is camelCase, so match the key case-insensitively
+        // — `"Reserved"` alone would pass even if the field were emitted.
+        assert!(
+            !json.to_ascii_lowercase().contains("reserved"),
+            "got: {json}"
+        );
     }
 
     #[test]

--- a/crates/canboat-core/src/from_json.rs
+++ b/crates/canboat-core/src/from_json.rs
@@ -34,19 +34,20 @@ use crate::types::{FieldInfo, FieldType};
 /// `None` if the line has no `pgn`, the PGN is unknown, or it isn't the
 /// object we expect.
 pub fn json_to_decoded(line: &str, db: &PgnDatabase) -> Option<DecodedPgn> {
-    // `-camel` output wraps the record in `{"<pgnId>":{…}}` and keys
-    // fields by their camelCase `id`; bare `-json` is unwrapped and
-    // keys by human `name`. Detect once so the rest of the reconstruction
-    // uses the matching key and, for camel, the exact variant.
+    // A wrapped record — canboat C's `-camel`, the Rust binaries'
+    // `--wrap` — nests everything under `{"<pgnId>":{…}}`, and the
+    // wrapper id names one exact variant of `pgn`.
     let camel_id = json::camel_wrapper_id(line);
-    let use_camel = camel_id.is_some();
     let pgn = json::int(line, "pgn")? as u32;
     let info = match camel_id {
-        // The wrapper id names one exact variant of `pgn`; fall back to
-        // the PGN number if this schema doesn't know that id.
+        // Fall back to the PGN number if this schema doesn't know that id.
         Some(id) => db.pgn_by_id(id).or_else(|| db.first_pgn(pgn))?,
         None => db.first_pgn(pgn)?,
     };
+    // Field keys are camelCase `id`s or human `name`s. The wrapper
+    // implies camel; an unwrapped record can be either (camelCase
+    // unwrapped is the current default), so sniff its field keys.
+    let use_camel = camel_id.is_some() || json::uses_camel_keys(line, info.fields);
 
     let src = json::int(line, "src").unwrap_or(0) as u8;
     let dst = json::int(line, "dst").unwrap_or(255) as u8;
@@ -238,6 +239,43 @@ mod tests {
             json::camel_wrapper_id(r#"{"windData":{"pgn":130306}}"#),
             Some("windData")
         );
+    }
+
+    /// The default output shape: camelCase keys, no wrapper. There is
+    /// no wrapper id to key off, so the reader has to sniff the field
+    /// keys — before it did, every field silently dropped out.
+    #[test]
+    fn flat_camel_record_decodes() {
+        let db = crate::PgnDatabase::embedded(Units::Si);
+        let line = r#"{"prio":2,"src":7,"dst":255,"pgn":130306,"description":"Wind Data","fields":{"windSpeed":5.0,"windAngle":1.2,"reference":{"value":2,"name":"Apparent"}}}"#;
+        let d = json_to_decoded(line, db).expect("flat camel decodes");
+        assert_eq!(d.pgn, 130306);
+        assert_eq!(field_f64(&d, "windSpeed"), Some(5.0));
+        assert_eq!(field_f64(&d, "windAngle"), Some(1.2));
+        let reference = d
+            .fields
+            .iter()
+            .find(|f| f.info.id == "reference")
+            .expect("reference field");
+        assert!(
+            matches!(reference.value, FieldValue::Lookup { value: 2, .. }),
+            "got: {:?}",
+            reference.value
+        );
+    }
+
+    #[test]
+    fn key_style_sniffing() {
+        let info = crate::PgnDatabase::embedded(Units::Si)
+            .first_pgn(130306)
+            .expect("PGN 130306 present");
+        let camel = r#"{"pgn":130306,"fields":{"windSpeed":5.0,"windAngle":1.2}}"#;
+        let bare = r#"{"pgn":130306,"fields":{"Wind Speed":5.0,"Wind Angle":1.2}}"#;
+        assert!(json::uses_camel_keys(camel, info.fields));
+        assert!(!json::uses_camel_keys(bare, info.fields));
+        // Nothing to go on (no fields emitted) → assume human names,
+        // which is what the pre-existing readers did.
+        assert!(!json::uses_camel_keys(r#"{"pgn":130306}"#, info.fields));
     }
 
     #[test]

--- a/crates/canboat-core/src/output/json.rs
+++ b/crates/canboat-core/src/output/json.rs
@@ -6,12 +6,14 @@
 //!
 //! ```json
 //! {"timestamp":"...","prio":N,"src":N,"dst":N,"pgn":N,
-//!  "description":"...","fields":{"Name":Value,"Name":Value,...}}
+//!  "description":"...","fields":{"id":Value,"id":Value,...}}
 //! ```
 //!
-//! Compact (no whitespace), keys in canboat order. Field names use the
-//! human-readable `Name` from canboat.json by default. The output is
-//! written without a trailing newline.
+//! Compact (no whitespace), keys in canboat order. Field keys are the
+//! camelCase `Id` from canboat.json by default ([`CamelCase::Lower`]);
+//! [`CamelCase::Off`] switches them to the human-readable `Name`, which
+//! is what canboat C prints. The output is written without a trailing
+//! newline.
 //!
 //! JSON is hand-emitted rather than constructed via serde_json so the
 //! output bytes match canboat exactly (number formatting, key order,
@@ -36,7 +38,8 @@ fn field_display_name(field: &DecodedField, mode: CamelCase) -> std::borrow::Cow
     }
 }
 
-/// Wrapper-object key for a record under `-camel` / `-upper-camel`.
+/// Wrapper-object key for a record under `--wrap`, spelled per
+/// [`JsonOptions::camel_case`].
 /// canboat uses `id` as the camelized form (e.g. `isoAddressClaim`,
 /// C: `pgn->camelDescription`). Only the wrapper key camelizes — the
 /// `description` field inside the record stays the human-readable
@@ -77,12 +80,19 @@ pub struct JsonOptions {
     pub debug: bool,
     /// Emit field keys + PGN descriptions as camelCase or
     /// UpperCamelCase identifiers instead of canboat's human-
-    /// readable form. Matches canboat C's `-camel` / `-upper-camel`
-    /// flags. See [`CamelCase`].
+    /// readable form. Defaults to [`CamelCase::Lower`] — the shape
+    /// JSON consumers want, and what the binaries emit unless
+    /// `--id spaces` asks otherwise.
     pub camel_case: CamelCase,
+    /// Nest each record in `{"<pgnKey>":{…}}` instead of emitting it
+    /// flat (matches canboat C's `-camel` wrapping, here its own
+    /// `--wrap` flag). Off by default: the flat record is what
+    /// canboatjs and the Signal K stack consume.
+    pub wrap: bool,
 }
 
-/// Identifier style selector for `-camel` / `-upper-camel`.
+/// Identifier style selector for `--id` (canboat C's `-camel` /
+/// `-upper-camel`).
 ///
 /// canboat C builds these by stripping spaces/punctuation from
 /// `"Unique Number"` → `"uniqueNumber"` (camelCase) or
@@ -92,12 +102,13 @@ pub struct JsonOptions {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum CamelCase {
     /// Use human-readable names (`"Unique Number"`, `"ISO Address
-    /// Claim"`). Default; matches canboat C's default output.
-    #[default]
+    /// Claim"`). `--id spaces`; matches canboat C's default output.
     Off,
-    /// lowerCamelCase identifiers (`"uniqueNumber"`).
+    /// lowerCamelCase identifiers (`"uniqueNumber"`). **The default**
+    /// (`--id camel`).
+    #[default]
     Lower,
-    /// UpperCamelCase identifiers (`"UniqueNumber"`).
+    /// UpperCamelCase identifiers (`"UniqueNumber"`). `--id uppercamel`.
     Upper,
 }
 
@@ -113,14 +124,19 @@ thread_local! {
 }
 
 pub fn write_json<W: fmt::Write>(w: &mut W, pgn: &DecodedPgn, opts: &JsonOptions) -> fmt::Result {
-    // In camelCase mode (`-camel` / `-upper-camel`) every record is
-    // wrapped in `{"<camelId>":{...}}`, keyed on the PGN's camelCase
-    // identifier; the trailing `}` is balanced after the body closes.
-    // Plain `-json` never wraps. canboat C originally keyed this on the
-    // presence of a pinned `camelDescription` (so PGN 130846 wrapped
-    // even in plain `-json`); canboat#746 corrected it to key on the
-    // `-camel` flag instead. See `analyzer/analyzer.c::printPgn`.
-    let wrap = opts.camel_case != CamelCase::Off;
+    // Under [`JsonOptions::wrap`] every record is nested in
+    // `{"<pgnKey>":{...}}`, keyed on the PGN's identifier (spelled per
+    // [`JsonOptions::camel_case`]); the trailing `}` is balanced after
+    // the body closes.
+    //
+    // canboat C ties this to `-camel`: camelCase output always wraps.
+    // (It originally keyed on a pinned `camelDescription`, so PGN
+    // 130846 wrapped even in plain `-json`; canboat#746 changed it to
+    // the `-camel` flag. See `analyzer/analyzer.c::printPgn`.) The Rust
+    // binaries decouple the two — camelCase keys are the default and
+    // wrapping is not, which is the flat shape canboatjs emits — so
+    // `--id` and `--wrap` are independent here.
+    let wrap = opts.wrap;
     if wrap {
         w.write_char('{')?;
         w.write_str("\"")?;
@@ -1025,12 +1041,31 @@ mod tests {
     }
 
     #[test]
-    fn matches_canboat_json_shape() {
+    fn default_shape_is_flat_camel_case() {
+        // The default: camelCase field keys, no record wrapper — the
+        // shape canboatjs emits and the Signal K stack consumes.
         let pgn = sample_pgn();
         let mut out = String::new();
         write_json(&mut out, &pgn, &JsonOptions::default()).unwrap();
         // The sample timestamp lacks a trailing `Z`; the formatter
         // canonicalises it to ISO-8601 UTC on emit.
+        assert_eq!(
+            out,
+            r#"{"timestamp":"2018-10-16T22:25:25.166Z","prio":3,"src":35,"dst":255,"pgn":128267,"description":"Water Depth","fields":{"offset":0.000}}"#
+        );
+    }
+
+    #[test]
+    fn matches_canboat_json_shape() {
+        // `--id spaces`: canboat C's own output, spaced field names and
+        // no wrapper.
+        let pgn = sample_pgn();
+        let mut out = String::new();
+        let opts = JsonOptions {
+            camel_case: CamelCase::Off,
+            ..JsonOptions::default()
+        };
+        write_json(&mut out, &pgn, &opts).unwrap();
         assert_eq!(
             out,
             r#"{"timestamp":"2018-10-16T22:25:25.166Z","prio":3,"src":35,"dst":255,"pgn":128267,"description":"Water Depth","fields":{"Offset":0.000}}"#
@@ -1049,12 +1084,34 @@ mod tests {
         let mut out = String::new();
         let opts = JsonOptions {
             camel_case: CamelCase::Lower,
+            wrap: true,
             ..JsonOptions::default()
         };
         write_json(&mut out, &pgn, &opts).unwrap();
         assert_eq!(
             out,
             r#"{"waterDepth":{"timestamp":"2018-10-16T22:25:25.166Z","prio":3,"src":35,"dst":255,"pgn":128267,"description":"Water Depth","fields":{"offset":0.000}}}"#
+        );
+    }
+
+    #[test]
+    fn wrapping_is_independent_of_identifier_style() {
+        // canboat C ties the wrapper to `-camel`; here `--wrap` and
+        // `--id` are orthogonal, so a wrapped record can carry spaced
+        // names — and then the wrapper key is the human description,
+        // exactly as `pgn_wrapper_key` spells it.
+        let pgn = sample_pgn();
+        let mut out = String::new();
+        let opts = JsonOptions {
+            camel_case: CamelCase::Off,
+            wrap: true,
+            ..JsonOptions::default()
+        };
+        write_json(&mut out, &pgn, &opts).unwrap();
+        assert!(out.starts_with(r#"{"Water Depth":{"#), "got: {out}");
+        assert!(
+            out.ends_with(r#""fields":{"Offset":0.000}}}"#),
+            "got: {out}"
         );
     }
 
@@ -1088,7 +1145,7 @@ mod tests {
             },
         )
         .unwrap();
-        assert!(out.contains(r#""Offset":null"#), "got: {}", out);
+        assert!(out.contains(r#""offset":null"#), "got: {}", out);
     }
 
     #[test]
@@ -1129,7 +1186,7 @@ mod tests {
                 },
             )
             .unwrap();
-            assert!(out.contains(r#""Offset":null"#), "got: {out}");
+            assert!(out.contains(r#""offset":null"#), "got: {out}");
         }
     }
 
@@ -1160,7 +1217,7 @@ mod tests {
         )
         .unwrap();
         assert!(
-            out.contains(r#""Offset":{"value":275,"name":"Navico"}"#),
+            out.contains(r#""offset":{"value":275,"name":"Navico"}"#),
             "got: {}",
             out
         );

--- a/crates/canboat-core/src/snapshot.rs
+++ b/crates/canboat-core/src/snapshot.rs
@@ -305,13 +305,16 @@ where
     let description = crate::analyzer_json::value(line, "description")
         .unwrap_or("")
         .to_string();
-    // `-camel` lines key fields by their camelCase `id`; bare `-json` by
-    // human `name`. Pick the matching secondary-key field key so the
-    // snapshot stays correctly split per instance / function code.
-    let use_camel = crate::analyzer_json::camel_wrapper_id(line).is_some();
-    let field_key = move |f: &crate::FieldInfo| if use_camel { f.id } else { f.name };
     let is_ais = is_ais_pgn(pgn);
     let info = crate::PgnDatabase::embedded(crate::Units::Metric).first_pgn(pgn);
+    // Records key fields by camelCase `id` or by human `name`. A
+    // wrapper (`--wrap` / canboat C's `-camel`) always means camel;
+    // otherwise sniff, since camelCase unwrapped is the default. Pick
+    // the matching secondary-key field key so the snapshot stays
+    // correctly split per instance / function code.
+    let use_camel = crate::analyzer_json::camel_wrapper_id(line).is_some()
+        || info.is_some_and(|i| crate::analyzer_json::uses_camel_keys(line, i.fields));
+    let field_key = move |f: &crate::FieldInfo| if use_camel { f.id } else { f.name };
     let repeat_set = info.and_then(repeating_pk_set);
 
     let Some(rs) = repeat_set else {

--- a/crates/canboat-io/src/analyze.rs
+++ b/crates/canboat-io/src/analyze.rs
@@ -45,8 +45,9 @@ pub struct Config {
     /// producer's build version doesn't leak into version-agnostic
     /// output.
     pub suppress_startup_record: bool,
-    /// Unit system to decode into — `Metric` (the default: deg/°C/bar,
-    /// matching `analyzer` without `-si`) or `Si` (rad/K/Pa, `-si`).
+    /// Unit system to decode into — `Si` (the default: rad/K/Pa,
+    /// `--units si`) or `Metric` (deg/°C/bar, `--units metric`, which
+    /// is what canboat C prints without `-si`).
     pub units: canboat_core::Units,
 }
 

--- a/crates/canboat/src/convert.rs
+++ b/crates/canboat/src/convert.rs
@@ -143,6 +143,7 @@ Decoded-output shape (json/text only):
   --id STYLE     spaces | camel (default) | uppercamel
   --units SYSTEM si (default) | metric
   --wrap         nest each JSON record in {\"<pgnId>\":{…}} (off by default)
+  --no-banner    drop the leading {\"version\":…,\"units\":…} line (json only)
 
   Decoded output defaults to flat records with camelCase keys and strict
   SI units — the shape machine consumers want. For canboat C's historical
@@ -214,6 +215,13 @@ pub struct Args {
     /// their deprecated canboat C spellings. Defaults: camelCase + SI.
     #[command(flatten)]
     shape: canboat_cli::ShapeArgs,
+
+    /// Suppress the leading `{"version":…,"units":…}` banner that
+    /// `--to json` emits. Use when the output is diffed as a pure
+    /// record stream; leave it on when piping into `n2kd`, which reads
+    /// the unit system off that line.
+    #[arg(long)]
+    no_banner: bool,
 
     /// Lat/lon display format. Matches canboat's `-geo`.
     #[arg(long, value_name = "FMT", default_value = "dd")]
@@ -356,6 +364,23 @@ fn convert_decoded<W: Write>(
         geo: args.geo.into(),
     };
     let as_json = args.to == OutFormat::Json;
+
+    // Lead a JSON stream with the same one-line banner `analyzer` emits
+    // (version, commit, units, showLookupValues). It is a producer
+    // contract, not decoration: `n2kd` reads `"units"` off it to pick
+    // the schema it rebuilds each record against, and without it a
+    // bannerless stream is assumed Metric — which would silently read
+    // this converter's radians as degrees. Text output has no banner in
+    // canboat C either.
+    if as_json && !args.no_banner {
+        writeln!(
+            out,
+            "{}",
+            canboat_bridge::build_info::version_banner(args.shape.is_si(), args.nv)
+        )
+        .context("writing JSON banner")?;
+    }
+
     let cfg = analyze::Config {
         forced_format: forced,
         pgn_filter: args.pgn,

--- a/crates/canboat/src/convert.rs
+++ b/crates/canboat/src/convert.rs
@@ -20,9 +20,7 @@ use anyhow::{Context, Result};
 
 use canboat_core::RawFrame;
 use canboat_core::format::InputFormat;
-use canboat_core::output::{
-    CamelCase, GeoFormat, JsonOptions, TextOptions, write_json, write_text,
-};
+use canboat_core::output::{GeoFormat, JsonOptions, TextOptions, write_json, write_text};
 use canboat_io::{
     EblReader, EblWriter, FrameReader, FrameWriter, LineFrameReader, PlainWriter, TextLineWriter,
     analyze, container, copy,
@@ -77,8 +75,8 @@ enum FromFormat {
     /// Digital Yacht iKonvert (`!PDGY,<pgn>,…`).
     #[value(name = "ikonvert")]
     Ikonvert,
-    /// Analyzer JSON records, re-encoded to wire frames (`-camel` and
-    /// bare shapes; `-nv` values are written back verbatim).
+    /// Analyzer JSON records, re-encoded to wire frames (camelCase and
+    /// spaced-name shapes; `-nv` values are written back verbatim).
     #[value(name = "json")]
     Json,
     /// Airmar (`<ts> - <pgn> <canid> <hex>…`).
@@ -139,7 +137,18 @@ Output formats (--to, default json):
   text           canboat human-readable text, one line per record
   ydwg02         Yacht Devices YDWG-02 / YDEN received lines (raw frames)
   actisense      Actisense N2K-ASCII lines (raw frames)
-  actisense-ebl  Actisense .ebl binary log (raw frames)";
+  actisense-ebl  Actisense .ebl binary log (raw frames)
+
+Decoded-output shape (json/text only):
+  --id STYLE     spaces | camel (default) | uppercamel
+  --units SYSTEM si (default) | metric
+  --wrap         nest each JSON record in {\"<pgnId>\":{…}} (off by default)
+
+  Decoded output defaults to flat records with camelCase keys and strict
+  SI units — the shape machine consumers want. For canboat C's historical
+  output pass --id spaces --units metric. The old --camel / --upper-camel
+  / --si flags still work but are deprecated (--camel and --upper-camel
+  imply --wrap, as they do in canboat C).";
 
 #[derive(Debug, clap::Args)]
 pub struct Args {
@@ -201,20 +210,10 @@ pub struct Args {
     #[arg(long)]
     debug: bool,
 
-    /// Emit field keys and PGN descriptions as camelCase identifiers.
-    /// Matches canboat's `-camel`.
-    #[arg(long)]
-    camel: bool,
-
-    /// As `--camel`, but UpperCamelCase. Matches canboat's
-    /// `-upper-camel`.
-    #[arg(long, conflicts_with = "camel")]
-    upper_camel: bool,
-
-    /// Strict SI units — radians, kelvin, pascals — rather than the
-    /// practical defaults (deg, °C, bar). Matches canboat's `-si`.
-    #[arg(long)]
-    si: bool,
+    /// Identifier spelling (`--id`) and unit system (`--units`), plus
+    /// their deprecated canboat C spellings. Defaults: camelCase + SI.
+    #[command(flatten)]
+    shape: crate::output_opts::ShapeArgs,
 
     /// Lat/lon display format. Matches canboat's `-geo`.
     #[arg(long, value_name = "FMT", default_value = "dd")]
@@ -265,6 +264,7 @@ pub fn run(args: Args) -> Result<()> {
     // `RUST_LOG` for more. Ignore a double-init if a shim already set one.
     let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
         .try_init();
+    args.shape.warn_deprecated();
     let forced = args.from.and_then(FromFormat::to_input_format);
     let ebl = ebl_input(&args);
     let stdout = io::stdout();
@@ -302,16 +302,11 @@ fn convert_raw<W: Write>(
         Box::new(EblReader::new(source))
     } else if args.from == Some(FromFormat::Json) {
         // Bare physical values in the JSON are interpreted in the same
-        // unit system the output side uses (`--si` or metric); `-nv`
-        // raw values are unit-agnostic either way.
-        let units = if args.si {
-            canboat_core::Units::Si
-        } else {
-            canboat_core::Units::Metric
-        };
+        // unit system the output side uses (`--units`); `-nv` raw
+        // values are unit-agnostic either way.
         Box::new(crate::json_input::JsonFrameReader::new(
             source,
-            canboat_core::PgnDatabase::embedded(units),
+            canboat_core::PgnDatabase::embedded(args.shape.units()),
         ))
     } else {
         match forced {
@@ -348,18 +343,12 @@ fn convert_decoded<W: Write>(
     ebl: bool,
     out: &mut W,
 ) -> Result<()> {
-    let camel_case = if args.upper_camel {
-        CamelCase::Upper
-    } else if args.camel {
-        CamelCase::Lower
-    } else {
-        CamelCase::Off
-    };
     let json_opts = JsonOptions {
         include_empty: args.empty,
         name_value: args.nv,
         debug: args.debug,
-        camel_case,
+        camel_case: args.shape.camel_case(),
+        wrap: args.shape.wrap(),
     };
     let text_opts = TextOptions {
         show_unavailable: args.empty,
@@ -373,11 +362,7 @@ fn convert_decoded<W: Write>(
         src_filter: args.src,
         dst_filter: args.dst,
         suppress_startup_record: false,
-        units: if args.si {
-            canboat_core::Units::Si
-        } else {
-            canboat_core::Units::Metric
-        },
+        units: args.shape.units(),
     };
 
     let mut line = String::with_capacity(512);

--- a/crates/canboat/src/convert.rs
+++ b/crates/canboat/src/convert.rs
@@ -309,9 +309,9 @@ fn convert_raw<W: Write>(
     let mut reader: Box<dyn FrameReader> = if ebl {
         Box::new(EblReader::new(source))
     } else if args.from == Some(FromFormat::Json) {
-        // Bare physical values in the JSON are interpreted in the same
-        // unit system the output side uses (`--units`); `-nv` raw
-        // values are unit-agnostic either way.
+        // Bare physical values are read against whatever unit system the
+        // input's banner declares; `--units` is only the assumption for
+        // a bannerless stream. `-nv` raw values are unit-agnostic.
         Box::new(crate::json_input::JsonFrameReader::new(
             source,
             canboat_core::PgnDatabase::embedded(args.shape.units()),
@@ -416,6 +416,10 @@ fn convert_decoded<W: Write>(
         // complete N2K messages, so skip the line-reader / reassembly /
         // coalesced-mode machinery entirely: pull each frame and decode
         // it directly, honouring the filters.
+        // `db` decodes into the *output* unit system (`--units`). The
+        // JSON reader tracks the *input's* separately, from its banner,
+        // so `--from json` doubles as a unit converter: read a canboat C
+        // `"units":"std"` stream, emit SI (or the other way round).
         let db = canboat_core::PgnDatabase::embedded(cfg.units);
         let mut reader: Box<dyn FrameReader> = if ebl {
             Box::new(EblReader::new(source))

--- a/crates/canboat/src/convert.rs
+++ b/crates/canboat/src/convert.rs
@@ -213,7 +213,7 @@ pub struct Args {
     /// Identifier spelling (`--id`) and unit system (`--units`), plus
     /// their deprecated canboat C spellings. Defaults: camelCase + SI.
     #[command(flatten)]
-    shape: crate::output_opts::ShapeArgs,
+    shape: canboat_cli::ShapeArgs,
 
     /// Lat/lon display format. Matches canboat's `-geo`.
     #[arg(long, value_name = "FMT", default_value = "dd")]

--- a/crates/canboat/src/json_input.rs
+++ b/crates/canboat/src/json_input.rs
@@ -22,6 +22,12 @@
 //! (set 1) and `"list2"` (set 2) arrays inside `fields`, one object per
 //! iteration.
 //!
+//! Bare physical values are read against the unit system the stream's
+//! `{"version":…,"units":…}` banner declares — degrees in a `"std"`
+//! stream, radians in an `"si"` one. Without a banner the caller's
+//! assumption stands (`--units`, SI by default). `-nv` raw values are
+//! unit-agnostic and unaffected.
+//!
 //! This lives in the CLI crate (not `canboat-core`) because it is the
 //! one place a real JSON parser is warranted: nested repeating lists
 //! and `-nv` objects are beyond `analyzer_json`'s deliberate
@@ -51,7 +57,15 @@ const BARE_TOP_LEVEL: [&str; 7] = [
 /// A [`FrameSource`] that reads analyzer-JSON lines from `src` and
 /// yields the re-encoded frames. Lines that fail to encode are skipped
 /// with a warning (mirroring the analyzer's tolerance of undecodable
-/// input) — the startup `{"version":…}` header is skipped silently.
+/// input).
+///
+/// The stream's `{"version":…,"units":…}` banner is not merely skipped:
+/// its `units` decides how bare physical values in the following
+/// records are read back. A `43.0` in a `"units":"std"` stream is
+/// degrees; the same number in an SI stream is radians, and encoding it
+/// against the wrong schema puts the wrong bits on the wire. The
+/// constructor's `db` is only the assumption for a bannerless stream —
+/// the banner always wins.
 pub struct JsonFrameReader<R> {
     src: R,
     db: &'static PgnDatabase,
@@ -60,6 +74,8 @@ pub struct JsonFrameReader<R> {
 }
 
 impl<R: BufRead> JsonFrameReader<R> {
+    /// `db` supplies the unit system to assume until (and unless) the
+    /// stream declares its own in a banner.
     pub fn new(src: R, db: &'static PgnDatabase) -> Self {
         Self {
             src,
@@ -67,6 +83,21 @@ impl<R: BufRead> JsonFrameReader<R> {
             buf: String::with_capacity(512),
             line_no: 0,
         }
+    }
+}
+
+/// The unit system an analyzer banner declares, or `None` when `line`
+/// isn't a banner or doesn't say. canboat spells them `"si"` (strict SI)
+/// and `"std"` (canboat's practical Metric).
+fn banner_units(line: &str) -> Option<canboat_core::Units> {
+    if !line.starts_with("{\"version\"") {
+        return None;
+    }
+    let root: Value = serde_json::from_str(line).ok()?;
+    match root.as_object()?.get("units")?.as_str()? {
+        "si" => Some(canboat_core::Units::Si),
+        "std" => Some(canboat_core::Units::Metric),
+        _ => None,
     }
 }
 
@@ -80,6 +111,23 @@ impl<R: BufRead> FrameSource for JsonFrameReader<R> {
             self.line_no += 1;
             let line = self.buf.trim();
             if line.is_empty() {
+                continue;
+            }
+            // Adopt the producer's declared unit system for the rest of
+            // the stream. The banner itself is not a record, so either
+            // way this line yields no frame.
+            if let Some(units) = banner_units(line) {
+                if units != self.db.units() {
+                    log::info!(
+                        "input declares {} units; reading values against that schema",
+                        if units == canboat_core::Units::Si {
+                            "SI (rad/K/Pa)"
+                        } else {
+                            "Metric (deg/°C/bar)"
+                        }
+                    );
+                    self.db = PgnDatabase::embedded(units);
+                }
                 continue;
             }
             match frame_from_json(self.db, line) {
@@ -625,5 +673,42 @@ mod tests {
     fn ambiguous_bare_pgn_is_a_clear_error() {
         let err = frame_from_json(db(), r#"{"pgn":126208,"fields":{}}"#).unwrap_err();
         assert!(err.to_string().contains("-camel"), "got: {err:#}");
+    }
+
+    #[test]
+    fn banner_units_reads_the_producers_declaration() {
+        let si = r#"{"version":"8.0.0","commit":"abc","units":"si","showLookupValues":true}"#;
+        let std = r#"{"version":"7.1.0","units":"std","showLookupValues":true}"#;
+        assert_eq!(banner_units(si), Some(Units::Si));
+        assert_eq!(banner_units(std), Some(Units::Metric));
+        // Not a banner, or a banner that doesn't say — the caller's
+        // assumption stands rather than being silently overridden.
+        assert_eq!(banner_units(r#"{"version":"7.1.0"}"#), None);
+        assert_eq!(banner_units(r#"{"pgn":127250,"fields":{}}"#), None);
+    }
+
+    /// The whole point of tracking the banner: the same decimal means
+    /// different bits depending on the stream's units.
+    #[test]
+    fn banner_units_decide_how_bare_values_encode() {
+        let deg = frame_from_json(
+            PgnDatabase::embedded(Units::Metric),
+            r#"{"pgn":127250,"src":27,"description":"Vessel Heading","fields":{"heading":210.9}}"#,
+        )
+        .unwrap()
+        .unwrap();
+        let rad = frame_from_json(
+            PgnDatabase::embedded(Units::Si),
+            r#"{"pgn":127250,"src":27,"description":"Vessel Heading","fields":{"heading":210.9}}"#,
+        )
+        .unwrap()
+        .unwrap();
+        assert_ne!(
+            deg.data.as_slice(),
+            rad.data.as_slice(),
+            "210.9 deg and 210.9 rad must not encode alike"
+        );
+        // 210.9 deg = 3.68094 rad, i.e. 36809 in 0.0001 rad units.
+        assert_eq!(&deg.data[1..3], &[0xc9, 0x8f]);
     }
 }

--- a/crates/canboat/src/legacy/analyzer.rs
+++ b/crates/canboat/src/legacy/analyzer.rs
@@ -3,7 +3,7 @@
 //! `analyzer` legacy alias-module.
 //!
 //! `analyzer` has a rich, golden-tested CLI (JSON banner, `--fixtime`
-//! startup-record suppression, `--nv/--empty/--geo/--camel/--debug`)
+//! startup-record suppression, `--nv/--empty/--geo/--id/--debug`)
 //! that doesn't map onto a `convert` flag prefix, so it is preserved
 //! verbatim here and dispatched by argv[0] rather than translated. The
 //! heavy lifting still lives in [`canboat_io::analyze`]; this is only
@@ -23,7 +23,7 @@ use clap::Parser;
 
 use canboat_core::{
     format::InputFormat,
-    output::{CamelCase, GeoFormat, JsonOptions, TextOptions, write_json, write_text},
+    output::{GeoFormat, JsonOptions, TextOptions, write_json, write_text},
 };
 use canboat_io::analyze::{self, Config};
 
@@ -53,11 +53,6 @@ struct Cli {
     #[arg(long)]
     nv: bool,
 
-    /// Show values in strict SI units — radians, kelvin, pascals — rather
-    /// than the practical defaults (deg, °C, bar). Matches canboat's `-si`.
-    #[arg(long)]
-    si: bool,
-
     /// JSON: wrap every field with byte/bit diagnostics (`-debug`).
     #[arg(long)]
     debug: bool,
@@ -66,13 +61,11 @@ struct Cli {
     #[arg(long, value_name = "FMT", default_value = "dd")]
     geo: String,
 
-    /// Emit field keys + PGN descriptions as camelCase identifiers.
-    #[arg(long, conflicts_with = "upper_camel")]
-    camel: bool,
-
-    /// Same as `--camel` but UpperCamelCase.
-    #[arg(long = "upper-camel")]
-    upper_camel: bool,
+    /// Identifier spelling (`--id`) and unit system (`--units`), plus
+    /// their deprecated canboat C spellings. Defaults: camelCase + SI.
+    /// canboat C's historical shape is `--id spaces --units metric`.
+    #[command(flatten)]
+    shape: crate::output_opts::ShapeArgs,
 
     /// Use the given string in place of any analyzer-generated
     /// timestamps (matches canboat's `-fixtime`).
@@ -117,24 +110,15 @@ pub fn run(argv: Vec<OsString>) -> Result<()> {
 }
 
 fn run_cli(cli: Cli) -> Result<()> {
-    let units = if cli.si {
-        canboat_core::Units::Si
-    } else {
-        canboat_core::Units::Metric
-    };
+    cli.shape.warn_deprecated();
+    let units = cli.shape.units();
 
-    let camel_case = if cli.upper_camel {
-        CamelCase::Upper
-    } else if cli.camel {
-        CamelCase::Lower
-    } else {
-        CamelCase::Off
-    };
     let json_opts = JsonOptions {
         include_empty: cli.empty,
         name_value: cli.nv,
         debug: cli.debug,
-        camel_case,
+        camel_case: cli.shape.camel_case(),
+        wrap: cli.shape.wrap(),
     };
     let geo = match cli.geo.as_str() {
         "dd" => GeoFormat::Dd,
@@ -160,7 +144,7 @@ fn run_cli(cli: Cli) -> Result<()> {
         writeln!(
             out,
             "{}",
-            canboat_bridge::build_info::version_banner(cli.si, cli.nv)
+            canboat_bridge::build_info::version_banner(cli.shape.is_si(), cli.nv)
         )
         .context("writing JSON banner")?;
     }

--- a/crates/canboat/src/legacy/analyzer.rs
+++ b/crates/canboat/src/legacy/analyzer.rs
@@ -65,7 +65,7 @@ struct Cli {
     /// their deprecated canboat C spellings. Defaults: camelCase + SI.
     /// canboat C's historical shape is `--id spaces --units metric`.
     #[command(flatten)]
-    shape: crate::output_opts::ShapeArgs,
+    shape: canboat_cli::ShapeArgs,
 
     /// Use the given string in place of any analyzer-generated
     /// timestamps (matches canboat's `-fixtime`).

--- a/crates/canboat/src/main.rs
+++ b/crates/canboat/src/main.rs
@@ -26,6 +26,7 @@ mod format_message;
 mod interface;
 mod json_input;
 mod legacy;
+mod output_opts;
 mod replay;
 mod tui;
 

--- a/crates/canboat/src/main.rs
+++ b/crates/canboat/src/main.rs
@@ -26,7 +26,6 @@ mod format_message;
 mod interface;
 mod json_input;
 mod legacy;
-mod output_opts;
 mod replay;
 mod tui;
 
@@ -94,6 +93,7 @@ fn main() -> ExitCode {
             // The pipeline library no longer initialises logging — the host
             // (this binary) owns it. Convert the clap Args to the plain config,
             // then set up env_logger from its verbosity before running.
+            args.warn_deprecated();
             let mut config: server::BridgeConfig = (*args).into();
             // Config-dir *discovery* is a binary concern, not the library's:
             // when the user didn't pass `--config-dir`, probe for the

--- a/crates/canboat/src/output_opts.rs
+++ b/crates/canboat/src/output_opts.rs
@@ -1,0 +1,250 @@
+// (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
+
+//! Shared decoded-output shape flags for `canboat convert` and the
+//! `analyzer` shim.
+//!
+//! Both CLIs decide three orthogonal things about a decoded record: how
+//! field keys and PGN descriptions are spelled (`--id`), which unit
+//! system numeric fields are decoded into (`--units`), and whether the
+//! record is nested under its PGN id (`--wrap`). They are declared once
+//! here and `#[command(flatten)]`ed into both parsers so the two can't
+//! drift.
+//!
+//! **The defaults are camelCase identifiers, strict SI units and no
+//! wrapper** — `--id camel --units si`. That is exactly the shape the
+//! JSON consumers already want: canboatjs' `FromPgn` defaults to
+//! `useCamel: true`, has no unit conversion at all (so Signal K has
+//! always read SI), and emits each record flat.
+//!
+//! canboat C's spellings — `--camel`, `--upper-camel`, `--si` — are kept
+//! as deprecated aliases so existing command lines keep producing their
+//! exact output; `--camel` / `--upper-camel` therefore still imply
+//! `--wrap`, which in canboat C rides along with camelCase. Pre-change
+//! behaviour is `--id spaces --units metric`.
+
+use canboat_core::Units;
+use canboat_core::output::CamelCase;
+
+/// `--id` values: how field keys and the PGN description are spelled.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum IdStyle {
+    /// Human-readable names — `"Unique Number"`, `"ISO Address Claim"`.
+    /// What canboat C prints without `-camel`.
+    Spaces,
+    /// lowerCamelCase identifiers — `"uniqueNumber"`. The default.
+    #[default]
+    Camel,
+    /// UpperCamelCase identifiers — `"UniqueNumber"`.
+    #[value(name = "uppercamel", alias = "upper-camel")]
+    UpperCamel,
+}
+
+impl From<IdStyle> for CamelCase {
+    fn from(s: IdStyle) -> Self {
+        match s {
+            IdStyle::Spaces => CamelCase::Off,
+            IdStyle::Camel => CamelCase::Lower,
+            IdStyle::UpperCamel => CamelCase::Upper,
+        }
+    }
+}
+
+/// `--units` values: which unit system numeric fields decode into.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum UnitSystem {
+    /// Strict SI base units — `rad`, `K`, `Pa`, `C`. The default.
+    #[default]
+    Si,
+    /// canboat's practical humanized units — `deg`, `°C`, `bar`, `Ah`.
+    /// What canboat C prints without `-si`.
+    Metric,
+}
+
+impl From<UnitSystem> for Units {
+    fn from(u: UnitSystem) -> Self {
+        match u {
+            UnitSystem::Si => Units::Si,
+            UnitSystem::Metric => Units::Metric,
+        }
+    }
+}
+
+/// The `--id` / `--units` pair plus the deprecated flags they replace.
+/// Flattened into both `convert` and the `analyzer` shim.
+#[derive(Debug, Clone, Default, clap::Args)]
+pub struct ShapeArgs {
+    /// Spelling of field keys and PGN descriptions: `spaces`
+    /// ("Unique Number"), `camel` ("uniqueNumber", the default) or
+    /// `uppercamel` ("UniqueNumber").
+    #[arg(long, value_enum, value_name = "STYLE",
+          conflicts_with_all = ["camel", "upper_camel"])]
+    id: Option<IdStyle>,
+
+    /// Unit system for numeric fields: `si` (rad/K/Pa, the default) or
+    /// `metric` (canboat's humanized deg/°C/bar).
+    #[arg(long, value_enum, value_name = "SYSTEM", conflicts_with = "si")]
+    units: Option<UnitSystem>,
+
+    /// JSON: nest each record in `{"<pgnId>":{…}}` instead of emitting
+    /// it flat. Off by default; implied by the deprecated `--camel` /
+    /// `--upper-camel`, which is how canboat C spells it.
+    #[arg(long)]
+    wrap: bool,
+
+    /// Deprecated: camelCase is now the default. Same as
+    /// `--id camel --wrap`.
+    #[arg(long, conflicts_with = "upper_camel")]
+    camel: bool,
+
+    /// Deprecated: use `--id uppercamel --wrap`.
+    #[arg(long = "upper-camel")]
+    upper_camel: bool,
+
+    /// Deprecated: SI is now the default. Same as `--units si`.
+    #[arg(long)]
+    si: bool,
+}
+
+impl ShapeArgs {
+    /// The resolved identifier style. `--id` wins; the deprecated
+    /// `--camel` / `--upper-camel` are honoured when it is absent.
+    pub fn id_style(&self) -> IdStyle {
+        match self.id {
+            Some(id) => id,
+            None if self.upper_camel => IdStyle::UpperCamel,
+            None if self.camel => IdStyle::Camel,
+            None => IdStyle::default(),
+        }
+    }
+
+    /// The resolved identifier style, as the output layer's enum.
+    pub fn camel_case(&self) -> CamelCase {
+        self.id_style().into()
+    }
+
+    /// The resolved unit system. `--units` wins; the deprecated `--si`
+    /// is honoured when it is absent.
+    pub fn unit_system(&self) -> UnitSystem {
+        match self.units {
+            Some(u) => u,
+            None if self.si => UnitSystem::Si,
+            None => UnitSystem::default(),
+        }
+    }
+
+    /// The resolved unit system, as the database's enum.
+    pub fn units(&self) -> Units {
+        self.unit_system().into()
+    }
+
+    /// Whether each JSON record is nested under its PGN key. Explicit
+    /// `--wrap`, or the deprecated flags that imply it — so a command
+    /// line written for canboat C's `-camel` keeps its exact output.
+    pub fn wrap(&self) -> bool {
+        self.wrap || self.camel || self.upper_camel
+    }
+
+    /// True when decoding into strict SI — what the analyzer JSON
+    /// banner reports as `"units":"si"`.
+    pub fn is_si(&self) -> bool {
+        self.unit_system() == UnitSystem::Si
+    }
+
+    /// Nudge users off the canboat C spellings, on stderr so decoded
+    /// stdout stays clean. Call once, before the decode loop.
+    pub fn warn_deprecated(&self) {
+        if self.camel {
+            eprintln!(
+                "warning: --camel is deprecated; camelCase is now the default, so use --wrap \
+                 if you still want records nested under their PGN id"
+            );
+        }
+        if self.upper_camel {
+            eprintln!("warning: --upper-camel is deprecated; use --id uppercamel --wrap");
+        }
+        if self.si {
+            eprintln!(
+                "warning: --si is deprecated and is now the default; drop it, or say --units si"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Debug, Parser)]
+    struct Harness {
+        #[command(flatten)]
+        shape: ShapeArgs,
+    }
+
+    fn shape(args: &[&str]) -> ShapeArgs {
+        let mut argv = vec!["test"];
+        argv.extend_from_slice(args);
+        Harness::parse_from(argv).shape
+    }
+
+    #[test]
+    fn defaults_are_camel_si_and_unwrapped() {
+        let s = shape(&[]);
+        assert_eq!(s.camel_case(), CamelCase::Lower);
+        assert_eq!(s.units(), Units::Si);
+        assert!(!s.wrap());
+    }
+
+    #[test]
+    fn legacy_defaults_are_reachable() {
+        let s = shape(&["--id", "spaces", "--units", "metric"]);
+        assert_eq!(s.camel_case(), CamelCase::Off);
+        assert_eq!(s.units(), Units::Metric);
+        assert!(!s.wrap());
+    }
+
+    #[test]
+    fn deprecated_flags_still_resolve() {
+        assert_eq!(shape(&["--camel"]).camel_case(), CamelCase::Lower);
+        assert_eq!(shape(&["--upper-camel"]).camel_case(), CamelCase::Upper);
+        assert_eq!(shape(&["--si"]).units(), Units::Si);
+    }
+
+    /// canboat C ties wrapping to `-camel`, so the deprecated spellings
+    /// must keep producing the wrapped record their users expect —
+    /// while `--id camel` on its own does not.
+    #[test]
+    fn only_the_deprecated_camel_flags_imply_wrap() {
+        assert!(shape(&["--camel"]).wrap());
+        assert!(shape(&["--upper-camel"]).wrap());
+        assert!(!shape(&["--id", "camel"]).wrap());
+        assert!(!shape(&["--id", "uppercamel"]).wrap());
+        assert!(shape(&["--id", "uppercamel", "--wrap"]).wrap());
+    }
+
+    #[test]
+    fn uppercamel_accepts_both_spellings() {
+        assert_eq!(
+            shape(&["--id", "uppercamel"]).camel_case(),
+            CamelCase::Upper
+        );
+        assert_eq!(
+            shape(&["--id", "upper-camel"]).camel_case(),
+            CamelCase::Upper
+        );
+    }
+
+    #[test]
+    fn new_and_deprecated_forms_conflict() {
+        for argv in [
+            vec!["test", "--id", "camel", "--camel"],
+            vec!["test", "--id", "spaces", "--upper-camel"],
+            vec!["test", "--units", "metric", "--si"],
+        ] {
+            assert!(
+                Harness::try_parse_from(&argv).is_err(),
+                "expected {argv:?} to be rejected"
+            );
+        }
+    }
+}

--- a/crates/canboat/src/tui/client.rs
+++ b/crates/canboat/src/tui/client.rs
@@ -180,8 +180,17 @@ fn ingest_raw_capture(path: &Path, tx: &mpsc::UnboundedSender<LoadItem>) -> anyh
     use canboat_core::frame::RawFrame;
     use canboat_core::output::{JsonOptions, write_json};
     use canboat_core::snapshot::classify_json_line;
-    let cfg = canboat_io::analyze::Config::default();
-    let json_opts = JsonOptions::default();
+    // The TUI is the human-facing surface: it shows spaced field names
+    // and humanized units, so it pins both rather than following the
+    // machine-facing library defaults (camelCase + SI).
+    let cfg = canboat_io::analyze::Config {
+        units: canboat_core::Units::Metric,
+        ..Default::default()
+    };
+    let json_opts = JsonOptions {
+        camel_case: canboat_core::output::CamelCase::Off,
+        ..Default::default()
+    };
     let mut buf = String::with_capacity(512);
     let mut raw = String::with_capacity(128);
     canboat_io::analyze::decode_file(path, &cfg, |decoded| {

--- a/crates/canboat/src/tui/state.rs
+++ b/crates/canboat/src/tui/state.rs
@@ -899,28 +899,50 @@ pub(crate) fn field_value(line: &Value, f: FieldRef) -> Option<&Value> {
     line.pointer(&format!("/fields/{}", json_pointer_escape(f.field.name)))
 }
 
-/// Canonicalize a `server --camel` analyzer record back to bare `-json`
-/// shape. `-camel` wraps each record `{"<pgnId>":{…}}` and keys its fields
-/// by camelCase `id`; this strips the wrapper and renames every field key
-/// (recursing into `list`/`list2` repeat sets) to its human name via the
-/// schema, using the wrapper id to pick the exact PGN variant. A bare
-/// record has no single-key wrapper and is returned untouched — so this
-/// is a no-op on the default stream, and every reader downstream stays
-/// name-keyed and camel-oblivious.
+/// Canonicalize a camelCase analyzer record to the spaced-name shape
+/// every reader below expects, in both flavours the servers emit:
+///
+/// * **flat** (`--id camel`, the default) — field keys are camelCase
+///   `id`s on an unwrapped record; rename them to their human names.
+/// * **wrapped** (`--wrap`, canboat C's `-camel`) — additionally strip
+///   the `{"<pgnId>":{…}}` envelope, whose id names the exact PGN
+///   variant, and restore the human `description` the wrapper replaced.
+///
+/// Renaming recurses into `list`/`list2` repeat sets. A spaced-name
+/// record passes through untouched (no key matches a schema `id`), so
+/// every reader downstream stays name-keyed and camel-oblivious.
 pub(crate) fn normalize_camel(line: Value) -> Value {
-    // The camel wrapper is the only shape that presents as a one-key
-    // object whose value is itself a record (`{"windData":{"pgn":…}}`);
-    // a bare record always has several top-level keys.
+    // The wrapper is the only shape that presents as a one-key object
+    // whose value is itself a record (`{"windData":{"pgn":…}}`); any
+    // unwrapped record has several top-level keys.
     let is_wrapper = matches!(&line, Value::Object(o)
         if o.len() == 1 && o.values().next().is_some_and(|v| v.get("pgn").is_some()));
-    if !is_wrapper {
-        return line;
-    }
     let Value::Object(top) = line else {
-        unreachable!("checked Object above")
+        return line;
     };
-    let (wrapper_id, mut record) = top.into_iter().next().expect("one entry");
     let db = PgnDatabase::embedded(Units::Metric);
+    if !is_wrapper {
+        // Flat record: `description` still carries the human string in
+        // every `--id` mode, so it picks the variant; fall back to the
+        // PGN number.
+        let mut record = Value::Object(top);
+        let pgn = record.get("pgn").and_then(Value::as_u64).unwrap_or(0) as u32;
+        let info = record
+            .get("description")
+            .and_then(Value::as_str)
+            .and_then(|d| {
+                db.pgn_variants(pgn)
+                    .find(|p| p.description == d || p.id == d)
+            })
+            .or_else(|| db.first_pgn(pgn));
+        if let Some(info) = info
+            && let Some(Value::Object(fields)) = record.get_mut("fields")
+        {
+            rekey_fields(fields, info);
+        }
+        return record;
+    }
+    let (wrapper_id, mut record) = top.into_iter().next().expect("one entry");
     let pgn = record.get("pgn").and_then(Value::as_u64).unwrap_or(0) as u32;
     if let Some(info) = db.pgn_by_id(&wrapper_id).or_else(|| db.first_pgn(pgn))
         && let Value::Object(obj) = &mut record
@@ -1134,6 +1156,51 @@ mod tests {
             entry.line.get("productInformation").is_none(),
             "wrapper stripped"
         );
+    }
+
+    #[test]
+    fn flat_camel_record_normalizes_to_bare_and_reads() {
+        // The default `server` shape: camelCase field keys on an
+        // *unwrapped* record. There is no wrapper to key off, so the
+        // normalizer has to rekey from the field ids — before it did,
+        // every name-keyed reader in the TUI came up empty.
+        let mut s = state();
+        let flat = json!({
+            "prio": 6, "src": 11, "pgn": 126996,
+            "description": "Product Information",
+            "fields": {
+                "modelId": "ACME Radar",
+                "softwareVersionCode": "1.2.3",
+                "certificationLevel": 2
+            }
+        });
+        s.upsert(126996, 11, None, "Product Information".into(), flat);
+
+        let devs = s.device_list();
+        let dev = devs.iter().find(|d| d.src == 11).expect("device src 11");
+        assert_eq!(dev.model, "ACME Radar");
+        assert_eq!(dev.software, "1.2.3");
+
+        let entry = s.entries.values().next().expect("one entry");
+        assert_eq!(entry.description, "Product Information");
+        assert_eq!(
+            entry
+                .line
+                .pointer("/fields/Model ID")
+                .and_then(Value::as_str),
+            Some("ACME Radar")
+        );
+    }
+
+    #[test]
+    fn spaced_name_record_passes_through_untouched() {
+        // `--id spaces` output must not be disturbed by the rekeying.
+        let line = json!({
+            "prio": 6, "src": 12, "pgn": 126996,
+            "description": "Product Information",
+            "fields": {"Model ID": "ACME Radar", "Certification Level": 2}
+        });
+        assert_eq!(normalize_camel(line.clone()), line);
     }
 
     #[test]

--- a/crates/canboat/tests/convert_formats.rs
+++ b/crates/canboat/tests/convert_formats.rs
@@ -135,6 +135,45 @@ fn json_round_trips_through_its_own_banner() {
     );
 }
 
+/// `--from json` reads bare physical values against the unit system the
+/// input's *banner* declares, not the one `--units` asks for on output.
+/// That makes the pair a unit converter — and, more importantly, stops a
+/// canboat C `"units":"std"` stream from having its degrees re-encoded
+/// as radians now that SI is the default.
+#[test]
+fn json_input_follows_the_banners_units() {
+    // Metric out: heading in degrees, banner says "std".
+    let metric = run(&["convert", "--to", "json", "--units", "metric"], HEADING);
+    let s = String::from_utf8(metric.clone()).unwrap();
+    assert!(s.lines().next().unwrap().contains(r#""units":"std""#));
+    assert!(s.contains(r#""heading":210.9"#), "metric json: {s}");
+
+    // Feed it back with the default (SI) output: the same record must
+    // come out in radians, not have 210.9 read as radians.
+    let si = String::from_utf8(run(&["convert", "--from", "json"], &metric)).unwrap();
+    assert!(si.lines().next().unwrap().contains(r#""units":"si""#));
+    assert!(si.contains(r#""heading":3.68"#), "si json: {si}");
+}
+
+#[test]
+fn the_banner_outranks_the_units_flag_on_input() {
+    // SI-bannered input, `--units metric` on the command line: the flag
+    // governs the output, the banner governs how the input is read, so
+    // the wire bits survive.
+    let si_json = run(&["convert", "--to", "json"], HEADING);
+    let back = run(
+        &[
+            "convert", "--from", "json", "--to", "plain", "--units", "metric",
+        ],
+        &si_json,
+    );
+    assert_eq!(
+        String::from_utf8(back).unwrap().as_bytes(),
+        HEADING,
+        "banner-declared input units were ignored"
+    );
+}
+
 #[test]
 fn actisense_ebl_emits_binary_framing() {
     // EBL is output-only; assert it produced a binary record that opens

--- a/crates/canboat/tests/convert_formats.rs
+++ b/crates/canboat/tests/convert_formats.rs
@@ -66,6 +66,75 @@ fn actisense_round_trips_to_plain() {
     assert!(s.contains(BODY), "round-trip lost the body: {s}");
 }
 
+/// `--to json` leads with the same producer banner `analyzer` emits.
+/// `n2kd` reads `"units"` off it to pick the schema it rebuilds records
+/// against, so a missing banner means a stream decoded in the wrong
+/// unit system, silently.
+#[test]
+fn json_leads_with_the_version_banner() {
+    let out = run(&["convert", "--to", "json"], PLAIN);
+    let s = String::from_utf8(out).unwrap();
+    let banner = s.lines().next().expect("a first line");
+    assert!(banner.starts_with(r#"{"version":"#), "banner: {banner}");
+    assert!(banner.contains(r#""units":"si""#), "banner: {banner}");
+    assert!(
+        banner.contains(r#""showLookupValues":false"#),
+        "banner: {banner}"
+    );
+    // …and the records still follow it.
+    assert!(
+        s.lines()
+            .nth(1)
+            .is_some_and(|l| l.contains("\"pgn\":127251"))
+    );
+}
+
+#[test]
+fn banner_tracks_the_output_shape() {
+    let metric = String::from_utf8(run(
+        &["convert", "--to", "json", "--units", "metric", "--nv"],
+        PLAIN,
+    ))
+    .unwrap();
+    let banner = metric.lines().next().unwrap();
+    assert!(banner.contains(r#""units":"std""#), "banner: {banner}");
+    assert!(
+        banner.contains(r#""showLookupValues":true"#),
+        "banner: {banner}"
+    );
+}
+
+#[test]
+fn no_banner_suppresses_it_and_text_never_has_one() {
+    let bare = String::from_utf8(run(&["convert", "--to", "json", "--no-banner"], PLAIN)).unwrap();
+    assert!(
+        !bare.contains("\"version\""),
+        "banner leaked through --no-banner: {bare}"
+    );
+    // canboat C emits no banner in text mode either.
+    let text = String::from_utf8(run(&["convert", "--to", "text"], PLAIN)).unwrap();
+    assert!(!text.contains("\"version\""), "text got a banner: {text}");
+}
+
+/// The banner must not break `--from json`: it is not a record, and the
+/// re-encoder skips `{"version":…}` lines. Uses PGN 127250 rather than
+/// the shared `PLAIN` fixture because 127251's trailing Reserved field
+/// renders as a hex display string that the encoder can't take back —
+/// a pre-existing limitation, unrelated to the banner.
+const HEADING: &[u8] = b"2026-01-01T00:00:00.000Z,3,127250,27,255,8,00,ca,8f,ff,7f,ff,7f,fd\n";
+
+#[test]
+fn json_round_trips_through_its_own_banner() {
+    let json = run(&["convert", "--to", "json", "--nv"], HEADING);
+    assert!(String::from_utf8_lossy(&json).starts_with(r#"{"version":"#));
+    let back = run(&["convert", "--from", "json", "--to", "plain"], &json);
+    assert_eq!(
+        String::from_utf8(back).unwrap().as_bytes(),
+        HEADING,
+        "round trip through the banner is not byte-exact"
+    );
+}
+
 #[test]
 fn actisense_ebl_emits_binary_framing() {
     // EBL is output-only; assert it produced a binary record that opens

--- a/crates/canboat/tests/golden.rs
+++ b/crates/canboat/tests/golden.rs
@@ -78,6 +78,14 @@ fn canboat_path() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_canboat"))
 }
 
+/// The `.out` fixtures are canboat C's output, and canboat C prints
+/// spaced field names in its humanized units. The Rust `analyzer` now
+/// defaults to the machine-facing shape (camelCase keys, strict SI, no
+/// record wrapper), so every golden case asks for the C shape back
+/// explicitly. Comparing against C is the whole point of these tests —
+/// the defaults are exercised by the unit tests in `output_opts`.
+const C_SHAPE: &[&str] = &["--id", "spaces", "--units", "metric"];
+
 /// Drive the analyzer binary on `<test_dir>/<in_name>` with `args`,
 /// then byte-diff stdout against `<test_dir>/<expected_name>`.
 fn run_case(in_name: &str, expected_name: &str, args: &[&str]) {
@@ -106,6 +114,7 @@ fn run_case_skipping(in_name: &str, expected_name: &str, args: &[&str], skip_lin
     // dispatches into the analyzer path — same as the installed shim.
     let mut child = Command::new(canboat_path())
         .arg0("analyzer")
+        .args(C_SHAPE)
         .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())


### PR DESCRIPTION
The Rust binaries emitted spaced field names and canboat's humanized units by
default. Every JSON consumer downstream wants the opposite: canboatjs'
`FromPgn` defaults to `useCamel: true`, does no unit conversion at all, and
emits each record flat — so the whole Signal K stack has always read flat
camelCase + SI, and had to ask for it every time.

This flips the defaults and replaces the canboat C flag spellings with three
orthogonal ones, shared by `convert`, the `analyzer` shim and `server` via one
`ShapeArgs` in `canboat-cli` so they can't drift:

| flag | values | default |
|---|---|---|
| `--id` | `spaces` / `camel` / `uppercamel` | `camel` |
| `--units` | `si` / `metric` | `si` |
| `--wrap` | — | off |

`--camel`, `--upper-camel` and `--si` still work, warn on stderr, and conflict
with their replacements. **canboat C's output is `--id spaces --units metric`.**

### The wrapper is now its own flag

canboat C ties `{"<pgnId>":{…}}` nesting to `-camel`. Here it is `--wrap`, so
the default is the flat record canboatjs emits; `--camel` / `--upper-camel`
still imply it, keeping existing command lines byte-identical.

### Three things this broke, and how they're fixed

All three inferred "camelCase field keys" from the presence of the wrapper,
which stops being true once camel is the default:

- **`from_json` / `snapshot`** — added `analyzer_json::uses_camel_keys` key
  sniffing. Without it `analyzer --json | n2kd` silently dropped every field.
- **The TUI** — keys every reader by human field name and only un-camelized
  *wrapped* records, so a default `server` would have left it showing entries
  with no fields. `normalize_camel` now rekeys flat records too.
- **Golden tests** — now pass `--id spaces --units metric`. Those fixtures are
  canboat C's own output; comparing against C is their whole point.

### Two related fixes that fell out

- **`convert --to json` emits the version banner** (`--no-banner` to suppress),
  closing the header half of the post-merge follow-up. `n2kd` reads `"units"`
  off that line; without it a bannerless stream is assumed Metric, so this
  converter's radians would have been read as degrees.
- **`convert --from json` reads bare values against the *input's* banner**, not
  `--units`. Before, a canboat C `"units":"std"` stream fed to a default
  convert had heading 210.9° re-encoded as 210.9 rad — valid bits, no error.
  `--units` is now only the assumption for a bannerless stream, which makes the
  pair a unit converter:

  ```
  $ canboat convert --units metric < hdg.raw | canboat convert --from json
  {"version":…,"units":"si",…}
  {…,"fields":{"sid":0,"heading":3.6809,"reference":"Magnetic"}}
  ```

### Library surface

`CamelCase::default()` is now `Lower`, `Units::default()` is now `Si`, and
`BridgeConfig`'s `camel` / `upper_camel` / `si` bools become typed
`camel_case: CamelCase`, `units: Units`, `wrap: bool`. The TUI pins the human
shape (spaced names, metric) explicitly rather than following the defaults.

### Testing

24 test targets green; `CANBOAT_GOLDEN=required` passes all 15 goldens; clippy
clean. `make pr` reports no database-contract change (nothing under
`database/` is touched). Verified on live sockets, not only in tests: default
`server` serves flat camel + an SI banner, `server --camel` still serves the
id-keyed wrapped snapshot, and `convert --nv | n2kd --nmea0183` yields
`$ADMWV,43.0,R,10.8,K*33` from an SI stream.

### Note for review

Text output follows `--units` too, so a bare `analyzer` now prints
`Wind Angle = 0.0000 rad` where it used to print `0.0 deg`. One default for
both output modes is the simplest rule, but keeping text on metric is a small
conditional if you'd rather.

BREAKING CHANGE: `canboat convert`, the `analyzer` shim and `canboat server`
now emit camelCase field keys and SI units by default, and no longer wrap
records under their PGN id when camelCase is active. Pass
`--id spaces --units metric` for the previous output. `--camel`,
`--upper-camel` and `--si` are deprecated. In the library,
`CamelCase::default()` is `Lower`, `Units::default()` is `Si`, and
`BridgeConfig`'s `camel` / `upper_camel` / `si` fields are replaced by
`camel_case` / `units` / `wrap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)