### PR TITLE
fix(rust): satisfy clippy 1.98's chunks_exact_to_as_chunks

### DIFF
--- a/crates/canboat-core/src/format/candump.rs
+++ b/crates/canboat-core/src/format/candump.rs
@@ -179,7 +179,9 @@ fn parse_log(line: &str) -> Result<RawFrame, ParseError> {
             offset: None,
         });
     }
-    for (i, pair) in bytes.chunks_exact(2).enumerate() {
+    // `as_chunks` rather than `chunks_exact`: the length parity was checked
+    // above, so the remainder is always empty (clippy::chunks_exact_to_as_chunks).
+    for (i, pair) in bytes.as_chunks::<2>().0.iter().enumerate() {
         let s = std::str::from_utf8(pair).map_err(|_| ParseError::BadHexByte {
             index: i,
             value: data_part.to_string(),


### PR DESCRIPTION
Rust 1.98 added [`clippy::chunks_exact_to_as_chunks`](https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#chunks_exact_to_as_chunks), which is warn-by-default and therefore an **error** under the Rust CI job's `-D warnings`.

There is exactly one site in the workspace, and the result is that **every PR opened since 1.98 shipped fails `Rust Clippy` regardless of what it changes** — master is red for this reason alone, not because of anything in those PRs. (Example: #853, a one-line database fix, fails Clippy.)

```
error: using `chunks_exact` with a constant chunk size
   --> crates/canboat-core/src/format/candump.rs:182:28
    |
182 |     for (i, pair) in bytes.chunks_exact(2).enumerate() {
    |                            ^^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks::<2>().0.iter()`
```

## The change

Switch to `as_chunks::<2>()`, exactly as the lint suggests. `bytes.len()` parity is validated a few lines above, so the remainder half of the returned tuple is always empty and behaviour is unchanged.

## Verification

- Reproduced with a real `clippy 0.1.98`: unfixed → exit 101 with the error above; with this change → `cargo clippy --workspace --all-targets --locked -- -D warnings` exits 0 across the whole workspace.
- `cargo test -p canboat-core` passes, including the guards this change relies on: `rejects_odd_hex_in_log_payload` and `rejects_can_fd_payloads`.
- `as_chunks` was stabilised in Rust **1.88**, which is the workspace MSRV, so this does not move the floor — confirmed by checking the workspace against a real 1.88 toolchain.

## Note

`build-windows` is failing separately on a Chocolatey 504/503 while fetching Cygwin 3.6.9. That's an upstream flake, unrelated to this change, and clears on a re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal parsing of candump log payloads while preserving existing behavior.
  * No user-visible changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->