### PR TITLE
fix(decode): apply the range-derived sentinels to hints-less number fields

### DIFF
--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -79,7 +79,21 @@ fn range_max_sentinel(f: &FieldInfo, ex: Extracted, bits: u32) -> Option<FieldVa
         return None;
     }
     let raw_max = (1u64 << bits) - 1;
-    let raw_range_max = (range_max / resolution + 0.5) as u64;
+    // `rangeMax` is stated in DISPLAY units, so both display shifts have
+    // to come off before it can be compared against the raw bit-width
+    // maximum: the schema's `offset` (J1939 Excess-K: raw 0 reads
+    // 233 K) and the unit conversion the Metric schema variant applies
+    // on top of it (the same field's range is 485 K in SI and
+    // 209.85 C in Metric — both raw 252). Dropping either term makes
+    // the range look wider than the field can hold, the check bails
+    // out, and the all-ones "not available" pattern decodes as a real
+    // reading where the C prints Unknown.
+    let display_offset = f.offset.map(|o| o as f64).unwrap_or(0.0);
+    let raw_range_max_f = (range_max - display_offset - f.unit_offset) / resolution + 0.5;
+    if raw_range_max_f < 0.0 {
+        return None;
+    }
+    let raw_range_max = raw_range_max_f as u64;
     if raw_range_max >= raw_max {
         return None;
     }
@@ -1336,6 +1350,19 @@ fn decode_number(
         return FieldValue::NotAvailable;
     };
     if let Some(sent) = sentinel_field_value(f, ex) {
+        return sent;
+    }
+    // No explicit hints in the schema: fall back to the range-derived
+    // check. The C resolves `reservedCount` for every number field from
+    // `rangeMax` against the raw bit-width maximum
+    // (`extractNumberNotEmpty`), whether or not per-field hints exist,
+    // so a field carrying only a range — every J1939 definition — must
+    // get the same treatment here.
+    //
+    // Unsigned only: for a signed field the all-ones pattern is -1, a
+    // legitimate reading the C prints as such, and the comparison below
+    // is against the *unsigned* raw.
+    if !effective_signed && let Some(sent) = range_max_sentinel(f, ex, bit_length) {
         return sent;
     }
     let resolution = f.resolution.unwrap_or(1.0);

--- a/crates/canboat/tests/golden.rs
+++ b/crates/canboat/tests/golden.rs
@@ -126,13 +126,18 @@ fn run_case_skipping(in_name: &str, expected_name: &str, args: &[&str], skip_lin
         .stderr(Stdio::piped())
         .spawn()
         .expect("spawn analyzer");
-    child
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(&input)
-        .expect("write stdin");
+    // Feed stdin from its own thread: a fixture whose decoded output
+    // exceeds the pipe buffer (~64 KiB) deadlocks otherwise — the child
+    // blocks writing stdout that nobody drains while this thread blocks
+    // writing stdin that the child is not reading. Only the J1939
+    // fixture is currently large enough to hit it.
+    let mut stdin = child.stdin.take().expect("stdin piped");
+    let writer = std::thread::spawn(move || {
+        stdin.write_all(&input).expect("write stdin");
+        // Drop closes the pipe, signalling EOF to the analyzer.
+    });
     let out = child.wait_with_output().expect("wait analyzer");
+    writer.join().expect("stdin writer thread");
     assert!(
         out.status.success(),
         "analyzer exited with {:?}\nstderr: {}",
@@ -298,6 +303,7 @@ fn short_frame_text_debug() {
 /// anomalous-Reserved text rendering (`Reserved = FC` on ECU #2).
 /// candump pretty lines carry no timestamps, so `--fixtime` supplies
 /// the fixture's stamp.
+///
 #[test]
 fn j1939_candump_text() {
     run_case(


### PR DESCRIPTION
Closes #823.

canboat C resolves `reservedCount` for **every** number field from `rangeMax` against the raw bit-width maximum (`extractNumberNotEmpty`, print.c), whether or not the schema carries explicit per-field sentinel hints. The Rust decoder only consulted the hints, so a field carrying just a range decoded its all-ones "not available" pattern as a real reading where the C prints `Unknown`:

```
  can0  18FEEE00   [8]  3E FF FF FF FF FF FF FF      # J1939 PGN 65262

C   : Engine Coolant Temp = 22 C; Engine Fuel Temp 1 = Unknown; ...
Rust: Engine Coolant Temp = 22 C; Engine Fuel Temp 1 = 215 C;   ...
```

The range-derived check already existed as `range_max_sentinel` but was reachable only from one 32-bit call site. Two corrections were needed before it could be used generally:

- **Display shifts.** `rangeMax` is in display units, so both have to come off before comparing against the raw maximum — the schema `offset` (J1939 Excess-K: raw 0 reads 233 K) *and* the unit conversion the Metric variant applies on top. The same field's range is 485 K in SI and 209.85 C in Metric, both raw 252; dropping either term makes the range look wider than the field can hold and the check bails out. This is why a per-field `rangeMax` authored in one unit system cannot fix it — the value has to come from the per-variant schema, which keel already emits correctly.
- **Signedness.** The fallback is unsigned-only: for a signed field the all-ones pattern is -1, a legitimate reading the C prints as such, and the comparison is against the unsigned raw. (Visible on the `PERCENTAGE_INT8` fields in the same PGN.)

### Test harness deadlock

The golden harness wrote the child's stdin from the test thread while nothing drained its stdout, so any fixture whose decoded output exceeds the pipe buffer (~64 KiB) hung forever. No existing fixture was large enough to trigger it; the J1939 candump fixture is. Stdin now goes out on its own thread.

### Tested

`CANBOAT_GOLDEN=required cargo test --workspace`: 24 suites, **16/16 goldens**, zero failures — no NMEA 2000 output changes from the shared-decoder change. `make rust-precommit` clean. Verified directly against the C binary on the J1939 fixture in both unit systems.