### PR TITLE
fix(encode): absent repeating-list count encodes as zero

### DIFF
--- a/crates/canboat/src/json_input.rs
+++ b/crates/canboat/src/json_input.rs
@@ -223,27 +223,10 @@ fn stage_fields(
                 .map_err(|e| anyhow!("{key}: {e}"))?;
         }
     }
-    // canboatjs writes an *unavailable* count when a record carries
-    // neither the count field nor its list; the builder would otherwise
-    // auto-fill 0. Match canboatjs so re-encodes stay bit-identical.
-    let info = builder.pgn_info();
-    for (set_key, count_order) in [
-        ("list", info.repeating_field_set1_count_field),
-        ("list2", info.repeating_field_set2_count_field),
-    ] {
-        let Some(order) = count_order else { continue };
-        let Some(count_field) = info.fields.get(order as usize - 1) else {
-            continue;
-        };
-        if !fields.contains_key(set_key)
-            && !fields.contains_key(count_field.id)
-            && !fields.contains_key(count_field.name)
-        {
-            builder
-                .push_by_name(count_field.name, EncodeValue::NotAvailable)
-                .map_err(|e| anyhow!("{}: {e}", count_field.name))?;
-        }
-    }
+    // A record carrying neither the count field nor its list encodes
+    // a count of zero — the builder's auto-fill. canboat#812 settled
+    // this: zero over the unavailable sentinel (canboatjs writes
+    // unavailable; that difference is canboatjs-side now).
     Ok(())
 }
 


### PR DESCRIPTION
Implements the #812 ruling on the last open fill convention: a JSON record carrying neither a repeating-list count field nor its list now encodes the count as zero — the builder's natural auto-fill — instead of the unavailable sentinel the driver staged to match canboatjs. Reserved all-ones and STRING_FIX 0xff were confirmed as-is in the same issue, so with this the Rust encoder follows the settled convention on all three points and the remaining byte differences against canboatjs are canboatjs-side.

Tested: cargo test --workspace green, make rust-precommit clean.

Closes #812.