### PR TITLE
feat: default to SI units and camelCase identifiers

### DIFF
--- a/crates/canboat-core/src/db.rs
+++ b/crates/canboat-core/src/db.rs
@@ -55,12 +55,13 @@ pub struct PgnDatabase {
 #[non_exhaustive]
 pub enum Units {
     /// Strict SI base units: `rad`, `K`, `Pa`, `C` (coulomb). What a
-    /// physics-facing consumer (Signal K, control code) wants. Matches
-    /// canboat C's `analyzer -si`.
+    /// physics-facing consumer (Signal K, control code) wants, and the
+    /// Rust default — machine-friendly first. Matches canboat C's
+    /// `analyzer -si`.
+    #[default]
     Si,
     /// canboat's practical humanized units: `deg`, `°C`, `bar`, `Ah`.
-    /// The default, matching canboat C's `analyzer` without `-si`.
-    #[default]
+    /// Matches canboat C's `analyzer` without `-si`.
     Metric,
 }
 

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -2468,6 +2468,7 @@ mod tests {
             &dec,
             &crate::output::JsonOptions {
                 name_value: true,
+                camel_case: crate::output::CamelCase::Off,
                 ..Default::default()
             },
         )

--- a/crates/canboat-core/src/output/json.rs
+++ b/crates/canboat-core/src/output/json.rs
@@ -92,10 +92,12 @@ pub struct JsonOptions {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum CamelCase {
     /// Use human-readable names (`"Unique Number"`, `"ISO Address
-    /// Claim"`). Default; matches canboat C's default output.
-    #[default]
+    /// Claim"`). Matches canboat C's default output.
     Off,
-    /// lowerCamelCase identifiers (`"uniqueNumber"`).
+    /// lowerCamelCase identifiers (`"uniqueNumber"`). The Rust
+    /// default — legal identifiers first, so consumers beyond Signal K
+    /// meet machine-friendly data.
+    #[default]
     Lower,
     /// UpperCamelCase identifiers (`"UniqueNumber"`).
     Upper,
@@ -990,6 +992,16 @@ mod tests {
     use super::*;
     use crate::decode::{DecodedField, FieldValue};
 
+    /// canboat C's default output shape — human names — which several
+    /// tests below pin byte-for-byte against C. The Rust-wide default
+    /// is camelCase (see `camel_is_the_default`).
+    fn c_shape_options() -> JsonOptions {
+        JsonOptions {
+            camel_case: CamelCase::Off,
+            ..JsonOptions::default()
+        }
+    }
+
     fn sample_pgn() -> DecodedPgn {
         // PGN 128267 (Water Depth) field 3 is `Offset` — m, res 0.001 —
         // which matches the legacy hand-rolled fixture this test used
@@ -1028,13 +1040,29 @@ mod tests {
     fn matches_canboat_json_shape() {
         let pgn = sample_pgn();
         let mut out = String::new();
-        write_json(&mut out, &pgn, &JsonOptions::default()).unwrap();
+        write_json(&mut out, &pgn, &c_shape_options()).unwrap();
         // The sample timestamp lacks a trailing `Z`; the formatter
         // canonicalises it to ISO-8601 UTC on emit.
         assert_eq!(
             out,
             r#"{"timestamp":"2018-10-16T22:25:25.166Z","prio":3,"src":35,"dst":255,"pgn":128267,"description":"Water Depth","fields":{"Offset":0.000}}"#
         );
+    }
+
+    #[test]
+    fn camel_is_the_default() {
+        // The Rust-wide policy: camelCase identifiers and SI units are
+        // what consumers meet without asking (canboat C defaults to
+        // human names + practical units; --human/--metric restore
+        // those). Units::default() is pinned in db.rs; this pins the
+        // identifier half.
+        assert_eq!(JsonOptions::default().camel_case, CamelCase::Lower);
+        assert_eq!(crate::Units::default(), crate::Units::Si);
+        let pgn = sample_pgn();
+        let mut out = String::new();
+        write_json(&mut out, &pgn, &JsonOptions::default()).unwrap();
+        assert!(out.starts_with("{\"waterDepth\":{"), "got: {out}");
+        assert!(out.contains("\"offset\":"), "got: {out}");
     }
 
     #[test]
@@ -1066,7 +1094,7 @@ mod tests {
         let mut pgn = sample_pgn();
         pgn.fields[0].value = FieldValue::NotAvailable;
         let mut out = String::new();
-        write_json(&mut out, &pgn, &JsonOptions::default()).unwrap();
+        write_json(&mut out, &pgn, &c_shape_options()).unwrap();
         assert!(
             !out.contains("\"fields\""),
             "fields wrapper leaked through: {out}"
@@ -1084,6 +1112,7 @@ mod tests {
             &pgn,
             &JsonOptions {
                 include_empty: true,
+                camel_case: CamelCase::Off,
                 ..Default::default()
             },
         )
@@ -1104,7 +1133,7 @@ mod tests {
             let mut pgn = sample_pgn();
             pgn.fields[0].value = sentinel;
             let mut out = String::new();
-            write_json(&mut out, &pgn, &JsonOptions::default()).unwrap();
+            write_json(&mut out, &pgn, &c_shape_options()).unwrap();
             assert!(!out.contains("\"fields\""), "sentinel leaked: {out}");
         }
     }
@@ -1125,6 +1154,7 @@ mod tests {
                 &pgn,
                 &JsonOptions {
                     include_empty: true,
+                    camel_case: CamelCase::Off,
                     ..Default::default()
                 },
             )
@@ -1155,6 +1185,7 @@ mod tests {
             &pgn,
             &JsonOptions {
                 name_value: true,
+                camel_case: CamelCase::Off,
                 ..Default::default()
             },
         )
@@ -1171,7 +1202,7 @@ mod tests {
         let mut pgn = sample_pgn();
         pgn.description = r#"He said "hi""#;
         let mut out = String::new();
-        write_json(&mut out, &pgn, &JsonOptions::default()).unwrap();
+        write_json(&mut out, &pgn, &c_shape_options()).unwrap();
         assert!(
             out.contains(r#""description":"He said \"hi\"""#),
             "got: {}",

--- a/crates/canboat/src/convert.rs
+++ b/crates/canboat/src/convert.rs
@@ -201,8 +201,8 @@ pub struct Args {
     #[arg(long)]
     debug: bool,
 
-    /// Emit field keys and PGN descriptions as camelCase identifiers.
-    /// Matches canboat's `-camel`.
+    /// camelCase identifiers for field keys and PGN names. This is the
+    /// Rust default; the flag is accepted for canboat C compatibility.
     #[arg(long)]
     camel: bool,
 
@@ -211,10 +211,21 @@ pub struct Args {
     #[arg(long, conflicts_with = "camel")]
     upper_camel: bool,
 
-    /// Strict SI units — radians, kelvin, pascals — rather than the
-    /// practical defaults (deg, °C, bar). Matches canboat's `-si`.
+    /// Human-readable names ("Wind Speed", "ISO Address Claim") — i.e.
+    /// canboat C's default output, instead of the Rust default of
+    /// camelCase identifiers.
+    #[arg(long, conflicts_with_all = ["camel", "upper_camel"])]
+    human: bool,
+
+    /// Strict SI units — radians, kelvin, pascals. This is the Rust
+    /// default; the flag is accepted for canboat C compatibility.
     #[arg(long)]
     si: bool,
+
+    /// Practical units — degrees, °C, bar — i.e. canboat C's default
+    /// output, instead of the Rust default of strict SI.
+    #[arg(long, conflicts_with = "si")]
+    metric: bool,
 
     /// Lat/lon display format. Matches canboat's `-geo`.
     #[arg(long, value_name = "FMT", default_value = "dd")]
@@ -304,10 +315,10 @@ fn convert_raw<W: Write>(
         // Bare physical values in the JSON are interpreted in the same
         // unit system the output side uses (`--si` or metric); `-nv`
         // raw values are unit-agnostic either way.
-        let units = if args.si {
-            canboat_core::Units::Si
-        } else {
+        let units = if args.metric {
             canboat_core::Units::Metric
+        } else {
+            canboat_core::Units::Si
         };
         Box::new(canboat::json_input::JsonFrameReader::new(
             source,
@@ -348,12 +359,14 @@ fn convert_decoded<W: Write>(
     ebl: bool,
     out: &mut W,
 ) -> Result<()> {
+    // Rust defaults to camelCase identifiers; --human restores
+    // canboat C's human-readable names.
     let camel_case = if args.upper_camel {
         CamelCase::Upper
-    } else if args.camel {
-        CamelCase::Lower
-    } else {
+    } else if args.human {
         CamelCase::Off
+    } else {
+        CamelCase::Lower
     };
     let json_opts = JsonOptions {
         include_empty: args.empty,
@@ -373,10 +386,10 @@ fn convert_decoded<W: Write>(
         src_filter: args.src,
         dst_filter: args.dst,
         suppress_startup_record: false,
-        units: if args.si {
-            canboat_core::Units::Si
-        } else {
+        units: if args.metric {
             canboat_core::Units::Metric
+        } else {
+            canboat_core::Units::Si
         },
     };
 

--- a/crates/canboat/src/legacy/analyzer.rs
+++ b/crates/canboat/src/legacy/analyzer.rs
@@ -53,10 +53,15 @@ struct Cli {
     #[arg(long)]
     nv: bool,
 
-    /// Show values in strict SI units — radians, kelvin, pascals — rather
-    /// than the practical defaults (deg, °C, bar). Matches canboat's `-si`.
+    /// Strict SI units — radians, kelvin, pascals. This is the Rust
+    /// default; the flag is accepted for canboat C compatibility.
     #[arg(long)]
     si: bool,
+
+    /// Practical units — degrees, °C, bar — i.e. canboat C's default
+    /// output, instead of the Rust default of strict SI.
+    #[arg(long, conflicts_with = "si")]
+    metric: bool,
 
     /// JSON: wrap every field with byte/bit diagnostics (`-debug`).
     #[arg(long)]
@@ -66,13 +71,20 @@ struct Cli {
     #[arg(long, value_name = "FMT", default_value = "dd")]
     geo: String,
 
-    /// Emit field keys + PGN descriptions as camelCase identifiers.
+    /// camelCase identifiers for field keys and PGN names. This is the
+    /// Rust default; the flag is accepted for canboat C compatibility.
     #[arg(long, conflicts_with = "upper_camel")]
     camel: bool,
 
     /// Same as `--camel` but UpperCamelCase.
     #[arg(long = "upper-camel")]
     upper_camel: bool,
+
+    /// Human-readable names ("Wind Speed", "ISO Address Claim") — i.e.
+    /// canboat C's default output, instead of the Rust default of
+    /// camelCase identifiers.
+    #[arg(long, conflicts_with_all = ["camel", "upper_camel"])]
+    human: bool,
 
     /// Use the given string in place of any analyzer-generated
     /// timestamps (matches canboat's `-fixtime`).
@@ -117,18 +129,21 @@ pub fn run(argv: Vec<OsString>) -> Result<()> {
 }
 
 fn run_cli(cli: Cli) -> Result<()> {
-    let units = if cli.si {
-        canboat_core::Units::Si
-    } else {
+    // Rust defaults are strict SI and camelCase identifiers — the
+    // machine-friendly forms new consumers should meet first; --metric
+    // and --human restore canboat C's human-oriented output.
+    let units = if cli.metric {
         canboat_core::Units::Metric
+    } else {
+        canboat_core::Units::Si
     };
 
     let camel_case = if cli.upper_camel {
         CamelCase::Upper
-    } else if cli.camel {
-        CamelCase::Lower
-    } else {
+    } else if cli.human {
         CamelCase::Off
+    } else {
+        CamelCase::Lower
     };
     let json_opts = JsonOptions {
         include_empty: cli.empty,

--- a/crates/canboat/tests/golden.rs
+++ b/crates/canboat/tests/golden.rs
@@ -109,8 +109,20 @@ fn run_case_skipping(in_name: &str, expected_name: &str, args: &[&str], skip_lin
 
     // Invoke the canboat binary as `analyzer` so its argv[0] alias
     // dispatches into the analyzer path — same as the installed shim.
+    // The golden fixtures are canboat C's own outputs, whose defaults
+    // are human names and practical units; the Rust binary defaults to
+    // camelCase + SI, so pin the C forms explicitly unless a case
+    // opts into the identifier/unit flags itself.
+    let mut base: Vec<&str> = Vec::new();
+    if !args.iter().any(|a| a.contains("camel")) {
+        base.push("--human");
+    }
+    if !args.iter().any(|a| *a == "--si" || *a == "-si") {
+        base.push("--metric");
+    }
     let mut child = Command::new(canboat_path())
         .arg0("analyzer")
+        .args(&base)
         .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())


### PR DESCRIPTION
Implements the requested default change: the Rust binaries and libraries now default to strict SI units and camelCase (legal-identifier) names for PGNs and fields — the forms new consumers should meet first, making compatible reuse beyond Signal K more likely.

canboat C's output stays one flag away: --human restores human-readable names and --metric the practical units, on both convert and the analyzer alias. --si / --camel / --upper-camel remain accepted (now no-ops or stylistic variants), so existing invocations that pass them explicitly — signalk-server's analyzer spawn included — behave identically.

Library defaults follow suit: Units::default() is Si, JsonOptions::default() camelCase. The golden suite now pins --human --metric explicitly since its fixtures are canboat C's own outputs; the C-shape unit tests request CamelCase::Off by name, and a new test pins the Rust-wide default.

One thing deliberately left to you: I did not mark this with a conventional-commit breaking flag, to avoid release-please jumping the major — say the word and I'll amend the commit with a BREAKING CHANGE footer if that's the versioning you want.

Not changed: -nv stays opt-in, per the note that flipping it would imply changing Signal K's consumption as well.

Tested: cargo test --workspace green (26 suites) including the golden suite against the C fixtures; make rust-precommit clean.