### PR TITLE
feat(quirk): correct dates from a GPS that missed the week rollover

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,25 @@ The remaining C converters, the helper scripts in `util/` (PHP, perl and ksh)
 and the Python tooling will most likely move to Rust in time; the C `n2kd` and
 `n2kd_monitor` already have, and were removed in v8.
 
+## Device quirks
+
+Some devices misbehave in ways CANboat can cover for. Each workaround is a
+named *quirk*, and every one of them is **off by default** — they all rewrite
+or invent data, so you switch on the ones you need:
+
+| Quirk | What it does | Where |
+| --- | --- | --- |
+| `gps-rollover` | Corrects GNSS dates from a receiver that never learned about the GPS 1024-week rollover and reports one or two epochs in the past (PGN 129029, 129033, and 126992 when its source is GPS) | `analyzer -quirk gps-rollover`, `canboat convert --quirk gps-rollover`, `canboat server --quirk gps-rollover` |
+| `scx20` | Answers a PGN 59904 request for a Furuno SCX-20's Product Information on its behalf, so the Furuno Setting Tool can find it | `canboat server --quirk scx20` (needs `--socketcan`) |
+| `wmm` | Computes magnetic variation locally with WMM 2025 and emits its own PGN 127258, asking older-WMM sources to stop | `canboat server --quirk wmm` |
+| `motion` | Impersonates a B&G H5000 Motion Sensor so a Navico Hercules accepts an SCX-20 | `canboat server --quirk motion` (needs `--socketcan`) |
+
+`gps-rollover` is the odd one out: it corrects a decoded value rather than
+putting a frame on the bus, which is why it is available when decoding a
+capture file too. Do not use it on a capture made before April 2019 — it
+cannot tell a rolled-over date from a genuinely old one, and will move the
+whole log forward twenty years.
+
 ## The library
 
 The decoder is also a set of Rust crates, so you can embed NMEA 2000 handling

--- a/analyzer/analyzer.c
+++ b/analyzer/analyzer.c
@@ -161,6 +161,7 @@ static void usage(char **argv, char **av)
 {
   printf("Unknown or invalid argument %s\n", av[0]);
   printf("Usage: %s [[-raw] [-json [-empty] [-nv] [-camel]] [-data] [-debug] [-d] [-q] [-si] [-geo {dd|dm|dms}] "
+         "[-quirk gps-rollover] "
          "-format <fmt> "
          "[-src <src> | -dst <dst> | <pgn>]] ["
 #ifndef SKIP_SETSYSTEMCLOCK
@@ -178,6 +179,10 @@ static void usage(char **argv, char **av)
   printf("     -geo dd           Print geographic format in dd.dddddd format\n");
   printf("     -geo dm           Print geographic format in dd.mm.mmm format\n");
   printf("     -geo dms          Print geographic format in dd.mm.sss format\n");
+  printf("     -quirk gps-rollover\n");
+  printf("                       Correct GNSS dates from a receiver that never handled the GPS week rollover\n");
+  printf("                       and reports one or two 1024-week epochs in the past. Off by default; do not\n");
+  printf("                       use it when replaying a capture made before April 2019.\n");
 #ifndef SKIP_SETSYSTEMCLOCK
   printf("     -clocksrc         Set the systemclock from time info from this NMEA source address\n");
 #endif
@@ -261,6 +266,19 @@ int main(int argc, char **argv)
       else if (strcasecmp(av[2], "dms") == 0)
       {
         showGeo = GEO_DMS;
+      }
+      else
+      {
+        usage(argv, av + 1);
+      }
+      ac--;
+      av++;
+    }
+    else if (ac > 2 && strcasecmp(av[1], "-quirk") == 0)
+    {
+      if (strcasecmp(av[2], "gps-rollover") == 0)
+      {
+        g_quirkGpsRollover = true;
       }
       else
       {

--- a/analyzer/analyzer.h
+++ b/analyzer/analyzer.h
@@ -106,6 +106,7 @@ extern GeoFormats   showGeo;
 extern char        *sep;
 extern char         closingBraces[16]; // } and ] chars to close sentence in JSON mode, otherwise empty string
 extern bool         g_skip;
+extern bool         g_quirkGpsRollover; // -quirk gps-rollover: correct dates from a pre-2019 GPS receiver
 extern const Field *g_ftf;
 extern int64_t      g_length;
 extern bool         g_lengthValid; // true once a DYNAMIC_FIELD_LENGTH set g_length (so a length of 0 means "empty", not "unknown")

--- a/analyzer/print.c
+++ b/analyzer/print.c
@@ -1387,7 +1387,10 @@ extern bool fieldPrintDate(const Field   *field,
 
   d = correctGpsRollover(field, msg, msgLen, d);
 
-  t  = d * 86400;
+  // Widen before multiplying: d * 86400 overflows a 32-bit int from
+  // 2038-01-19 onwards, and the sentinel check above lets d run to
+  // 0xfffc = 2149-06-03.
+  t  = (time_t) d * 86400;
   tm = gmtime(&t);
   if (!tm)
   {

--- a/analyzer/print.c
+++ b/analyzer/print.c
@@ -29,6 +29,7 @@ limitations under the License.
 extern int g_variableFieldRepeat[2]; // Actual number of repetitions
 bool       g_skip;
 int64_t    g_previousFieldValue;
+bool       g_quirkGpsRollover; // -quirk gps-rollover; see correctGpsRollover()
 
 static bool unhandledStartOffset(const char *fieldName, size_t startBit)
 {
@@ -1258,6 +1259,92 @@ extern bool fieldPrintTime(const Field   *field,
   return true;
 }
 
+/*
+ * One GPS rollover epoch: the week number is 10 bits counted from
+ * 1980-01-06, so it wraps every 1024 weeks = 7168 days (1999-08-22,
+ * 2019-04-07, next 2038-11-21). A receiver resolves the wrap with a
+ * base week from its firmware build date; one that was never updated
+ * keeps a base that is one -- or, if it also missed 1999, two -- epochs
+ * stale and reports dates that far in the past. Only the week number
+ * wraps, so the time of day is right and the fix is a whole number of
+ * epochs.
+ */
+#define GPS_ROLLOVER_DAYS (7168u)
+/* Largest day count that is a date rather than a sentinel: 2149-06-03. */
+#define MAX_DATE_DAY (0xfffcu)
+/*
+ * Floor for "today": a boat computer without an RTC comes up believing
+ * it is 1970 and gets its clock *from* the GPS we are correcting, so
+ * the system clock alone is not a usable reference. 2026-01-01.
+ */
+#define MIN_REFERENCE_DAY (20454u)
+
+/*
+ * Snap a rolled-over date to the epoch nearest today -- which is what
+ * the receiver's own base-week logic does, so it handles a doubly stale
+ * receiver and the 2038 rollover without a code change.
+ *
+ * Only dates from a GNSS receiver on our own bus are touched: 129029,
+ * 129033, and 126992 when its source is GPS. The AIS reports carry
+ * another station's clock and the remaining DATE fields (Maretron
+ * counters, route database entries, station data) are not receiver
+ * clocks at all. `msg`/`msgLen` are the whole message, before
+ * adjustDataLenStart() moved the caller's pointer to the field.
+ */
+static uint16_t correctGpsRollover(const Field *field, const uint8_t *msg, size_t msgLen, uint16_t d)
+{
+  int64_t  source;
+  uint64_t today;
+  uint32_t reference;
+  uint32_t behind;
+  uint32_t epochs;
+  uint32_t corrected;
+
+  if (!g_quirkGpsRollover || field->pgn == NULL)
+  {
+    return d;
+  }
+
+  switch (field->pgn->pgn)
+  {
+    case 129029: // GNSS Position Data
+    case 129033: // Time & Date
+      break;
+
+    case 126992: // System Time, but only when Source (field 2) is GPS.
+      // GLONASS counts weeks from its own epoch; radio station and the
+      // local cesium/rubidium/crystal clocks do not roll over at all.
+      if (!extractNumberByOrder(field->pgn, 2, msg, msgLen, &source) || source != 0)
+      {
+        return d;
+      }
+      break;
+
+    default:
+      return d;
+  }
+
+  today     = (uint64_t) time(NULL) / 86400;
+  reference = (today > UINT16_MAX) ? UINT16_MAX : (uint32_t) today;
+  if (reference < MIN_REFERENCE_DAY)
+  {
+    reference = MIN_REFERENCE_DAY;
+  }
+
+  behind = (reference > d) ? reference - d : 0;
+  epochs = (behind + GPS_ROLLOVER_DAYS / 2) / GPS_ROLLOVER_DAYS;
+  if (epochs == 0)
+  {
+    return d;
+  }
+  corrected = d + epochs * GPS_ROLLOVER_DAYS;
+  if (corrected > MAX_DATE_DAY)
+  {
+    return d;
+  }
+  return (uint16_t) corrected;
+}
+
 extern bool fieldPrintDate(const Field   *field,
                            const char    *fieldName,
                            const uint8_t *data,
@@ -1265,10 +1352,12 @@ extern bool fieldPrintDate(const Field   *field,
                            size_t         startBit,
                            size_t        *bits)
 {
-  char       buf[sizeof("2008.03.10") + 1];
-  time_t     t;
-  struct tm *tm;
-  uint16_t   d;
+  char           buf[sizeof("2008.03.10") + 1];
+  time_t         t;
+  struct tm     *tm;
+  uint16_t       d;
+  const uint8_t *msg    = data;
+  size_t         msgLen = dataLen;
 
   if (!adjustDataLenStart(&data, &dataLen, &startBit))
   {
@@ -1295,6 +1384,8 @@ extern bool fieldPrintDate(const Field   *field,
     printEmpty(fieldName, d - INT64_C(0xffff));
     return true;
   }
+
+  d = correctGpsRollover(field, msg, msgLen, d);
 
   t  = d * 86400;
   tm = gmtime(&t);

--- a/analyzer/tests/invalid-pgn-test.out
+++ b/analyzer/tests/invalid-pgn-test.out
@@ -1,1 +1,1 @@
-2011-11-24T22:42:04.388Z 3  36 255 126992 System Time:  SID = 240 (bytes = "F0"); Source = GLONASS (bytes = "01", bits = "0001"); Reserved = 00 (bytes = "00", bits = "0000"); Date = 1985.04.17 (bytes = "00 D8"); Time = 57:05:02.8508 (bytes = "1C 3F 7D 7A")
+2011-11-24T22:42:04.388Z 3  36 255 126992 System Time:  SID = 240 (bytes = "F0"); Source = GLONASS (bytes = "01", bits = "0001"); Reserved = 00 (bytes = "00", bits = "0000"); Date = 2121.05.25 (bytes = "00 D8"); Time = 57:05:02.8508 (bytes = "1C 3F 7D 7A")

--- a/crates/canboat-bridge/src/server/bridge.rs
+++ b/crates/canboat-bridge/src/server/bridge.rs
@@ -124,7 +124,7 @@ impl Bridge {
                 let name = match kind {
                     quirks::QuirkKind::Scx20 => "scx20",
                     quirks::QuirkKind::Motion => "motion",
-                    quirks::QuirkKind::Wmm => unreachable!(),
+                    quirks::QuirkKind::Wmm | quirks::QuirkKind::GpsRollover => unreachable!(),
                 };
                 anyhow::bail!(
                     "--quirk {name} only works with --socketcan; it claims/impersonates \

--- a/crates/canboat-bridge/src/server/mod.rs
+++ b/crates/canboat-bridge/src/server/mod.rs
@@ -190,7 +190,9 @@ pub struct Args {
     ///
     /// `scx20` and `motion` impersonate/claim a device and need
     /// `--socketcan`; `wmm` emits canboat's own PGN and works with any
-    /// writable backend (socketcan / NGT-1 / iKonvert).
+    /// writable backend (socketcan / NGT-1 / iKonvert);
+    /// `gps-rollover` only rewrites decoded dates and needs no backend
+    /// at all.
     #[arg(long, value_enum, value_name = "NAME")]
     quirk: Vec<quirks::QuirkKind>,
 

--- a/crates/canboat-bridge/src/server/quirks/mod.rs
+++ b/crates/canboat-bridge/src/server/quirks/mod.rs
@@ -80,9 +80,14 @@ pub struct Quirks {
 impl Quirks {
     pub fn new(kinds: Vec<QuirkKind>) -> Self {
         // Not a frame emitter: it flips a switch in the decoder and
-        // has no state of its own here.
+        // has no state of its own here. The switch is process-wide --
+        // `decode()` takes no options -- so set it both ways, or a
+        // pipeline built without the quirk would inherit it from an
+        // earlier one in the same process.
         if kinds.contains(&QuirkKind::GpsRollover) {
             canboat_core::quirk::enable_gps_rollover();
+        } else {
+            canboat_core::quirk::disable_gps_rollover();
         }
         Self {
             scx20: kinds.contains(&QuirkKind::Scx20).then(scx20::Scx20::new),
@@ -122,13 +127,30 @@ impl Quirks {
 mod tests {
     use super::*;
 
+    /// `Quirks::new` writes the process-wide GPS rollover switch, so the
+    /// tests that call it must not run concurrently with each other.
+    static SWITCH: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn enabled_reflects_configured_quirks() {
+        let _guard = SWITCH.lock().unwrap_or_else(|e| e.into_inner());
         assert!(!Quirks::new(vec![]).is_enabled());
         assert!(Quirks::new(vec![QuirkKind::Scx20]).is_enabled());
         assert!(Quirks::new(vec![QuirkKind::Wmm]).is_enabled());
         let both = Quirks::new(vec![QuirkKind::Scx20, QuirkKind::Wmm]);
         assert!(both.is_enabled());
         assert!(both.scx20.is_some() && both.wmm.is_some());
+    }
+
+    /// The GPS rollover switch lives in the decoder, which is
+    /// process-wide, so a second pipeline that did not ask for it must
+    /// not inherit it from the first.
+    #[test]
+    fn gps_rollover_does_not_leak_into_the_next_pipeline() {
+        let _guard = SWITCH.lock().unwrap_or_else(|e| e.into_inner());
+        let _first = Quirks::new(vec![QuirkKind::GpsRollover]);
+        assert!(canboat_core::quirk::gps_rollover_reference_day().is_some());
+        let _second = Quirks::new(vec![QuirkKind::Wmm]);
+        assert!(canboat_core::quirk::gps_rollover_reference_day().is_none());
     }
 }

--- a/crates/canboat-bridge/src/server/quirks/mod.rs
+++ b/crates/canboat-bridge/src/server/quirks/mod.rs
@@ -25,6 +25,12 @@
 //!   own PGN 127258, plus ask older-WMM sources to stop. It emits
 //!   canboat's *own* node (no impersonation), so it works with any
 //!   writable backend. Lives in [`wmm`].
+//!
+//! A third kind is not a frame emitter at all: `GpsRollover` corrects a
+//! decoded date in place, and lives in [`canboat_core::quirk`] so that
+//! a plain `canboat convert` over a capture gets it too. [`Quirks::new`]
+//! just switches it on there; [`Quirks::process_decoded`] never sees
+//! it.
 
 pub mod motion;
 pub mod scx20;
@@ -52,6 +58,12 @@ pub enum QuirkKind {
     /// present, so a Navico Hercules accepts it. Needs to claim a new
     /// device, so needs socketcan.
     Motion,
+    /// Correct GNSS dates from a receiver that never learned about the
+    /// GPS 1024-week rollover and reports one or two epochs in the
+    /// past. Rewrites the decoded value (see
+    /// [`canboat_core::quirk`]); nothing is written to the bus, and no
+    /// particular backend is needed.
+    GpsRollover,
 }
 
 /// Stateful side of the quirk machinery. Owned by the pipeline; lives
@@ -67,6 +79,11 @@ pub struct Quirks {
 
 impl Quirks {
     pub fn new(kinds: Vec<QuirkKind>) -> Self {
+        // Not a frame emitter: it flips a switch in the decoder and
+        // has no state of its own here.
+        if kinds.contains(&QuirkKind::GpsRollover) {
+            canboat_core::quirk::enable_gps_rollover();
+        }
         Self {
             scx20: kinds.contains(&QuirkKind::Scx20).then(scx20::Scx20::new),
             wmm: kinds.contains(&QuirkKind::Wmm).then(wmm::WmmQuirk::new),

--- a/crates/canboat-cli/src/lib.rs
+++ b/crates/canboat-cli/src/lib.rs
@@ -16,8 +16,10 @@
 use std::env;
 use std::ffi::OsString;
 
+pub mod quirk;
 pub mod shape;
 
+pub use quirk::{DecodeQuirk, QuirkArgs};
 pub use shape::{IdStyle, ShapeArgs, UnitSystem};
 
 /// The canboat copyright line and schema version, extracted from

--- a/crates/canboat-cli/src/quirk.rs
+++ b/crates/canboat-cli/src/quirk.rs
@@ -1,0 +1,52 @@
+// (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
+
+//! The shared `--quirk` flag for the binaries that decode a stream:
+//! `canboat convert`, `canboat interface` and the `analyzer` shim.
+//!
+//! These are the *decode-time* quirks from [`canboat_core::quirk`] —
+//! corrections applied to a decoded value. `canboat server` has its own
+//! `--quirk` covering the same names plus the bus-side quirks that emit
+//! frames (`scx20`, `wmm`, `motion`).
+//!
+//! Every quirk is off by default: each one will happily "correct" data
+//! that was never wrong, which is exactly what happens when you replay
+//! an old capture.
+
+use canboat_core::quirk;
+
+/// Decode-time quirks a stream-reading binary can switch on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum DecodeQuirk {
+    /// Correct dates from a GPS receiver that never learned about the
+    /// 1024-week rollover and reports one or two epochs in the past.
+    GpsRollover,
+}
+
+impl DecodeQuirk {
+    /// Switch this quirk on in `canboat-core`.
+    pub fn enable(self) {
+        match self {
+            DecodeQuirk::GpsRollover => quirk::enable_gps_rollover(),
+        }
+    }
+}
+
+/// The `--quirk` flag itself, `#[command(flatten)]`ed into a parser.
+#[derive(Debug, Clone, Default, clap::Args)]
+pub struct QuirkArgs {
+    /// Enable a decode-time device quirk (repeatable). `gps-rollover`
+    /// corrects GNSS dates from a receiver that never handled the GPS
+    /// week rollover. Off by default — do not use it when replaying a
+    /// capture made before April 2019.
+    #[arg(long = "quirk", value_enum, value_name = "QUIRK")]
+    pub quirk: Vec<DecodeQuirk>,
+}
+
+impl QuirkArgs {
+    /// Apply every requested quirk. Call once, before decoding starts.
+    pub fn apply(&self) {
+        for q in &self.quirk {
+            q.enable();
+        }
+    }
+}

--- a/crates/canboat-core/src/decode.rs
+++ b/crates/canboat-core/src/decode.rs
@@ -562,7 +562,10 @@ impl PgnDatabase {
             .pick_variant(frame)
             .ok_or(DecodeError::UnknownPgn { pgn: frame.pgn })?;
 
-        let (fields, has_repeating_set) = decode_fields(info, &frame.data, self)?;
+        let (mut fields, has_repeating_set) = decode_fields(info, &frame.data, self)?;
+        // Opt-in device-quirk corrections (GPS week rollover); a no-op
+        // — one relaxed atomic load — unless a quirk was switched on.
+        crate::quirk::apply(frame.pgn, &mut fields);
         let index_by_order = build_index_by_order(&fields);
 
         Ok(DecodedPgn {

--- a/crates/canboat-core/src/lib.rs
+++ b/crates/canboat-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod frame;
 pub mod from_json;
 pub mod os;
 pub mod output;
+pub mod quirk;
 pub mod reassembly;
 mod schema_data;
 mod schema_data_j1939;

--- a/crates/canboat-core/src/quirk.rs
+++ b/crates/canboat-core/src/quirk.rs
@@ -1,0 +1,250 @@
+// (C) 2009-2026, Kees Verruijt, Harlingen, The Netherlands.
+
+//! Opt-in corrections for known device misbehaviour, applied at decode
+//! time.
+//!
+//! This is the sans-I/O half of canboat's quirk machinery. The quirks in
+//! `canboat-bridge` *emit* synthetic frames onto the bus; the ones here
+//! *rewrite* a decoded value in place, so they also apply to a plain
+//! `canboat convert` run over a capture file — which is where a broken
+//! date is usually first noticed.
+//!
+//! Every quirk is off by default and switched on explicitly, because
+//! every one of them will happily "correct" data that was never wrong.
+//!
+//! ## GPS week rollover
+//!
+//! The GPS week number is 10 bits counted from the 1980-01-06 epoch, so
+//! it wraps every 1024 weeks (7168 days): 1999-08-22, 2019-04-07, and
+//! next on 2038-11-21. A receiver resolves the wrap by carrying a base
+//! week from its firmware build date; one that was never updated keeps
+//! using a base that is now one (or, for a receiver that also missed
+//! 1999, two) epochs stale and reports dates that far in the past. Only
+//! the week number wraps, so the time of day is unaffected and the
+//! correction is a whole number of epochs.
+//!
+//! [`corrected_gps_date`] therefore does not just add 7168 days: it
+//! snaps the reported date to the epoch nearest a reference day, which
+//! is what a receiver's own base-week logic does. That covers a
+//! doubly-stale receiver today, and the 2038 rollover without a code
+//! change.
+
+use std::sync::atomic::{AtomicU16, Ordering};
+
+use crate::decode::{DecodedField, FieldValue};
+
+/// One GPS rollover epoch: 1024 weeks, in days.
+pub const GPS_ROLLOVER_DAYS: u16 = 7168;
+
+/// Largest day count that is still a date rather than a sentinel
+/// (0xfffd..=0xffff are Unknown / Out-of-range / Reserved) — 2149-06-03.
+const MAX_DATE_DAY: u32 = 0xfffc;
+
+/// Floor for the reference day used by [`enable_gps_rollover`]:
+/// 2026-01-01. A boat computer without an RTC comes up believing it is
+/// 1970 and gets its clock *from* the GPS we are correcting, so the
+/// system clock alone is not a usable reference. Snapping to the nearest
+/// epoch tolerates a reference that is off by up to ~9.8 years, so this
+/// only ever needs revisiting long after the 2038 rollover.
+const MIN_REFERENCE_DAY: u16 = 20454;
+
+/// Reference day for the GPS rollover quirk, as days since 1970-01-01.
+/// Zero means the quirk is off — no other value can mean that, since
+/// day 0 is 1970-01-01 and every real reference is decades later.
+static GPS_ROLLOVER_REFERENCE: AtomicU16 = AtomicU16::new(0);
+
+/// Turn the GPS week rollover quirk on, taking the reference day from
+/// the system clock (floored at [`MIN_REFERENCE_DAY`]).
+pub fn enable_gps_rollover() {
+    enable_gps_rollover_at(today().max(MIN_REFERENCE_DAY));
+}
+
+/// Turn the quirk on with an explicit reference day (days since
+/// 1970-01-01). Mainly for tests and for a host that knows better than
+/// the system clock what day it is.
+pub fn enable_gps_rollover_at(reference_day: u16) {
+    GPS_ROLLOVER_REFERENCE.store(reference_day, Ordering::Relaxed);
+}
+
+/// Turn the quirk off again.
+pub fn disable_gps_rollover() {
+    GPS_ROLLOVER_REFERENCE.store(0, Ordering::Relaxed);
+}
+
+/// The reference day in force, or `None` when the quirk is off.
+pub fn gps_rollover_reference_day() -> Option<u16> {
+    match GPS_ROLLOVER_REFERENCE.load(Ordering::Relaxed) {
+        0 => None,
+        d => Some(d),
+    }
+}
+
+/// Today as days since 1970-01-01, or 0 if the clock predates the epoch.
+fn today() -> u16 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| (d.as_secs() / 86400).min(u16::MAX as u64) as u16)
+        .unwrap_or(0)
+}
+
+/// Snap `days` (days since 1970-01-01) to the GPS rollover epoch nearest
+/// `reference_day`.
+///
+/// Returns `days` unchanged when it is already within half an epoch of
+/// the reference, and when the correction would run into the sentinel
+/// range.
+pub fn corrected_gps_date(days: u16, reference_day: u16) -> u16 {
+    let behind = u32::from(reference_day).saturating_sub(u32::from(days));
+    let epoch = u32::from(GPS_ROLLOVER_DAYS);
+    let epochs = (behind + epoch / 2) / epoch;
+    if epochs == 0 {
+        return days;
+    }
+    let corrected = u32::from(days) + epochs * epoch;
+    if corrected > MAX_DATE_DAY {
+        return days;
+    }
+    corrected as u16
+}
+
+/// PGN 126992 System Time `Source` value for GPS. GLONASS (1) counts
+/// weeks from its own epoch and the remaining sources — radio station,
+/// local cesium / rubidium / crystal — do not roll over at all.
+const SYSTEM_TIME_SOURCE_GPS: u64 = 0;
+
+/// Rewrite the date fields of a decoded PGN in place when the GPS
+/// rollover quirk is on.
+///
+/// Only dates that came from a GNSS receiver on our own bus are
+/// touched: 129029 GNSS Position Data, 129033 Time & Date, and 126992
+/// System Time when its source is GPS. The AIS reports carry another
+/// station's clock, and the remaining DATE fields in the database
+/// (Maretron counters, route database entries, tide/current station
+/// data) are not receiver clocks at all.
+pub(crate) fn apply(pgn: u32, fields: &mut [DecodedField]) {
+    if let Some(reference_day) = gps_rollover_reference_day() {
+        apply_at(pgn, fields, reference_day);
+    }
+}
+
+/// [`apply`] with an explicit reference day, independent of the global
+/// switch — the testable half.
+fn apply_at(pgn: u32, fields: &mut [DecodedField], reference_day: u16) {
+    match pgn {
+        129029 | 129033 => {}
+        126992 => {
+            let source_is_gps = fields
+                .iter()
+                .find(|f| f.id() == "source")
+                .and_then(|f| f.value.lookup_value())
+                .is_some_and(|v| v == SYSTEM_TIME_SOURCE_GPS);
+            if !source_is_gps {
+                return;
+            }
+        }
+        _ => return,
+    }
+    for f in fields.iter_mut() {
+        if let FieldValue::Date(days) = f.value {
+            f.value = FieldValue::Date(corrected_gps_date(days, reference_day));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Days since 1970-01-01 for a date, the long way round, so the
+    /// expectations below read as dates rather than as magic numbers.
+    fn day(y: i32, m: u32, d: u32) -> u16 {
+        // Days from civil date, Howard Hinnant's algorithm.
+        let y = if m <= 2 { y - 1 } else { y };
+        let era = y.div_euclid(400);
+        let yoe = (y - era * 400) as u32;
+        let mp = (m + 9) % 12;
+        let doy = (153 * mp + 2) / 5 + d - 1;
+        let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+        (era as i64 * 146097 + doe as i64 - 719468) as u16
+    }
+
+    #[test]
+    fn one_epoch_behind_is_corrected() {
+        // The example from SignalK/n2k-signalk#271.
+        let reported = day(2002, 11, 18);
+        let reference = day(2022, 7, 4);
+        assert_eq!(corrected_gps_date(reported, reference), day(2022, 7, 4));
+    }
+
+    #[test]
+    fn two_epochs_behind_is_corrected() {
+        // A receiver that missed the 1999 rollover as well as 2019.
+        let reference = day(2026, 8, 29);
+        let reported = reference - 2 * GPS_ROLLOVER_DAYS;
+        assert_eq!(corrected_gps_date(reported, reference), reference);
+    }
+
+    #[test]
+    fn a_current_date_is_left_alone() {
+        let reference = day(2026, 8, 29);
+        assert_eq!(corrected_gps_date(reference, reference), reference);
+        assert_eq!(
+            corrected_gps_date(reference - 30, reference),
+            reference - 30
+        );
+    }
+
+    #[test]
+    fn a_merely_old_date_is_left_alone() {
+        // Nine years back is not a rollover artefact — it is under half
+        // an epoch, so it must not be snapped forward.
+        let reference = day(2026, 8, 29);
+        let reported = day(2017, 8, 29);
+        assert_eq!(corrected_gps_date(reported, reference), reported);
+    }
+
+    #[test]
+    fn a_stale_reference_still_corrects() {
+        // Clockless host: reference stuck at the 2026 floor while the
+        // real date is 2030 and the receiver is an epoch behind it.
+        let real_today = day(2030, 6, 1);
+        let reported = real_today - GPS_ROLLOVER_DAYS;
+        assert_eq!(corrected_gps_date(reported, MIN_REFERENCE_DAY), real_today);
+    }
+
+    #[test]
+    fn the_sentinel_range_is_never_entered() {
+        // 2145 is inside the last epoch before the day count would
+        // overflow into 0xfffd..0xffff.
+        let late = 0xfffcu16 - 100;
+        assert_eq!(corrected_gps_date(late, u16::MAX), late);
+    }
+
+    /// Decode a PGN 126992 System Time frame with `source` and
+    /// `date`, apply the quirk at `reference_day`, and hand back the
+    /// resulting raw day count.
+    fn system_time_date(source: u8, date: u16, reference_day: u16) -> Option<u16> {
+        let d = date.to_le_bytes();
+        // SID, Source (low nibble) + Reserved, Date, Time.
+        let data = [0x36, 0xf0 | source, d[0], d[1], 0x10, 0x6d, 0xff, 0x19];
+        let frame = crate::RawFrame::new(None, 3, 126992, 12, 255, data);
+        let mut decoded = crate::PgnDatabase::embedded(crate::Units::Si)
+            .decode(&frame)
+            .expect("decodes");
+        apply_at(frame.pgn, &mut decoded.fields, reference_day);
+        decoded.fields.iter().find_map(|f| match f.value {
+            FieldValue::Date(d) => Some(d),
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn system_time_is_corrected_only_for_a_gps_source() {
+        let reference = day(2022, 7, 4);
+        let reported = day(2002, 11, 18);
+        assert_eq!(system_time_date(0, reported, reference), Some(reference));
+        // Local Crystal clock (5): not a GNSS receiver, so the date
+        // stands as sent.
+        assert_eq!(system_time_date(5, reported, reference), Some(reported));
+    }
+}

--- a/crates/canboat/src/convert.rs
+++ b/crates/canboat/src/convert.rs
@@ -221,6 +221,11 @@ pub struct Args {
     #[command(flatten)]
     shape: canboat_cli::ShapeArgs,
 
+    /// Decode-time device quirks, off by default (`--quirk
+    /// gps-rollover`). Not for replaying pre-2019 captures.
+    #[command(flatten)]
+    quirk: canboat_cli::QuirkArgs,
+
     /// Suppress the leading `{"version":…,"units":…}` banner that
     /// `--to json` emits. Use when the output is diffed as a pure
     /// record stream; leave it on when piping into `n2kd`, which reads
@@ -285,6 +290,7 @@ pub fn run(args: Args) -> Result<()> {
     let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
         .try_init();
     args.shape.warn_deprecated();
+    args.quirk.apply();
     let forced = args.from.and_then(FromFormat::to_input_format);
     let ebl = ebl_input(&args);
     let stdout = io::stdout();

--- a/crates/canboat/src/legacy/analyzer.rs
+++ b/crates/canboat/src/legacy/analyzer.rs
@@ -67,6 +67,11 @@ struct Cli {
     #[command(flatten)]
     shape: canboat_cli::ShapeArgs,
 
+    /// Decode-time device quirks, off by default (`--quirk
+    /// gps-rollover`). Not for replaying pre-2019 captures.
+    #[command(flatten)]
+    quirk: canboat_cli::QuirkArgs,
+
     /// Use the given string in place of any analyzer-generated
     /// timestamps (matches canboat's `-fixtime`).
     #[arg(long, value_name = "STRING")]
@@ -117,6 +122,7 @@ pub fn run(argv: Vec<OsString>) -> Result<()> {
 
 fn run_cli(cli: Cli) -> Result<()> {
     cli.shape.warn_deprecated();
+    cli.quirk.apply();
     let units = cli.shape.units();
 
     let json_opts = JsonOptions {


### PR DESCRIPTION
Closes #862.

The GPS week number is 10 bits from the 1980-01-06 epoch, so it wraps every 1024 weeks (7168 days): 1999-08-22, 2019-04-07, next 2038-11-21. A receiver resolves the wrap with a base week from its firmware build date; one that was never updated keeps a stale base and reports dates one — or, if it also missed 1999, two — epochs in the past. Only the week number wraps, so the time of day is right and the fix is a whole number of epochs.

## What it does

The correction works on the raw field, a 16-bit count of days since 1970-01-01, so it is exact: no timezone, no DST, no string round trip. It **snaps the date to the epoch nearest a reference day** rather than blindly adding 7168 days — that is what a receiver's own base-week logic does, and it covers a doubly stale receiver today and the 2038 rollover without a code change.

The reference is the system clock floored at 2026-01-01. The floor matters: a boat computer without an RTC comes up believing it is 1970 and gets its clock *from* the GPS being corrected. Snapping to the nearest epoch tolerates a reference that is off by up to ~9.8 years, so a stale floor still corrects properly.

Only dates from a GNSS receiver on our own bus are touched:

- **129029** GNSS Position Data
- **129033** Time & Date
- **126992** System Time, only when `Source` is GPS — GLONASS counts weeks from its own epoch, and radio station / local cesium / rubidium / crystal do not roll over at all.

The AIS reports carry another station's clock, and the remaining DATE fields in the database (Maretron counters, route database entries, station data) are not receiver clocks.

## Off by default

Replaying a pre-2019 capture with this on moves the whole log forward twenty years, so it is opt-in everywhere:

```
analyzer -quirk gps-rollover
canboat convert --quirk gps-rollover
canboat server --quirk gps-rollover
```

## Where it lives

This is the first *decode-time* quirk. The bridge's existing quirks all emit synthetic frames (`process_decoded` → `Vec<RawFrame>`), so it does not fit that shape, and a bridge-only quirk would miss a plain `analyzer` run over a log file — which is exactly what people do when they hit this. It lives in `canboat-core` as `quirk.rs`, is applied in `PgnDatabase::decode` (one relaxed atomic load on the common path), and `canboat server --quirk gps-rollover` just switches it on. The C `analyzer` carries the same logic in `fieldPrintDate()`.

## Testing

Seven unit tests on the Rust side (one epoch, two epochs, current date untouched, a merely-old date untouched, stale reference, the sentinel range, and 126992 gated on its source). Both implementations were checked against each other on a 126992 single frame and a 129029 fast packet, and agree exactly.

No C golden test: the output depends on `time(NULL)`, so any fixture would expire. The Rust tests pin the reference explicitly and cover the arithmetic.

## Notes

Reported downstream as SignalK/n2k-signalk#271, where it was patched in the Signal K 129029 handler by re-parsing the formatted date string — which is also where the one-day discrepancy in that thread comes from: shifting days with local-time `getDate()`/`setDate()` slips across a DST boundary. Working on the raw day count avoids it.

canboat/canboatjs#464 does the same thing there.

Found in passing, **not** fixed here: `-clocksrc` in the C analyzer is dead code. `currentDate` (`analyzer/analyzer.c:140`) is only ever initialised to `UINT16_MAX` and never assigned, so the `setSystemClock()` guard can never be true. Worth its own issue.

## Checklist

- [x] PR **title** follows Conventional Commits
- [x] No PGN database change (no YAML touched, nothing regenerated)
- [x] Tests pass (`make tests`, `cargo test --workspace`, `cargo clippy`)
- [x] `make pr` reports no contract changes
- [x] Behaviour is documented rather than inferred — see #862 for the rollover arithmetic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the opt-in `gps-rollover` device quirk to correct dates from affected pre-2019 GPS receivers.
  - Available through `canboat convert`, `canboat interface`, and the analyzer command without requiring a backend.
  - Corrections apply only to supported GNSS date fields and GPS-sourced system time data.
  - Quirks remain disabled unless explicitly enabled.

- **Documentation**
  - Documented supported commands, requirements, date limitations, and capture-file behavior.
  - Clarified requirements for `scx20`, `motion`, and `wmm` quirks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->