### PR TITLE
revert: fold the release re-stamp into release-please's own commit

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,39 +63,11 @@ jobs:
       - name: re-stamp Cargo.lock
         run: cargo update --workspace
 
-      # Fold the regenerated files into release-please's own commit rather than
-      # adding a second one.
-      #
-      # release-please pushes a bumped Cargo.toml with a stale Cargo.lock, so
-      # every `cargo --locked` job starts failing within seconds - well before
-      # this job can push a fix. A measured cycle: release commit at 07:46:06,
-      # Rust CI red at 07:46:48, fix pushed at 07:47:18. The workflows' own
-      # cancel-in-progress cannot help, because the doomed run is already over
-      # by the time the second push arrives.
-      #
-      # Amending moves the branch head, so the PR's checks are those of the
-      # corrected commit and the transient red is no longer attached to it. It
-      # also keeps the release history at one commit instead of trailing a
-      # "chore: regenerate" every time.
-      #
-      # Only ever amends release-please's own commit; anything else gets a
-      # normal commit, so a hand-pushed change to the release branch is never
-      # rewritten.
       - name: commit regenerated files
         run: |
-          if git diff --quiet; then
-            echo "nothing regenerated"
-            exit 0
+          if ! git diff --exit-code; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -am "chore: regenerate docs/*, canboat.dbc and Cargo.lock for release"
+            git push
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          case "$(git log -1 --format=%s)" in
-            "chore: release "*)
-              git commit -a --amend --no-edit
-              git push --force-with-lease
-              ;;
-            *)
-              git commit -am "chore: regenerate docs/*, canboat.dbc and Cargo.lock for release"
-              git push
-              ;;
-          esac


### PR DESCRIPTION
Reverts #843. **My change made things worse — it should come out before the next release.**

## What went wrong

#843 amended release-please's commit and force-pushed, so the transient `--locked` failure would no longer be attached to the PR. That part worked: the release PR is now a single commit with a correct `Cargo.lock`.

But **a force-push by the bot does not deliver a `pull_request` synchronize event**, so nothing gated on `pull_request` runs on the corrected head. Measured on the live 8.1.0-beta2 PR (#821):

| head | how it was made | workflow runs | check-runs |
|---|---|---|---|
| `3013acf` | separate commit (old behaviour) | **5** | **16** |
| `708d3bc` | amended + force-pushed (#843) | **1** | **1** |

The single survivor is `PR Title`, which triggers on `pull_request_target`. `CI`, `Rust CI`, `Upward compatibility` and `Autofix` never ran.

Ruled out:

- **Not lag** — still 1 run six minutes after the push, versus the old style where all 5 appeared immediately.
- **Not the GITHUB_TOKEN suppression rule** — `RELEASE_PLEASE_TOKEN` is configured, and the same bot identity pushing a *normal* commit did trigger all five runs.

A release PR that can merge with **one** check is a worse outcome than one that goes red for a minute and heals itself. Taking the red back.

## ⚠️ #821 is currently under-tested

Its head `708d3bc` carries only `validate-pr-title`. **Don't merge it as-is.** Once this revert lands, any push to master will refresh the release PR through the old path and restore the full 16 checks. Alternatively, closing and reopening #821 forces a `synchronize` and re-runs everything.

## The original complaint still stands

release-please writes a bumped `Cargo.toml` with a stale `Cargo.lock`, and `cargo build --workspace --locked` fails within ~38 seconds — too fast for `cancel-in-progress` to catch, which is why only the Rust jobs go red while the slower `CI` run gets cancelled cleanly.

Repairing it *after* the fact can't win that race. A real fix has to put a correct `Cargo.lock` in release-please's **first** commit, which `release-type: simple` has no mechanism for. The realistic options are switching to the `rust` release type, or teaching the config to update `Cargo.lock`'s member entries directly — both bigger changes than this was, and worth deciding deliberately rather than as a CI tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)