### PR TITLE
ci: fold the release re-stamp into release-please's own commit

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,11 +63,39 @@ jobs:
       - name: re-stamp Cargo.lock
         run: cargo update --workspace
 
+      # Fold the regenerated files into release-please's own commit rather than
+      # adding a second one.
+      #
+      # release-please pushes a bumped Cargo.toml with a stale Cargo.lock, so
+      # every `cargo --locked` job starts failing within seconds - well before
+      # this job can push a fix. A measured cycle: release commit at 07:46:06,
+      # Rust CI red at 07:46:48, fix pushed at 07:47:18. The workflows' own
+      # cancel-in-progress cannot help, because the doomed run is already over
+      # by the time the second push arrives.
+      #
+      # Amending moves the branch head, so the PR's checks are those of the
+      # corrected commit and the transient red is no longer attached to it. It
+      # also keeps the release history at one commit instead of trailing a
+      # "chore: regenerate" every time.
+      #
+      # Only ever amends release-please's own commit; anything else gets a
+      # normal commit, so a hand-pushed change to the release branch is never
+      # rewritten.
       - name: commit regenerated files
         run: |
-          if ! git diff --exit-code; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git commit -am "chore: regenerate docs/*, canboat.dbc and Cargo.lock for release"
-            git push
+          if git diff --quiet; then
+            echo "nothing regenerated"
+            exit 0
           fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          case "$(git log -1 --format=%s)" in
+            "chore: release "*)
+              git commit -a --amend --no-edit
+              git push --force-with-lease
+              ;;
+            *)
+              git commit -am "chore: regenerate docs/*, canboat.dbc and Cargo.lock for release"
+              git push
+              ;;
+          esac


### PR DESCRIPTION
Every release cycle turns the release PR red for about a minute, then heals itself. This removes the red.

## What happens today

release-please pushes a bumped `Cargo.toml` with a **stale `Cargo.lock`** — it bumps the workspace version but doesn't know it must re-stamp the lockfile's member entries. Every `cargo --locked` job then refuses:

```
error: cannot update the lock file /home/runner/work/canboat/canboat/Cargo.lock because --locked was passed to prevent this
```

The `regenerate` job already fixes this — but it cannot win the race. Measured on the current 8.1.0-beta2 PR (#821):

```
07:46:06   chore: release 8.1.0-beta2      Cargo.lock stale
07:46:10   Rust CI starts
07:46:48   Rust CI FAILS                   38s — --locked errors immediately
07:47:18   regenerate pushes the fix       30 seconds too late
```

Six Rust jobs go red across three platforms (`test` ×3, `clippy`, `docs`, `msrv`).

**`cancel-in-progress` can't save it.** Both workflows already have it, and in that same cycle it worked — for the slow one. The `CI` run was **cancelled** when the second push arrived; `Rust CI` had already **finished failing** 30 seconds earlier. A workflow that fails in 38 seconds is never around to be cancelled.

## The change

Amend release-please's commit instead of adding a second one:

```sh
case "$(git log -1 --format=%s)" in
  "chore: release "*) git commit -a --amend --no-edit; git push --force-with-lease ;;
  *)                  git commit -am "chore: regenerate …"; git push ;;
esac
```

The branch head moves, so the PR's checks become those of the corrected commit and the transient failure is no longer attached to it. It also keeps the release history at **one** commit instead of trailing a `chore: regenerate docs/*, canboat.dbc and Cargo.lock for release` every cycle.

Two safety properties:

- **Only release-please's own commit is amended.** Anything else takes the normal path, so a hand-pushed change to the release branch is never rewritten.
- **The no-change case is an explicit `git diff --quiet` test**, not `git diff --exit-code &&`. Under GitHub's `bash -e` the latter risks aborting the step precisely when there *is* work to do.

## Verification

The step's shell was rehearsed against a throwaway remote in all three states:

| state | result |
|---|---|
| release commit + regenerated files | **amended** — 2 commits, head still `chore: release 8.1.0-beta2` |
| non-release commit + changes | **new commit** — safe fallback |
| nothing regenerated | no-op, exits 0 |

Workflow YAML re-parsed to confirm the step list is intact.

## What this does not do

The doomed run still *starts* and still appears once in the Actions tab; it is simply no longer attached to the PR. Preventing it outright would mean making release-please emit a correct `Cargo.lock` in its first commit, which `release-type: simple` has no mechanism for — the alternative is switching to the `rust` release type, a much larger change to how this mostly-C repo releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)