### PR TITLE
test(overrides): give each test engine its own temp file

### DIFF
--- a/crates/canboat-bridge/src/n2kd/overrides.rs
+++ b/crates/canboat-bridge/src/n2kd/overrides.rs
@@ -404,9 +404,38 @@ mod tests {
     const NAME_A: u64 = 0x0004_0000_1066_7913;
     const NAME_B: u64 = 0x0004_0000_0761_9208;
 
+    /// Each engine gets its own file. Tests call `save()` for real, so a
+    /// shared path would let concurrently-running tests clobber each other,
+    /// and a PID-only name would collide across repeated `cargo test` runs.
+    struct TempPath(PathBuf);
+
+    impl Drop for TempPath {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
+    thread_local! {
+        static TEMP_PATHS: std::cell::RefCell<Vec<TempPath>> =
+            const { std::cell::RefCell::new(Vec::new()) };
+    }
+
+    fn temp_path() -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "cb-ov-test-{}-{}.json",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        // Held until the test thread ends, then removed.
+        TEMP_PATHS.with(|p| p.borrow_mut().push(TempPath(path.clone())));
+        path
+    }
+
     fn engine() -> OverrideEngine {
         OverrideEngine {
-            path: std::env::temp_dir().join(format!("cb-ov-test-{}.json", std::process::id())),
+            path: temp_path(),
             src_name: [None; 256],
             rules: HashMap::new(),
             replayed: HashMap::new(),


### PR DESCRIPTION
The override tests call `save()` for real, so each engine writes to disk. They all shared a single path built from the PID:

```rust
path: std::env::temp_dir().join(format!("cb-ov-test-{}.json", std::process::id())),
```

Nothing ever removed that file, so `/tmp` accumulated one `cb-ov-test-<pid>.json` per distinct PID — 65 of them on my machine. Where `/tmp` is a tmpfs that is RAM which is not reclaimed until reboot. Sharing one path across engines also means concurrently running tests can clobber each other's state.

Each engine now gets a unique path from the PID plus an atomic counter, with a `Drop` guard that removes the file when the test thread ends.

`first_sight_replays_overrides_to_current_src` builds two engines, but the second copies `rules` in memory and never reads the first one's file, so per-engine paths do not change its behaviour.

Tested: `cargo test -p canboat-bridge` passes (77 tests) and leaves no files behind in `/tmp`; `cargo fmt --check` and `cargo clippy --all-targets` are clean.