### PR TITLE
ci: gate keel check, so the database validates its own samples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,14 @@ jobs:
       - name: make tests
         run: make tests
 
+      # keel's rule set - R01..R23 plus R40, which decodes every `samples:`
+      # entry in database/ and compares it against its `expects:` - was only
+      # ever run by hand. `keel generate` does not run it, so a database that
+      # decodes its own samples wrongly still built, tested and generated
+      # cleanly. Gate it before the artifacts are generated from that source.
+      - name: keel check
+        run: keel/keel check
+
       - name: make generated
         run: make generated
 


### PR DESCRIPTION
Follow-up to #839, and a guard worth having in place before PR 3 of #837 rewrites a large part of the database.

## The gap

`keel check` is invoked **nowhere** — not by any Makefile target, not by any workflow. `make generated` calls `keel generate`, which goes straight to emitting artifacts; `check` is a separate subcommand that runs the rule set.

So every keel rule has been unenforced, including **R40**, which decodes all **553 `samples:` lines across 218 PGNs** and compares each against its `expects:`. That's the regression suite for the PGN database — the part of this repo that is hardest to get right and easiest to break silently.

## Demonstrated, not assumed

I broke one sample expectation on purpose and ran the full automated build:

```
keel check      -> 3 errors, exit 1
make tests      -> exit 0
make generated  -> exit 0
```

A database that decodes its own recorded samples wrongly built, tested and generated cleanly, and would have passed the entire CI matrix.

Not hypothetical either: **20 stale sample expectations in #840** were caught only because I happened to run `keel check` by hand. Nothing would have stopped them merging.

## The change

One step in `build-ubuntu`, placed **before** `make generated` so the source is validated before artifacts are derived from it:

```yaml
- name: keel check
  run: keel/keel check
```

Verified `keel check` exits **1** on failure and **0** when clean — the shim ends in `exec "$BIN" "$@"`, so the status propagates.

No new toolchain requirement: the same job already builds keel through the shim when it runs `make generated`. This only moves that build one step earlier.

## What it now enforces

R01 well-formed objects · R02 PGN ranges · R03–R06 lengths and repeats · R07 proprietary layout · R08/R22 lookup wiring · R09 sentinels · R11–R15 field rules · R20/R21 variant distinguishability and id uniqueness · R23 fieldtype hierarchy · **R40 sample decodes**.

Run `keel rules` for the full inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)