### PR TITLE
test: add real PGN 129808 non-distress samples (all-ships SÉCURITÉ + individual position)

### DIFF
--- a/samples/pgn129808.raw
+++ b/samples/pgn129808.raw
@@ -1,3 +1,5 @@
 2022-04-17-04:35:34.254,4,129808,3,255,83,70,70,33,14,00,5f,1e,6e,64,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,12,01,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,70,69,80,e7,77,b1,3a,68,c0,a6,c1,04,ff,ff,ff,ff,ff,7f,fd,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,64,0a,01,30,38
-
-
+2026-08-27-11:03:58.994,4,129808,4,255,62,74,6c,00,16,29,02,28,64,7e,39,30,30,30,31,36,ff,ff,ff,ff,ff,ff,02,01,ff,ff,ff,7f,ff,ff,ff,7f,ff,ff,ff,ff,ff,ff,ff,ff,ff,7f,fc,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,40,f2,b5,17,d4,34,00,00
+2026-08-27-15:13:26.497,4,129808,4,255,62,74,6c,00,16,29,02,28,64,7e,39,30,30,30,31,36,ff,ff,ff,ff,ff,ff,02,01,ff,ff,ff,7f,ff,ff,ff,7f,ff,ff,ff,ff,ff,ff,ff,ff,ff,7f,fc,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,c0,c3,a6,20,d4,34,01,00
+2026-09-05-10:46:07.912,4,129808,4,255,62,78,6c,16,2d,27,18,00,79,7e,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,02,01,e0,1f,34,17,da,eb,e3,00,80,4e,1a,17,ff,ff,ff,ff,ff,7a,fc,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,80,4e,1a,17,dd,34,17,00
+2026-09-05-10:47:00.221,4,129808,4,255,62,78,6c,16,2d,27,18,00,79,7e,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,02,01,e0,1f,34,17,da,eb,e3,00,80,4e,1a,17,ff,ff,ff,ff,ff,7a,fc,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,ff,80,4e,1a,17,dd,34,00,00


### PR DESCRIPTION
Adds real on-wire PGN 129808 captures from a YachtDevices YDWG02 gateway, to complement the existing distress sample with the **non-distress variants** that #460 / #461 and #452 are about — "truth" for the fields that until now only had hand-written fixtures downstream.

Four frames, raw bytes unmodified:

- **2× All ships / Safety (SÉCURITÉ)** — Spanish coast station navigational/met-warning broadcasts (MMSI 002241024, public, ch16).
- **2× Individual stations** — position-registration updates (own-vessel self-poll; addressee = own MMSI).

They exercise fields the distress sample doesn't:
- the general 129808 variant (not the distress variant);
- `DSC Category` on the non-distress path (silently dropped without #461 — Safety/Urgency/Routine all decode as no category on stock);
- `1st Telecommand`, `Proposed Rx Frequency/Channel`;
- reported latitude/longitude/time on the individual calls;
- the 10-digit DECIMAL `DSC Message Address` (#451 / #452) — e.g. the coast station arrives as `0022410240`.

All four decode cleanly through canboatjs with #451/#452 (DECIMAL) + #461 (match-sibling) applied.

Context: sailingnaturali/signalk-dsc#8 and #10, canboat/canboatjs#460.
