### PR TITLE
chore: fix the PR template's database steps and collapse generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,3 +19,21 @@ samples/** -text
 # break the golden-file comparison.
 analyzer/tests/mixed-format.in    -text
 analyzer/tests/recombine-frames.in -text
+
+# Generated artifacts. The database is authored as YAML under database/ and
+# these files are produced from it by `keel generate` / `make generated`; they
+# are committed, and CI (build-ubuntu) regenerates and diffs them to enforce
+# lockstep. Marking them linguist-generated keeps GitHub's "Files changed" view
+# from burying the one-line database edit that caused them under megabytes of
+# collapsed regeneration, and keeps them out of the repo's language stats.
+#
+# NOTE: analyzer/pgn.h is NOT generated - it is hand-authored source. Only the
+# *-generated-data.h files below come out of keel.
+docs/canboat.xml                                  linguist-generated=true
+docs/canboat.json                                 linguist-generated=true
+docs/canboat.html                                 linguist-generated=true
+docs/canboat.dbc                                  linguist-generated=true
+analyzer/*-generated-data.h                       linguist-generated=true
+crates/canboat-core/src/schema_generated.rs       linguist-generated=true
+crates/canboat-core/src/schema_generated_j1939.rs linguist-generated=true
+crates/canboat-io/src/fastpacket_generated.rs     linguist-generated=true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,9 +9,37 @@
 
 
 
+<!--
+  CHANGING THE PGN DATABASE? The database is a YAML tree - edit it there, never
+  in the generated files:
+
+    1. database/pgns/<pgn:06>-<id>.yaml   (or database/lookups/, database/j1939/)
+       or run  keel/keel edit  for a local web editor
+    2. keel/keel check                    validates the tree
+    3. make generated                     regenerates docs/*, docs/canboat.dbc,
+                                          analyzer/*-generated-data.h and the
+                                          Rust schema_generated.rs
+    4. commit the regenerated files IN THE SAME COMMIT
+
+  docs/canboat.{xml,json,html,dbc}, analyzer/*-generated-data.h and
+  *_generated*.rs are OUTPUT. Editing them by hand will be undone by the next
+  regeneration, and the build-ubuntu gate (which regenerates and diffs) fails.
+
+  Those files are marked linguist-generated, so GitHub collapses them in the
+  "Files changed" view - your actual database edit is the YAML file.
+
+  Branches in this repo get regenerated automatically by the "Autofix generated
+  files" workflow if you forget. FORK PRs ARE NOT AUTO-FIXED - run
+  `make generated` yourself or build-ubuntu will fail.
+
+  See AGENTS.md for the full workflow.
+-->
+
 ## Checklist
 
 - [ ] PR **title** follows Conventional Commits (`feat` / `fix` / … — see [CONTRIBUTING.md](../CONTRIBUTING.md))
-- [ ] If I changed the PGN database (`analyzer/*.h`), I ran `make generated` and committed the regenerated `docs/` and `dbc-exporter/` files
+- [ ] If I changed the PGN database, I edited the **YAML under `database/`** (not the generated files) and `keel/keel check` passes
+- [ ] I ran `make generated` and committed the regenerated files in the same commit
 - [ ] Tests pass (`make tests`)
+- [ ] I ran `make pr` and acted on its contract report (mark the title `type!:` if it reports a breaking change)
 - [ ] New or changed decodes are backed by a real capture (added to `samples/`) or public documentation


### PR DESCRIPTION
Two small contributor-experience fixes, both prompted by #853.

## 1. The PR template's database checklist was stale

It still read:

> - [ ] If I changed the PGN database (`analyzer/*.h`), I ran `make generated` and committed the regenerated `docs/` and `dbc-exporter/` files

That predates the keel refactor and is wrong in three ways:

- the database is now a **YAML tree under `database/`**, not `analyzer/*.h`
- `analyzer/*-generated-data.h` are **output**, not source
- `dbc-exporter/` contains no generated artifacts at all — it's the exporter's own source; the DBC lands in `docs/canboat.dbc`

Anyone following it literally would hand-edit generated files and fail the `build-ubuntu` gate.

Replaced with the actual workflow — edit YAML → `keel/keel check` → `make generated` → commit the artifacts in the same commit — as a comment block in the template body, so it's visible while writing the PR. Also added:

- an explicit note that **fork PRs are not covered by the Autofix workflow** (this bites external contributors, and the failure mode is a confusing `build-ubuntu` red)
- a `make pr` checklist item, so the contract report doesn't get skipped

## 2. Generated files marked `linguist-generated`

In #853 the real change was a **one-line** edit to `database/pgns/065020-generatorPhaseCAcPower.yaml`. But in the Files-changed view it sat here:

```
analyzer/pgn-generated-data.h
crates/canboat-core/src/schema_generated.rs        ~5.6 MB  "Large diffs are not rendered by default"
database/pgns/065020-generatorPhaseCAcPower.yaml   ← the actual change, 1 line
docs/canboat.dbc
docs/canboat.html
docs/canboat.json                                  large
docs/canboat.xml                                   ~2.3 MB  "Large diffs are not rendered by default"
```

— easy to scroll past and conclude the YAML was never updated. Marking the ten generated artifacts collapses them by default, so the database edit is what you actually see, and keeps them out of the repo's language statistics.

They remain committed and still gated: `build-ubuntu` regenerates and diffs them, so nothing about the lockstep enforcement changes.

## Verification

`git check-attr linguist-generated` confirms the patterns cover exactly the keel outputs and nothing else:

- **marked** (10): `docs/canboat.{xml,json,html,dbc}`, `analyzer/*-generated-data.h` (5 files), `schema_generated.rs`, `schema_generated_j1939.rs`, `fastpacket_generated.rs`
- **not marked**: `analyzer/pgn.h` (hand-authored, *not* generated), `analyzer/analyzer.c`, the `database/**/*.yaml` sources, `docs/canboat.xsd`, `docs/canboat.xsl`
- `docs/canboat.dbc` keeps its existing `-text` binary handling (`git check-attr text` → `unset`), so `make generated` still produces no spurious CRLF diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the pull request checklist with clearer database change instructions, validation steps, generated-file requirements, and breaking-change checks.
  * Clarified the expected workflow for editing configuration files and regenerating related documentation and source files.

* **Chores**
  * Improved repository file classification so generated documentation and source files are identified correctly in GitHub language statistics and displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->