### PR TITLE
ci: run the C test suite on every PR, and stop dropping loop failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
       - name: make
         run: make
 
+      # The C regression suite (analyzer, actisense-serial, candump2analyzer)
+      # ran only from release.yaml, so a decode regression stayed invisible
+      # until release day. Gate it on every PR instead.
+      - name: make tests
+        run: make tests
+
       - name: make generated
         run: make generated
 

--- a/Makefile
+++ b/Makefile
@@ -145,14 +145,14 @@ man/man1:
 	$(MKDIR) man/man1
 
 clean:
-	for dir in $(SUBDIRS); do $(MAKE) -C $$dir clean; done
+	for dir in $(SUBDIRS); do $(MAKE) -C $$dir clean || exit 1; done
 	$(MAKE) -C dbc-exporter clean
 	-rm -R -f man $(BUILDDIR)
 
 install: $(BUILDDIR)/analyzer $(DESTDIR)$(BINDIR) $(DESTDIR)$(MANDIR)/man1
-	for i in $(BUILDDIR)/* util/*; do install -m $(EXEC_MOD) -b $$i $(DESTDIR)$(BINDIR); done
+	for i in $(BUILDDIR)/* util/*; do install -m $(EXEC_MOD) -b $$i $(DESTDIR)$(BINDIR) || exit 1; done
 ifeq ($(notdir $(HELP2MAN)),help2man)
-	for i in man/man1/*; do echo $$i; install -m $(ROOT_MOD) $$i $(DESTDIR)$(MANDIR)/man1; done
+	for i in man/man1/*; do echo $$i; install -m $(ROOT_MOD) $$i $(DESTDIR)$(MANDIR)/man1 || exit 1; done
 endif
 
 format:


### PR DESCRIPTION
Follow-up to #838, which turned up two gaps in how the build is gated.

## The PR gate never ran the C tests

`make tests` appears in exactly one place — `release.yaml:24`. So analyzer's 22 golden-output cases, plus the `actisense-serial` and `candump2analyzer` suites, have never been a pull-request gate. A decode regression could merge cleanly and stay invisible until release day.

`build-ubuntu` now runs it between `make` and `make generated`.

## The build *was* gated, but couldn't fail

To answer the obvious question: yes, the PR gate builds the C code, on three platforms — `build-ubuntu` (`make`), `build-armv7-musl` (`make`), `build-windows` (`make -C …`).

The problem was that those steps could not fail. `compile` looped over `SUBDIRS` discarding each subdirectory's exit status:

```make
for dir in $(SUBDIRS); do $(MAKE) -C $$dir; done
```

Only the last subdirectory (`replay`) could break the build; `analyzer` is 2nd of 11. That's not theoretical — it is exactly what happened in #838, where `analyzer-j1939` failed to compile, the error was printed, and `make tests` exited **0**.

#838 fixed that one loop because it had to. The same bug is still in `clean` and in both `install` loops, where a failed `install` silently ships a missing binary. This PR guards all three with `|| exit 1`.

## Verification

Broke `analyzer/lookup.c` on purpose and ran a full build:

```
make with broken analyzer = 2    (want non-zero; used to be 0)
```

Then restored it and confirmed a clean cycle from scratch:

```
make clean && make   -> 0
make tests           -> 0
make clean           -> 0   (guard doesn't break teardown)
```

`tools/contract-pr.sh` — no contract change.

## Since when

Neither gap is an 8.0.0 regression; both are considerably older.

**The swallowed loop dates to the initial import** — `1f4b56d`, *"Add sources from closed source subversion repository to open source git tree"*, **2012-04-03**. It arrived in the first Makefile:

```make
SUBDIRS= analyzer n2kd nmea0183
	for dir in $(SUBDIRS); do $(MAKE) -C $$dir; done
```

`analyzer` was already first in the list, so its build failures were never propagated — not once in the 14 years since.

**CI has never run the C suite.** `ci.yml` was created by `0c6ec1d` *"chore: minimal test"*, **2022-12-26**, running exactly three steps: `make`, `make generated`, `git diff --exit-code`. That is still the shape today. There was no Travis/CircleCI/AppVeyor before it.

The single exception: the cygwin job ran `make tests` for **two days** in June 2023 — added in `5153d90` (2023-06-19), removed in `15a2a20` (2023-06-21) with the message *"Do not run cygwin tests yet"*.

What is true is that `make tests` has run from `release.yaml` since `c13406c` (2023-06-21), so the suite has been exercised at release time — just never as a merge gate.

## Still open, deliberately not in this PR

`analyzer-j1939` has **no test coverage at all**. `analyzer/tests/j1939-pgn-test.in` and `.out` exist but no rule in `analyzer/tests/Makefile` references them, and the harness only defines `ANALYZER=$(TARGETDIR)/analyzer`. The fixture also isn't reproducible as-is: its input is timestamp-less candump format, so every line of the expected output carries the wall-clock instant it was generated (`2023-12-10T18:58:21.487Z`). Wiring it up means regenerating the golden file under `-fixtime`, which deserves its own review — happy to do that next.

Worth knowing now because #838 changed which manufacturer table that binary compiles against, and PR 3 of #837 will change its contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
